### PR TITLE
Fixed no compilers other than gcc are used for cross-building.

### DIFF
--- a/build_config/r2p2-cortex-m0plus.rb
+++ b/build_config/r2p2-cortex-m0plus.rb
@@ -5,7 +5,7 @@ MRuby::CrossBuild.new("r2p2-cortex-m0plus") do |conf|
   #   arm-none-eabi       | to make libmruby.a
   ###############################################################
 
-  conf.toolchain
+  conf.toolchain("gcc")
 
   conf.cc.command = "arm-none-eabi-gcc"
   conf.linker.command = "arm-none-eabi-ld"

--- a/build_config/r2p2_w-cortex-m0plus.rb
+++ b/build_config/r2p2_w-cortex-m0plus.rb
@@ -5,7 +5,7 @@ MRuby::CrossBuild.new("r2p2_w-cortex-m0plus") do |conf|
   #   arm-none-eabi       | to make libmruby.a
   ###############################################################
 
-  conf.toolchain
+  conf.toolchain("gcc")
 
   conf.cc.command = "arm-none-eabi-gcc"
   conf.linker.command = "arm-none-eabi-ld"


### PR DESCRIPTION
When building R2P2 on macOS, the following error was encountered:

```
arm-none-eabi-gcc: error: unrecognized command-line option '-Wzero-length-array'; did you mean '-Wzero-length-bounds'?
```

This issue was caused by Toolchain#guess referencing RUBY_PLATFORM and selecting clang.

https://github.com/picoruby/picoruby/blob/0a5292893de2ef4088f105ed2b1c7fd42acdb4e5/lib/mruby/build.rb#L27

Therefore, I fixed it to explicitly specify `gcc` for cross-building.

----

Additionally, to successfully build R2P2 on macOS, you need to install another tool.
I am planning to submit a Pull Request to add this information to the R2P2 README.

https://github.com/picoruby/R2P2/pull/10