### PR TITLE
Run PicoRuby on ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -1,0 +1,25 @@
+MRuby::CrossBuild.new("esp32") do |conf|
+  conf.toolchain("gcc")
+
+  conf.cc.command = "riscv32-esp-elf-gcc"
+  conf.linker.command = "riscv32-esp-elf-ld"
+  conf.archiver.command = "riscv32-esp-elf-ar"
+
+  conf.cc.host_command = "gcc"
+  conf.cc.flags << "-Wall"
+  conf.cc.flags << "-Wno-format"
+  conf.cc.flags << "-Wno-unused-function"
+  conf.cc.flags << "-Wno-maybe-uninitialized"
+
+  conf.cc.defines << "MRBC_TICK_UNIT=10"
+  conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=1"
+  conf.cc.defines << "MRBC_USE_FLOAT=2"
+  conf.cc.defines << "MRC_CUSTOM_ALLOC"
+  conf.cc.defines << "MRBC_CONVERT_CRLF=1"
+  conf.cc.defines << "NDEBUG"
+
+  conf.gem core: "picoruby-machine"
+  conf.gem core: "picoruby-shell"
+  conf.gem core: "picoruby-picorubyvm"
+  conf.picoruby
+end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -1,0 +1,26 @@
+MRuby::CrossBuild.new("esp32") do |conf|
+  conf.toolchain("gcc")
+
+  conf.cc.command = "xtensa-esp32-elf-gcc"
+  conf.linker.command = "xtensa-esp32-elf-ld"
+  conf.archiver.command = "xtensa-esp32-elf-ar"
+
+  conf.cc.host_command = "gcc"
+  conf.cc.flags << "-Wall"
+  conf.cc.flags << "-Wno-format"
+  conf.cc.flags << "-Wno-unused-function"
+  conf.cc.flags << "-Wno-maybe-uninitialized"
+  conf.cc.flags << "-mlongcalls"
+
+  conf.cc.defines << "MRBC_TICK_UNIT=10"
+  conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=1"
+  conf.cc.defines << "MRBC_USE_FLOAT=2"
+  conf.cc.defines << "MRC_CUSTOM_ALLOC"
+  conf.cc.defines << "MRBC_CONVERT_CRLF=1"
+  conf.cc.defines << "NDEBUG"
+
+  conf.gem core: "picoruby-machine"
+  conf.gem core: "picoruby-shell"
+  conf.gem core: "picoruby-picorubyvm"
+  conf.picoruby
+end

--- a/mrbgems/picoruby-env/ports/esp32/env.c
+++ b/mrbgems/picoruby-env/ports/esp32/env.c
@@ -1,0 +1,28 @@
+#include "../../include/env.h"
+#include <stdio.h>
+
+static const struct {
+    const char *key;
+    const char *value;
+} env_table[] = {
+    { "PWD", "" },      // Should be set in Shell.setup_system_files
+    { "TERM", "ansi" }, // may be overwritten by IO.wait_terminal
+    { "TZ", "JST-9" },
+    { "WIFI_MODULE", "" },
+    { NULL, NULL }
+};
+
+void c_env_new(struct VM *vm, mrbc_value v[], int argc)
+{
+  mrbc_value hash = mrbc_hash_new(vm, 0);
+  mrbc_value self = mrbc_instance_new(vm, v->cls, 0);
+  mrbc_instance_setiv(&self, mrbc_str_to_symid("env"), &hash);
+
+  for (int i = 0; env_table[i].key != NULL; i++) {
+    mrbc_value key_value = mrbc_string_new_cstr(vm, env_table[i].key);
+    mrbc_value value_value = mrbc_string_new_cstr(vm, env_table[i].value);
+    mrbc_hash_set(&hash, &key_value, &value_value);
+  }
+
+  SET_RETURN(self);
+}

--- a/mrbgems/picoruby-filesystem-fat/ports/esp32/flash_disk.c
+++ b/mrbgems/picoruby-filesystem-fat/ports/esp32/flash_disk.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../lib/ff14b/source/ff.h"
+
+// TODO: Implement this function logic
+void
+FILE_physical_address(FIL *fp, uint8_t **addr)
+{
+}
+
+// TODO: Implement this function logic
+int
+FILE_sector_size(void)
+{
+  return 0;
+}

