### PR TITLE
Remove MRC_CUSTOM_ALLOC from build_config for esp32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -14,7 +14,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "MRBC_TICK_UNIT=10"
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=1"
   conf.cc.defines << "MRBC_USE_FLOAT=2"
-  conf.cc.defines << "MRC_CUSTOM_ALLOC"
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -15,7 +15,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "MRBC_TICK_UNIT=10"
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=1"
   conf.cc.defines << "MRBC_USE_FLOAT=2"
-  conf.cc.defines << "MRC_CUSTOM_ALLOC"
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"


### PR DESCRIPTION
MRC_CUSTOM_ALLOC is now no longer needed; it was left in ESP32's build_config and should be removed.