### PR TITLE
Add RMT for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -27,5 +27,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-spi"
   conf.gem core: "picoruby-pwm"
   conf.gem core: "picoruby-watchdog"
+  conf.gem core: "picoruby-rmt"
+  conf.gem core: "picoruby-adafruit_sk6812"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -28,5 +28,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-spi"
   conf.gem core: "picoruby-pwm"
   conf.gem core: "picoruby-watchdog"
+  conf.gem core: "picoruby-rmt"
+  conf.gem core: "picoruby-adafruit_sk6812"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-adafruit_sk6812/mrbgem.rake
+++ b/mrbgems/picoruby-adafruit_sk6812/mrbgem.rake
@@ -1,0 +1,8 @@
+MRuby::Gem::Specification.new('picoruby-adafruit_sk6812') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'Yuhei Okazaki'
+  spec.summary = 'Adafruit SK6812 RGBW LED driver'
+
+  spec.add_dependency 'picoruby-rmt'
+end
+

--- a/mrbgems/picoruby-adafruit_sk6812/mrblib/sk6812.rb
+++ b/mrbgems/picoruby-adafruit_sk6812/mrblib/sk6812.rb
@@ -1,0 +1,11 @@
+require 'rmt'
+
+class SK6812
+  def initialize(gpio)
+    @rmt = RMT.new(gpio, t0h_ns: 300, t0l_ns: 900, t1h_ns: 600, t1l_ns: 600, reset_ns: 40000)
+  end
+
+  def output(r: 0, g: 0, b: 0)
+     @rmt.write([g, r, b])
+  end
+end

--- a/mrbgems/picoruby-rmt/include/rmt.h
+++ b/mrbgems/picoruby-rmt/include/rmt.h
@@ -1,0 +1,17 @@
+#ifndef RMT_DEFINED_H_
+#define RMT_DEFINED_H_
+
+#include <stdint.h>
+
+typedef struct RMT_symbol_dulation_t {
+  uint32_t t0h_ns;
+  uint32_t t0l_ns;
+  uint32_t t1h_ns;
+  uint32_t t1l_ns;
+  uint32_t reset_ns;
+} RMT_symbol_dulation_t;
+
+int RMT_init(uint32_t gpio, RMT_symbol_dulation_t *rmt_symbol_dulation);
+int RMT_write(uint8_t *buffer, uint32_t nbytes);
+
+#endif /* RMT_DEFINED_H_ */

--- a/mrbgems/picoruby-rmt/mrbgem.rake
+++ b/mrbgems/picoruby-rmt/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('picoruby-rmt') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'Yuhei Okazaki'
+  spec.summary = 'RMT(Remote Control) peripheral driver'
+end

--- a/mrbgems/picoruby-rmt/mrblib/rmt.rb
+++ b/mrbgems/picoruby-rmt/mrblib/rmt.rb
@@ -1,0 +1,28 @@
+class RMT
+  def initialize(pin, t0h_ns: 0, t0l_ns: 0, t1h_ns: 0, t1l_ns: 0, reset_ns: 0)
+    _init(pin, t0h_ns, t0l_ns, t1h_ns, t1l_ns, reset_ns)
+  end
+
+  def write(*params)
+    _write(params_to_array(*params))
+  end
+
+  # private
+
+  def params_to_array(*params)
+    ary = []
+    params.each do |param|
+      case param
+      when Array
+        # @type var param: Array[Integer]
+        ary += param
+      when Integer
+        ary << param
+      when String
+        # @type var param: String
+        ary += param.bytes
+      end
+    end
+    return ary
+  end
+end

