### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Setup CRuby


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).