### PR TITLE
Build on macOS

### DIFF
--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -79,6 +79,10 @@ module MRuby
       end
       cc.include_paths << gems['mruby-compiler2'].dir + "/lib/prism/include"
 
+      if /darwin/ =~ RUBY_PLATFORM && system("which brew > /dev/null 2>&1") # for macOS && homebrew
+        linker.library_paths << File.join(`brew --prefix`.chomp, "/lib")
+      end
+
       cc.flags.flatten!
       cc.flags.reject! { |f| %w(-g -g1 -g2 -g3 -O0 -O1 -O2 -O3).include? f }
       if ENV["PICORUBY_DEBUG"]

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -81,6 +81,11 @@ module MRuby
 
       if /darwin/ =~ RUBY_PLATFORM && system("which brew > /dev/null 2>&1") # for macOS && homebrew
         linker.library_paths << File.join(`brew --prefix`.chomp, "/lib")
+
+        openssl_path = `brew --prefix openssl`.chomp
+        if openssl_path != "" && openssl_path != nil
+          cc.include_paths << File.join(openssl_path, "include")
+        end
       end
 
       cc.flags.flatten!


### PR DESCRIPTION
On mac OS, I could not build due to the following two obstacles

Unable to resolve path to libcrypto
```
LD    build/host/bin/picorbc
ld: library not found for -lcrypto
clang: error: linker command failed with exit code 1 (use -v to see invocation)
rake aborted!
```

Unable to resolve path to openssl/ssl.h
```
picoruby/mrbgems/picoruby-net/ports/posix/tcp.c:6:10: fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```

This PR solved these two problems and successfully built on macOS.

Note that it depends on homebrew, which is considered to be commonly used