--- a/mrbgems/picoruby-rmt/ports/esp32/rmt.c
+++ b/mrbgems/picoruby-rmt/ports/esp32/rmt.c
@@ -1,0 +1,113 @@
+#include "driver/rmt_tx.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "../../include/rmt.h"
+
+#define RMT_RESOLUTION_HZ (10000000)
+#define RMT_MEM_BLOCK_SYMBOLS (64)
+#define RMT_TRANS_QUEUE_DEPTH (4)
+
+static rmt_channel_handle_t rmt_channel = NULL;
+static rmt_encoder_handle_t rmt_encoder = NULL;
+static RMT_symbol_dulation_t rmt_symbol_dulation;
+
+static size_t
+encoder_callback(const void *data, size_t data_size,
+  size_t symbols_written, size_t symbols_free, rmt_symbol_word_t *symbols, bool *done, void *arg)
+{
+  if (symbols_free < 8) {
+    return 0;
+  }
+
+  const rmt_symbol_word_t symbol_zero = {
+    .level0 = 1,
+    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t0h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .level1 = 0,
+    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t0l_ns * RMT_RESOLUTION_HZ / 1000000000),
+  };
+  const rmt_symbol_word_t symbol_one = {
+    .level0 = 1,
+    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t1h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .level1 = 0,
+    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t1l_ns * RMT_RESOLUTION_HZ / 1000000000),
+  };
+  const rmt_symbol_word_t symbol_reset = {
+    .level0 = 0,
+    .duration0 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .level1 = 0,
+    .duration1 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+  };
+
+  size_t data_pos = symbols_written / 8;
+  uint8_t *data_bytes = (uint8_t*)data;
+  if (data_pos < data_size) {
+    size_t symbol_pos = 0;
+    for (int bitmask = 0x80; bitmask != 0; bitmask >>= 1) {
+      if (data_bytes[data_pos]&bitmask) {
+        symbols[symbol_pos++] = symbol_one;
+      } else {
+        symbols[symbol_pos++] = symbol_zero;
+      }
+    }
+    return symbol_pos;
+  } else {
+    symbols[0] = symbol_reset;
+    *done = 1;
+    return 1;
+  }
+}
+
+int
+RMT_init(uint32_t gpio, RMT_symbol_dulation_t *rsd)
+{
+  if (gpio >= GPIO_NUM_MAX) return -1;
+
+  rmt_symbol_dulation = *rsd;
+
+  rmt_tx_channel_config_t tx_chan_config = {
+    .clk_src = RMT_CLK_SRC_DEFAULT,
+    .gpio_num = gpio,
+    .mem_block_symbols = RMT_MEM_BLOCK_SYMBOLS,
+    .resolution_hz = RMT_RESOLUTION_HZ,
+    .trans_queue_depth = RMT_TRANS_QUEUE_DEPTH,
+  };
+  esp_err_t ret = rmt_new_tx_channel(&tx_chan_config, &rmt_channel);
+  if(ret != ESP_OK) {
+    return -1;
+  }
+
+  const rmt_simple_encoder_config_t simple_encoder_cfg = {
+    .callback = encoder_callback
+  };
+  ret = rmt_new_simple_encoder(&simple_encoder_cfg, &rmt_encoder);
+  if(ret != ESP_OK) {
+    return -1;
+  }
+
+  ret = rmt_enable(rmt_channel);
+  if(ret != ESP_OK) {
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+RMT_write(uint8_t *buffer, uint32_t nbytes)
+{
+  rmt_transmit_config_t tx_config = {
+    .loop_count = 0,
+  };
+  esp_err_t ret = rmt_transmit(rmt_channel, rmt_encoder, buffer, nbytes, &tx_config);
+  if(ret != ESP_OK) {
+    return -1;
+  }
+
+  ret = rmt_tx_wait_all_done(rmt_channel, portMAX_DELAY);
+  if(ret != ESP_OK) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/mrbgems/picoruby-rmt/src/rmt.c
+++ b/mrbgems/picoruby-rmt/src/rmt.c
@@ -1,0 +1,41 @@
+#include <mrubyc.h>
+
+#include "rmt.h"
+
+static void
+c_rmt__init(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  RMT_symbol_dulation_t rmt_symbol_dulation = {
+    .t0h_ns = GET_INT_ARG(2),
+    .t0l_ns = GET_INT_ARG(3),
+    .t1h_ns = GET_INT_ARG(4),
+    .t1l_ns = GET_INT_ARG(5),
+    .reset_ns = GET_INT_ARG(6)
+  };
+
+  int ret = RMT_init((uint32_t)GET_INT_ARG(1), &rmt_symbol_dulation);
+  SET_INT_RETURN(ret);
+}
+
+static void
+c_rmt__write(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_array value_ary = *(GET_ARY_ARG(1).array);
+  int len = value_ary.n_stored;
+  uint8_t txdata[len];
+
+  for (int i = 0 ; i < len ; i++) {
+    txdata[i] = mrbc_integer(value_ary.data[i]);
+  }
+
+  int ret = RMT_write(txdata, len);
+  SET_INT_RETURN(ret);
+}
+
+void
+mrbc_rmt_init(mrbc_vm *vm)
+{
+  mrbc_class *mrbc_class_RMT = mrbc_define_class(vm, "RMT", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_RMT, "_init", c_rmt__init);
+  mrbc_define_method(vm, mrbc_class_RMT, "_write", c_rmt__write);
+}


### PR DESCRIPTION
I added an mrbgem to control the full-color LED on the M5Stamp C3 Mate.
(Product reference: https://www.switch-science.com/products/7474?srsltid=AfmBOoq09F00EjRLdsH-DWmjrZRYf34pyjhr82EakuQykOLfTpmX6DtX)

The LED uses an adafruit_sk6812 chip, which requires communication via RMT (Remote Control).
On the ESP32, this can be achieved using the following functionality:
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/rmt.html

Based on this, I have added a SK6812 class.