### PR TITLE
Fixed an error due to an empty argument in the ar command.

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -238,6 +238,7 @@ module MRuby
     end
 
     def run(outfile, objfiles)
+      return if objfiles.empty?
       mkdir_p File.dirname(outfile)
       _pp "AR", outfile.relative_path
       _run archive_options, { :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' ') }


### PR DESCRIPTION
When running the `rake` command on the latest master branch, I encountered the following error:

```
❯ rake 
AR    build/host/lib/libmruby_core.a 
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
        ar -m [-TLsv] archive file ...
        ar -m [-abiTLsv] position archive file ...
        ar -p [-TLsv] archive [file ...]
        ar -q [-cTLsv] archive file ...
        ar -r [-cuTLsv] archive file ...
        ar -r [-abciuTLsv] position archive file ...
        ar -t [-TLsv] archive [file ...]
        ar -x [-ouTLsv] archive [file ...]
rake aborted!
Command failed with status (1): [ar rs "/Users/yuhei/ghq/github.com/picoruby/picoruby/build/host/lib/libmruby_core.a" ]
/Users/yuhei/ghq/github.com/picoruby/picoruby/lib/mruby/build/command.rb:33:in `_run'
/Users/yuhei/ghq/github.com/picoruby/picoruby/lib/mruby/build/command.rb:243:in `run'
/Users/yuhei/ghq/github.com/picoruby/picoruby/tasks/libmruby.rake:3:in `block (2 levels) in <top (required)>'
/Users/yuhei/ghq/github.com/picoruby/picoruby/Rakefile:46:in `block in <top (required)>'
Tasks: TOP => build => /Users/yuhei/ghq/github.com/picoruby/picoruby/build/host/lib/libmruby_core.a
(See full trace by running task with --trace)
```

In the following commit, the guard condition that prevented execution when arguments were empty was removed:  
[https://github.com/picoruby/picoruby/commit/a6a603e0c88c513af6d788f945e51bddf7abf31a](https://github.com/picoruby/picoruby/commit/a6a603e0c88c513af6d788f945e51bddf7abf31a)

However, it seems that there are still situations where the arguments remain empty in practice.
