### PR TITLE
Disable alloc_libc in ESP build config.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -22,5 +22,5 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
-  conf.picoruby
+  conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -23,5 +23,5 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
-  conf.picoruby
+  conf.picoruby(alloc_libc: false)
 end


### PR DESCRIPTION
Added because picoruby update requires `alloc_libc: false` to be specified in the build config for ESP32.