### PR TITLE
Redesign Task class 

### DIFF
--- a/build_config/r2p2-bin.rb
+++ b/build_config/r2p2-bin.rb
@@ -18,6 +18,7 @@ MRuby::Build.new do |conf|
   conf.gem core: "picoruby-vim"
   conf.gem core: "picoruby-sqlite3"
   conf.gem core: "picoruby-bin-r2p2"
+  conf.gem core: "picoruby-task-ext"
 
 end
 

--- a/mrbgems/picoruby-prk-keyboard/mrbgem.rake
+++ b/mrbgems/picoruby-prk-keyboard/mrbgem.rake
@@ -4,6 +4,8 @@ MRuby::Gem::Specification.new('picoruby-prk-keyboard') do |spec|
   spec.summary = 'PRK Firmware / class Keyboard'
 
   spec.require_name = 'keyboard'
+
+  spec.add_dependency 'picoruby-sandbox'
 end
 
 

--- a/mrbgems/picoruby-prk-keyboard/sig/keyboard.rbs
+++ b/mrbgems/picoruby-prk-keyboard/sig/keyboard.rbs
@@ -3,6 +3,7 @@
 # Global variables
 
 class Object
+  $keyboard_sandbox: Sandbox
   $volume: FAT
   PICORUBY_MSC: String
   README: String
@@ -104,6 +105,7 @@ class Keyboard
   @mouse: Mouse
   @output_report_cb: ^(Integer)->void
   @prev_rgb_effect: effect_type
+  @rgb_sandbox: Sandbox
   @ruby_mode_stop: bool
   @ruby_mode: bool
   @via: VIA
@@ -124,7 +126,6 @@ class Keyboard
 
   attr_reader layer: Symbol | nil
   attr_reader split_style: split_style_type
-  attr_reader sandbox: Sandbox
   attr_reader cols_size: Integer
   attr_reader rows_size: Integer
   attr_reader keycodes: Array[Integer]

--- a/mrbgems/picoruby-prk-rgb/mrbgem.rake
+++ b/mrbgems/picoruby-prk-rgb/mrbgem.rake
@@ -4,7 +4,6 @@ MRuby::Gem::Specification.new('picoruby-prk-rgb') do |spec|
   spec.summary = 'PRK Firmware / class RGB'
 
   spec.add_dependency 'picoruby-float-ext'
-  spec.add_dependency 'picoruby-task-ext'
 
   spec.require_name = 'rgb'
 end

--- a/mrbgems/picoruby-prk-rgb/mrblib/rgb.rb
+++ b/mrbgems/picoruby-prk-rgb/mrblib/rgb.rb
@@ -1,5 +1,4 @@
 require "float-ext"
