### PR TITLE
Add Watchdog for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -26,5 +26,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-rng"
   conf.gem core: "picoruby-spi"
   conf.gem core: "picoruby-pwm"
+  conf.gem core: "picoruby-watchdog"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -27,5 +27,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-rng"
   conf.gem core: "picoruby-spi"
   conf.gem core: "picoruby-pwm"
+  conf.gem core: "picoruby-watchdog"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
+++ b/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
@@ -38,8 +38,7 @@ Watchdog_update(void)
 bool
 Watchdog_caused_reboot(void)
 {
-  /* Not implemented */
-  return false;
+  return esp_reset_reason() == ESP_RST_TASK_WDT;
 }
 
 bool

--- a/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
+++ b/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
@@ -1,0 +1,57 @@
+#include "esp_task_wdt.h"
+
+void
+Watchdog_enable(uint32_t delay_ms, bool pause_on_debug)
+{
+  esp_task_wdt_config_t twdt_config = {
+    .timeout_ms = delay_ms,
+    .trigger_panic = pause_on_debug,
+  };
+  esp_task_wdt_init(&twdt_config);
+  esp_task_wdt_add(NULL);
+}
+
+void
+Watchdog_disable(void)
+{
+  esp_task_wdt_deinit();
+}
+
+void
+Watchdog_reboot(uint32_t delay_ms)
+{
+  /* Not implemented */
+}
+
+void
+Watchdog_start_tick(uint32_t cycles)
+{
+  /* Not implemented */
+}
+
+void
+Watchdog_update(void)
+{
+  esp_task_wdt_reset();
+}
+
+bool
+Watchdog_caused_reboot(void)
+{
+  /* Not implemented */
+  return false;
+}
+
+bool
+Watchdog_enable_caused_reboot(void)
+{
+  /* Not implemented */
+  return false;
+}
+
+uint32_t
+Watchdog_get_count(void)
+{
+  /* Not implemented */
+  return 0;
+}


### PR DESCRIPTION
Porting for ESP32 with Watchdog support.

On ESP32, only the following methods are supported

- Watchdog.enable
- Watchdog.disable
- Watchdog.update