### PR TITLE
Fixed build errors in ESP32C3 for adc and spi.

### DIFF
--- a/mrbgems/picoruby-adc/ports/esp32/adc.c
+++ b/mrbgems/picoruby-adc/ports/esp32/adc.c
@@ -100,10 +100,10 @@ init_adc(void)
   adc_unit_t units[UNIT_NUM] = { ADC_UNIT_1, ADC_UNIT_2 };
   
   for (int i = 0; i < UNIT_NUM ; i++) {
-    adc_oneshot_unit_init_cfg_t init_config;
-    init_config.unit_id = units[i];
-    init_config.clk_src = ADC_DIGI_CLK_SRC_PLL_F160M;
-    init_config.ulp_mode = ADC_ULP_MODE_DISABLE;
+    adc_oneshot_unit_init_cfg_t init_config = {
+      .unit_id = units[i],
+      .ulp_mode = ADC_ULP_MODE_DISABLE,
+    };
     if (adc_oneshot_new_unit(&init_config, &adc_handles[i]) != ESP_OK) {
       return -1;
     }
@@ -134,9 +134,10 @@ ADC_init(uint8_t pin)
     return -1;
   }
 
-  adc_oneshot_chan_cfg_t config;
-  config.atten = ADC_ATTEN_DB_12;
-  config.bitwidth = ADC_BITWIDTH_DEFAULT;
+  adc_oneshot_chan_cfg_t config = {
+    .atten = ADC_ATTEN_DB_12,
+    .bitwidth = ADC_BITWIDTH_DEFAULT,
+  };
 
   adc_oneshot_unit_handle_t handle = pin_to_unit_handle(pin);
   if (adc_oneshot_config_channel(handle, channel, &config) != ESP_OK) {

--- a/mrbgems/picoruby-spi/ports/esp32/spi.c
+++ b/mrbgems/picoruby-spi/ports/esp32/spi.c
@@ -54,12 +54,14 @@ SPI_unit_name_to_unit_num(const char *unit_name)
 {
   if (strcmp(unit_name, "ESP32_SPI2_HOST") == 0) {
     return SPI2_HOST;
-  } else if (strcmp(unit_name, "ESP32_SPI3_HOST") == 0) {
-    return SPI3_HOST;
   } if (strcmp(unit_name, "ESP32_HSPI_HOST") == 0) {
     return SPI2_HOST;
+#if (SOC_SPI_PERIPH_NUM == 3)
+  } else if (strcmp(unit_name, "ESP32_SPI3_HOST") == 0) {
+    return SPI3_HOST;
   } else if (strcmp(unit_name, "ESP32_VSPI_HOST") == 0) {
     return SPI3_HOST;
+#endif
   } else {
     return ERROR_INVALID_UNIT;
   }


### PR DESCRIPTION
I noticed that builds for the ESP32-C3 were failing and made two corrections:

## ADC

- The constant `ADC_DIGI_CLK_SRC_PLL_F160M` was undefined for ESP32-C3.
- By changing how the struct is declared, referencing this constant became unnecessary.

## SPI

- The definition `SPI3_HOST` was also undefined for ESP32-C3.
- Added a conditional check for undefined cases, referencing [this implementation in esp-idf](https://github.com/espressif/esp-idf/blob/5c51472e82a58098dda8d40a1c4f250c374fc900/components/esp_driver_spi/src/gpspi/spi_master.c#L247).
