### PR TITLE
Fix Build Error in `mruby-time-class` When Using ESP-IDF

### DIFF
--- a/mrbgems/picoruby-time-class/src/time.c
+++ b/mrbgems/picoruby-time-class/src/time.c
@@ -112,7 +112,7 @@ new_from_unixtime_us(struct VM *vm, mrbc_value v[], mrbc_int_t unixtime_us)
   data->unixtime_us = unixtime_us + unixtime_offset * USEC;
   time_t unixtime = data->unixtime_us / USEC;
   localtime_r(&unixtime, &data->tm);
-#ifdef MRBC_USE_HAL_POSIX
+#if defined(MRBC_USE_HAL_POSIX) || defined(MRBC_USE_HAL_ESP32)
   data->timezone = timezone;  /* global variable from time.h of glibc */
 #else
   data->timezone = _timezone; /* newlib? */
@@ -128,7 +128,7 @@ new_from_tm(struct VM *vm, mrbc_value v[], struct tm *tm)
   PICORUBY_TIME *data = (PICORUBY_TIME *)value.instance->data;
   data->unixtime_us = mktime(tm) * USEC;
   memcpy(&data->tm, tm, sizeof(struct tm));
-#ifdef MRBC_USE_HAL_POSIX
+#if defined(MRBC_USE_HAL_POSIX) || defined(MRBC_USE_HAL_ESP32)
   data->timezone = timezone;
 #else
   data->timezone = _timezone;


### PR DESCRIPTION
## Problem Description  

When building `mruby-time-class` with ESP-IDF, a build error occurred due to referencing `_timezone`.  

## Cause of the Issue  

ESP-IDF defines the variable `timezone` instead of `_timezone`, causing an undefined reference error during compilation.  

## Proposed Fix  

I modified the implementation to handle `timezone` in the same way as when `MRBC_USE_HAL_POSIX` is defined. This resolves the build error when using ESP-IDF.  

## Reference  

- [ESP-IDF System Time Documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/system_time.html)  
