### PR TITLE
Add RNG for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -23,5 +23,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picorubyvm"
   conf.gem core: "picoruby-gpio"
   conf.gem core: "picoruby-adc"
+  conf.gem core: "picoruby-rng"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -24,5 +24,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picorubyvm"
   conf.gem core: "picoruby-gpio"
   conf.gem core: "picoruby-adc"
+  conf.gem core: "picoruby-rng"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-rng/ports/esp32/rng.c
+++ b/mrbgems/picoruby-rng/ports/esp32/rng.c
@@ -1,0 +1,9 @@
+#include "../../include/rng.h"
+#include "esp_random.h"
+
+uint8_t
+c_rng_random_byte_impl(void)
+{
+  uint32_t random = esp_random();
+  return (uint8_t)random;
+}


### PR DESCRIPTION
I ported picoruby-rng, which provides RNG (Random Number Generation), to the ESP32.