### PR TITLE
Add /bin/nmble and /bin/nmcli to _path.txt

### DIFF
--- a/mrbgems/picoruby-shell/shell_executables/_path.txt
+++ b/mrbgems/picoruby-shell/shell_executables/_path.txt
@@ -1,8 +1,6 @@
 /etc/init.d/r2p2
 /etc/init.d/r2p2_wifi
 /bin/wifi_connect
-/bin/wifi_config
-/bin/wifi_config_ble
 /bin/mv
 /bin/free
 /bin/irb
@@ -18,5 +16,7 @@
 /bin/mkdir
 /bin/setup_sdcard
 /bin/machine-id
+/bin/nmble
+/bin/nmcli
 /etc/init.d/r2p2
 /etc/init.d/r2p2-wifi


### PR DESCRIPTION
While attempting to build PicoRuby for the R2P2-ESP32, I encountered an error.
To address this, I have added the necessary commands to _path.txt.