### PR TITLE
Added picoruby-gpio working with ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -22,5 +22,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
+  conf.gem core: "picoruby-gpio"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -23,5 +23,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
+  conf.gem core: "picoruby-gpio"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-gpio/ports/esp32/gpio.c
+++ b/mrbgems/picoruby-gpio/ports/esp32/gpio.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+#include "driver/gpio.h"
+
+#include "../../include/gpio.h"
+
+int
+GPIO_pin_num_from_char(const uint8_t *str)
+{
+  /* Not supported */
+  return -1;
+}
+
+void
+GPIO_init(uint8_t pin)
+{
+  gpio_reset_pin(pin);
+}
+
+void
+GPIO_set_dir(uint8_t pin, uint8_t dir)
+{
+  switch (dir) {
+    case (IN):
+      gpio_set_direction(pin, GPIO_MODE_INPUT);
+      break;
+    case (OUT):
+      gpio_set_direction(pin, GPIO_MODE_OUTPUT);
+      break;
+    case (HIGH_Z):
+      /* HIGH_Z is not supported */
+      break;
+  }
+}
+
+void
+GPIO_open_drain(uint8_t pin)
+{
+  /* Not supported */
+}
+
+void
+GPIO_pull_up(uint8_t pin)
+{
+  gpio_pullup_en(pin);
+}
+
+void
+GPIO_pull_down(uint8_t pin)
+{
+  gpio_pulldown_en(pin);
+}
+
+int
+GPIO_read(uint8_t pin)
+{
+  return gpio_get_level(pin);
+}
+
+void
+GPIO_write(uint8_t pin, uint8_t val)
+{
+  gpio_set_level(pin, val);
+}
+
+void
+GPIO_set_function(uint8_t pin, uint8_t function)
+{
+  /* Not supported */
+}


### PR DESCRIPTION
I have added picoruby-gpio which works with ESP32.

- It is available as per the following documentation
    - https://picoruby.github.io/GPIO.html
- open_drain is not yet supported
- set_function will be considered when implementing I2C, SPI, UART, PWM, etc. in the future.