### PR TITLE
fix: fix for building docker_psoc5lp_lib target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ docker_psoc5lp_lib: $(DEPS)
 	touch src/mrubyc/src/hal_psoc5lp/hal.c
 	$(MAKE) build_lib \
 	  HAL_DIR=hal_psoc5lp \
-	  CFLAGS="$(CFLAGS) -I../../../include/psoc5lp -mcpu=cortex-m3 -mthumb -g -ffunction-sections -ffat-lto-objects -O0 -DNDEBUG -DMRBC_USE_HAL_PSOC5LP" \
+	  CFLAGS="$(CFLAGS) -I../../../include/psoc5lp -mcpu=cortex-m3 -mthumb -g -ffunction-sections -ffat-lto-objects -O0 -DNDEBUG -DMRBC_USE_HAL_PSOC5LP -DPTR_SIZE=4" \
 	  LDFLAGS=$(LDFLAGS) \
 	  LIB_DIR=$(LIB_DIR_PSOC5LP) \
 	  COMMON_SRCS="alloc.c class.c console.c error.c global.c keyvalue.c load.c rrt0.c static.c symbol.c value.c vm.c" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,10 @@ else
 endif
 
 %.o: %.c
+ifeq ($(findstring -DPTR_SIZE=, $(CFLAGS)), -DPTR_SIZE=)
+else
 	cd include ; $(MAKE) all CC=$(CC)
+endif
 	$(CC) -c -MMD -MP $(CFLAGS) $(LDFLAGS) $<
 
 clean:

--- a/src/node.h
+++ b/src/node.h
@@ -4,7 +4,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "ruby-lemon-parse/parse_header.h"
+#ifndef PTR_SIZE
 #include "include/ptr_size.h"
+#endif
 
 const char *Node_valueName(Node *self);
 

--- a/src/ruby-lemon-parse/parse_header.h
+++ b/src/ruby-lemon-parse/parse_header.h
@@ -4,7 +4,9 @@
 #include <stdbool.h>
 
 #include "../scope.h"
+#ifndef PTR_SIZE
 #include "../include/ptr_size.h"
+#endif
 
 typedef enum atom_type {
   ATOM_NONE = 0,


### PR DESCRIPTION
When we build psoc5lp_lib, we can't run the binary on the host machine, so we can't check the size of void *.

So, I worked around this by defining PTR_SIZE in the docker_psoc5lp_lib target of make.