### PR TITLE
Random Number Generator

### DIFF
--- a/build_config/r2p2-cortex-m0plus.rb
+++ b/build_config/r2p2-cortex-m0plus.rb
@@ -46,5 +46,6 @@ MRuby::CrossBuild.new("r2p2-cortex-m0plus") do |conf|
   conf.gembox "peripheral_utils"
   conf.gembox "machine"
   conf.gem core: 'picoruby-adafruit_pcf8523'
+  conf.gem core: 'picoruby-rng'
 end
 

--- a/build_config/r2p2_w-cortex-m0plus.rb
+++ b/build_config/r2p2_w-cortex-m0plus.rb
@@ -48,5 +48,6 @@ MRuby::CrossBuild.new("r2p2_w-cortex-m0plus") do |conf|
   conf.gembox "machine"
   conf.gem core: 'picoruby-adafruit_pcf8523'
   conf.gem core: 'picoruby-ble'
+  conf.gem core: 'picoruby-rng'
 end
 

--- a/mrbgems/picoruby-rng/include/rng.h
+++ b/mrbgems/picoruby-rng/include/rng.h
@@ -1,0 +1,8 @@
+#ifndef RNG_DEFINED_H_
+#define RNG_DEFINED_H_
+
+#include <stdint.h>
+
+uint8_t rng_random_byte(void);
+
+#endif

--- a/mrbgems/picoruby-rng/include/rng.h
+++ b/mrbgems/picoruby-rng/include/rng.h
@@ -3,6 +3,6 @@
 
 #include <stdint.h>
 
-uint8_t rng_random_byte(void);
+uint8_t c_rng_random_byte_impl(void);
 
 #endif

--- a/mrbgems/picoruby-rng/mrbgem.rake
+++ b/mrbgems/picoruby-rng/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('picoruby-rng') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'Ryo Kajiwara'
+  spec.summary = 'Random Number Generator for PicoRuby'
+end

--- a/mrbgems/picoruby-rng/mrblib/rng.rb
+++ b/mrbgems/picoruby-rng/mrblib/rng.rb
@@ -1,0 +1,2 @@
+class RNG
+end

--- a/mrbgems/picoruby-rng/ports/rp2040/rng.c
+++ b/mrbgems/picoruby-rng/ports/rp2040/rng.c
@@ -2,7 +2,7 @@
 #include "hardware/structs/rosc.h"
 #include "pico/time.h"
 
-uint8_t rng_random_byte(void)
+uint8_t c_rng_random_byte_impl(void)
 {
   uint32_t random = 0;
   uint32_t bit = 0;

--- a/mrbgems/picoruby-rng/ports/rp2040/rng.c
+++ b/mrbgems/picoruby-rng/ports/rp2040/rng.c
@@ -1,0 +1,20 @@
+#include "../../include/rng.h"
+#include "hardware/structs/rosc.h"
+#include "pico/time.h"
+
+uint8_t rng_random_byte(void)
+{
+  uint32_t random = 0;
+  uint32_t bit = 0;
+  for (int i = 0; i < 8; i++) {
+    while (true) {
+      bit = rosc_hw->randombit;
+      sleep_us(5);
+      if (bit != rosc_hw->randombit)
+        break;
+    }
+    random = (random << 1) | bit;
+    sleep_us(5);
+  }
+  return (uint8_t) random;
+}

--- a/mrbgems/picoruby-rng/sig/rng.rbs
+++ b/mrbgems/picoruby-rng/sig/rng.rbs
@@ -1,2 +1,4 @@
 class RNG
+  def self.random_int: -> Integer
+  def self.random_string: (Integer) -> String
 end

--- a/mrbgems/picoruby-rng/sig/rng.rbs
+++ b/mrbgems/picoruby-rng/sig/rng.rbs
@@ -1,0 +1,2 @@
+class RNG
+end

--- a/mrbgems/picoruby-rng/src/rng.c
+++ b/mrbgems/picoruby-rng/src/rng.c
@@ -6,7 +6,11 @@
 static void
 c_rng_random_int(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  SET_INT_RETURN(rng_random_byte());
+  uint32_t ret = 0;
+  for (int i = 0; i < 4; i++) {
+    ret = (ret << 8) | c_rng_random_byte_impl();
+  }
+  SET_INT_RETURN(ret);
 }
 
 static void
@@ -23,7 +27,7 @@ c_rng_random_string(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   unsigned char* buf = mrbc_alloc(vm, len.i);
   for (int i = 0; i < len.i; i++) {
-    buf[i] = (unsigned char)rng_random_byte();
+    buf[i] = (unsigned char)c_rng_random_byte_impl();
   }
   mrbc_value ret = mrbc_string_new(vm, buf, len.i);
   mrbc_free(vm, buf);

--- a/mrbgems/picoruby-rng/src/rng.c
+++ b/mrbgems/picoruby-rng/src/rng.c
@@ -1,0 +1,40 @@
+#include <mrubyc.h>
+#include <alloc.h>
+
+#include "../include/rng.h"
+
+static void
+c_rng_random_int(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  SET_INT_RETURN(rng_random_byte());
+}
+
+static void
+c_rng_random_string(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+  mrbc_value len = GET_ARG(1);
+  if (len.tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong type of argument");
+    return;
+  }
+  unsigned char* buf = mrbc_alloc(vm, len.i);
+  for (int i = 0; i < len.i; i++) {
+    buf[i] = (unsigned char)rng_random_byte();
+  }
+  mrbc_value ret = mrbc_string_new(vm, buf, len.i);
+  mrbc_free(vm, buf);
+  SET_RETURN(ret);
+}
+
+void
+mrbc_rng_init(void)
+{
+  mrbc_class *class_RNG = mrbc_define_class(0, "RNG", mrbc_class_object);
+
+  mrbc_define_method(0, class_RNG, "random_int", c_rng_random_int);
+  mrbc_define_method(0, class_RNG, "random_string", c_rng_random_string);
+}


### PR DESCRIPTION
The RNG mrbgem implements generation of random numbers and strings. The main purpose of this is to generate random keys for cryptographic operations.

The API of the gem looks like the following:

- `RNG.random_int`: generates a 32-bit random integer.
    - To limit the range of generated numbers, use the `%` operator to get the residual.
- `RNG.random_string(length)`: generates a string of length `length` with random bytes.

This gem currently has an implementation for RP2040 that uses RP2040's Ring Oscillator (-> https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf, Section 2.17).