-require "task-ext"
 
 class RGB
   KEYCODE = {
@@ -34,13 +33,6 @@ class RGB
 
   attr_reader :pixel_size, :effect
   attr_accessor :action, :anchor, :split_sync
-
-  TASK_SCRIPT = "while true; $rgb&.show || sleep(3); end"
-
-  def start
-    return if Task[:rgb]
-    Task.new(:rgb).compile_and_run(TASK_SCRIPT, false)
-  end
 
   def init_values
     self.speed = @speed || 25

--- a/mrbgems/picoruby-prk-rgb/sig/rgb.rbs
+++ b/mrbgems/picoruby-prk-rgb/sig/rgb.rbs
@@ -18,7 +18,6 @@ class RGB
 
   KEYCODE: Hash[Symbol, Integer]
   EFFECTS: Array[effect_type]
-  TASK_SCRIPT: String
 
   def ws2812_init: (Integer, Integer, bool) -> void
   def ws2812_show: () -> void
@@ -58,7 +57,6 @@ class RGB
   attr_accessor split_sync: bool
 
   def initialize: (Integer pin, Integer underglow_size, Integer backlight_size, ?bool is_rgbw) -> void
-  def start: () -> void
   def init_values: () -> void
   def turn_off: () -> void
   def turn_on: () -> void

--- a/mrbgems/picoruby-prk-via/mrblib/via.rb
+++ b/mrbgems/picoruby-prk-via/mrblib/via.rb
@@ -522,20 +522,6 @@ class VIA
     @keymaps[layer][row][col] = keycode
     @keymap_saved = false
   end
-  
-  def eval_val(script)
-    sandbox = @kbd.sandbox
-    if sandbox.compile(script)
-      if sandbox.execute
-        sandbox.wait
-        sandbox.free_parser
-        return sandbox.error || sandbox.result
-      end
-    else
-      puts "Error: Compile failed"
-      return nil
-    end
-  end
 
   def task
     if USB.raw_hid_report_received?

--- a/mrbgems/picoruby-prk-via/sig/via.rbs
+++ b/mrbgems/picoruby-prk-via/sig/via.rbs
@@ -32,7 +32,6 @@ class VIA
   def get_modifier_name : (Integer) -> String
   def load_mode_keys: -> void
   def define_mode_key : (Symbol key_name, [Symbol | Array[Symbol] | Proc | nil, Symbol | Proc | nil, Integer?, Integer?] param) -> void
-  def eval_val : (String) -> untyped
   def sync_keymap : (?bool)-> void
   def init_keymap: -> void
   def save_on_keyboard: -> void

--- a/mrbgems/picoruby-task-ext/mrbgem.rake
+++ b/mrbgems/picoruby-task-ext/mrbgem.rake
@@ -4,5 +4,7 @@ MRuby::Gem::Specification.new('picoruby-task-ext') do |spec|
   spec.summary = 'Task class extension'
 
   spec.add_dependency 'picoruby-sandbox'
+
+  spec.require_name = 'task'
 end
 

--- a/mrbgems/picoruby-task-ext/sig/task.rbs
+++ b/mrbgems/picoruby-task-ext/sig/task.rbs
@@ -1,12 +1,21 @@
 class Task
-  TASKS: Hash[Symbol, Task]
+  TASKS: Array[Task::Tmp]
 
-  @sandbox: Sandbox
+  class Tmp
 
-  def self.[]: (Symbol) -> Task
-  def self.current: () -> Task
+    @proc: Proc
+    @args: Array[untyped]
+    @name: String | nil
+    @sandbox: Sandbox
 
-  def initialize: (Symbol) -> void
-  def compile_and_run: (String, ?bool wrap_rescue) -> self
-  def suspend: () -> self
+    def initialize: (Array[untyped], Proc) -> void
+    def name=: (String) -> String
+    def suspend: () -> self
+    def terminate: () -> self
+    def join: (?Integer|nil) -> (self | nil)
+    def _start: () -> void
+  end
+
+  def self.new: (*untyped) { (*untyped) -> void } -> Task::Tmp
+  def self.list: () -> Array[Task::Tmp]
 end

--- a/mrbgems/picoruby-task-ext/sig/task.rbs
+++ b/mrbgems/picoruby-task-ext/sig/task.rbs
@@ -5,8 +5,9 @@ class Task
 
     @proc: Proc
     @args: Array[untyped]
-    @name: String | nil
     @sandbox: Sandbox
+
+    attr_reader name: String | nil
 
     def initialize: (Array[untyped], Proc) -> void
     def name=: (String) -> String

--- a/mrbgems/prk_firmware.gembox
+++ b/mrbgems/prk_firmware.gembox
@@ -2,7 +2,6 @@ MRuby::GemBox.new do |conf|
 
   conf.gem github: 'picoruby/mruby-pico-compiler', branch: 'master'
   conf.gem core: 'picoruby-mrubyc'
-  conf.gem core: 'picoruby-task-ext'
   conf.gem core: 'picoruby-vfs'
   conf.gem core: 'picoruby-filesystem-fat'
   conf.gem core: 'picoruby-float-ext'


### PR DESCRIPTION
- Redesign Task class like Thread class in CRuby
- PRK stops using Task. Uses directly Sandbox instead