--- a/mrbgems/picoruby-io-console/ports/esp32/io-console.c
+++ b/mrbgems/picoruby-io-console/ports/esp32/io-console.c
@@ -1,0 +1,129 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <mrubyc.h>
+
+/*-------------------------------------
+ *
+ *  IO::Console
+ *
+ *------------------------------------*/
+
+static bool raw_mode = false;
+static bool raw_mode_saved = false;
+static bool echo_mode = true;
+static bool echo_mode_saved = true;
+
+void
+c_raw_bang(mrb_vm *vm, mrb_value *v, int argc)
+{
+  raw_mode_saved = raw_mode;
+  raw_mode = true;
+}
+
+void
+c_cooked_bang(mrb_vm *vm, mrb_value *v, int argc)
+{
+  raw_mode_saved = raw_mode;
+  raw_mode = false;
+}
+
+static void
+c_echo_eq(mrb_vm *vm, mrb_value *v, int argc)
+{
+  echo_mode_saved = echo_mode;
+  if (v[1].tt == MRBC_TT_FALSE) {
+    echo_mode = false;
+  } else {
+    echo_mode = true;
+  }
+}
+
+static void
+c_echo_q(mrb_vm *vm, mrb_value *v, int argc)
+{
+  if (echo_mode) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void
+c__restore_termios(mrb_vm *vm, mrb_value *v, int argc)
+{
+  raw_mode = raw_mode_saved;
+  echo_mode = echo_mode_saved;
+}
+
+static void
+c_gets(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrb_value str = mrbc_string_new(vm, NULL, 0);
+  char buf[2];
+  buf[1] = '\0';
+  while (true) {
+    int c = hal_getchar();
+    if (c == 3) { // Ctrl-C
+      mrbc_raise(vm, MRBC_CLASS(IOError), "Interrupted");
+      return;
+    }
+    if (c == 27) { // ESC
+      continue;
+    }
+    if (c == 8 || c == 127) { // Backspace
+      if (0 < str.string->size) {
+        str.string->size--;
+        mrbc_realloc(vm, str.string->data, str.string->size);
+        hal_write(1, "\b \b", 3);
+      }
+    } else
+    if (-1 < c) {
+      buf[0] = c;
+      mrbc_string_append_cstr(&str, buf);
+      hal_write(1, buf, 1);
+      if (c == '\n' || c == '\r') {
+        break;
+      }
+    }
+  }
+  SET_RETURN(str);
+}
+
+static void
+c_getc(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (raw_mode) {
+    char buf[1];
+    int c = hal_getchar();
+    if (-1 < c) {
+      buf[0] = c;
+      mrb_value str = mrbc_string_new(vm, buf, 1);
+      SET_RETURN(str);
+    } else {
+      SET_NIL_RETURN();
+    }
+  }
+  else {
+    c_gets(vm, v, argc);
+    mrbc_value str = v[0];
+    if (1 < str.string->size) {
+      mrbc_realloc(vm, str.string->data, 1);
+      str.string->size = 1;
+    }
+  }
+}
+
+void
+io_console_port_init(mrbc_vm *vm, mrbc_class *class_IO)
+{
+  mrbc_define_method(vm, class_IO, "raw!", c_raw_bang);
+  mrbc_define_method(vm, class_IO, "cooked!", c_cooked_bang);
+  mrbc_define_method(vm, class_IO, "echo?", c_echo_q);
+  mrbc_define_method(vm, class_IO, "echo=", c_echo_eq);
+  mrbc_define_method(vm, class_IO, "_restore_termios", c__restore_termios);
+  mrbc_define_method(vm, class_IO, "getc", c_getc);
+  mrbc_define_method(vm, mrbc_class_object, "gets", c_gets);
+}
+

--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -1,0 +1,144 @@
+#include "../../include/hal.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
+#include <freertos/task.h>
+
+#include "esp_sleep.h"
+#include "hal/efuse_hal.h"
+
+#define ESP32_MSEC_PER_TICK       (10)
+#define ESP32_TIMER_UNIT_PER_SEC  (1000000)
+
+void
+hal_init(void)
+{
+  /* Not required for ESP32 */
+}
+
+void
+hal_enable_irq()
+{
+  portENABLE_INTERRUPTS();
+}
+
+void
+hal_disable_irq()
+{
+  portDISABLE_INTERRUPTS();
+}
+
+void
+hal_idle_cpu()
+{
+  vTaskDelay(1);
+}
+
+int
+hal_write(int fd, const void *buf, int nbytes)
+{
+  for (int i = 0 ; i < nbytes ; i++) {
+    putchar(((char*)buf)[i]);
+  }
+  fflush(stdout);
+  return nbytes;
+}
+
+int hal_flush(int fd) {
+  return fflush(stdout);
+}
+
+int
+hal_read_available(void)
+{
+  int c = fgetc(stdin);
+  return ungetc(c, stdin) == EOF ? 0 : 1;
+}
+
+int
+hal_getchar(void)
+{
+  return fgetc(stdin);
+}
+
+void
+hal_abort(const char *s)
+{
+  if(s) {
+    hal_write(1, s, strlen(s));
+  }
+
+  abort();
+}
+
+
+/*-------------------------------------
+ *
+ * USB
+ *
+ *------------------------------------*/
+
+void
+Machine_tud_task(void)
+{
+  /* Not required for ESP32 */
+}
+
+bool
+Machine_tud_mounted_q(void)
+{
+  /* Not required for ESP32 */
+  return 0;
+}
+
+
+/*-------------------------------------
+ *
+ * RTC
+ *
+ *------------------------------------*/
+
+/*
+ * deep_sleep doesn't work yet
+ */
+void
+Machine_deep_sleep(uint8_t gpio_pin, bool edge, bool high)
+{
+}
+
+void
+Machine_sleep(uint32_t seconds)
+{
+  esp_sleep_enable_timer_wakeup(seconds * ESP32_TIMER_UNIT_PER_SEC);
+  esp_light_sleep_start();
+}
+
+void
+Machine_delay_ms(uint32_t ms)
+{
+  vTaskDelay(ms / ESP32_MSEC_PER_TICK);
+}
+
+/*
+ * busy_wait_ms doesn't work yet
+ */
+void
+Machine_busy_wait_ms(uint32_t ms)
+{
+}
+
+int
+Machine_get_unique_id(char *id_str)
+{
+  uint8_t mac[6];
+  efuse_hal_get_mac(mac);
+  sprintf(id_str, "%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  return 1;
+}

--- a/mrbgems/picoruby-time-class/src/time.c
+++ b/mrbgems/picoruby-time-class/src/time.c
@@ -119,7 +119,7 @@ new_from_unixtime_us(struct VM *vm, mrbc_value v[], mrbc_int_t unixtime_us)
   data->unixtime_us = unixtime_us + unixtime_offset * USEC;
   time_t unixtime = data->unixtime_us / USEC;
   localtime_r(&unixtime, &data->tm);
-#if defined(MRBC_USE_HAL_POSIX) || defined(MRBC_USE_HAL_ESP32)
+#if defined(MRBC_USE_HAL_POSIX)
   data->timezone = timezone;  /* global variable from time.h of glibc */
 #else
   data->timezone = _timezone; /* newlib? */
@@ -135,7 +135,7 @@ new_from_tm(struct VM *vm, mrbc_value v[], struct tm *tm)
   PICORUBY_TIME *data = (PICORUBY_TIME *)value.instance->data;
   data->unixtime_us = mktime(tm) * USEC;
   memcpy(&data->tm, tm, sizeof(struct tm));
-#if defined(MRBC_USE_HAL_POSIX) || defined(MRBC_USE_HAL_ESP32)
+#if defined(MRBC_USE_HAL_POSIX)
   data->timezone = timezone;
 #else
   data->timezone = _timezone;


### PR DESCRIPTION
Added Build Configuration for ESP32 in PicoRuby

I have added build configurations for ESP32 in PicoRuby.

With this change, PicoRuby can be built as a component for ESP-IDF using [this repository](https://github.com/yuuu/picoruby-esp32), which I have made public.

- Confirmed that the Shell launches successfully on ESP32-C3 (RISC-V) and ESP32 (Xtensa).
    - The reference implementation project is available [here](https://github.com/yuuu/espicoruby).
- We have a roadmap for picoruby-esp32
    - https://github.com/yuuu/picoruby-esp32/issues/8
    - For the current status, please check the link above.