### PR TITLE
Make it buildable for ESP32 with the latest master branch where MicroRuby has been merged.

### DIFF
--- a/mrbgems/picoruby-adc/ports/esp32/adc.c
+++ b/mrbgems/picoruby-adc/ports/esp32/adc.c
@@ -161,7 +161,7 @@ ADC_read_raw(uint8_t input)
 }
 
 #if MRBC_USE_FLOAT
-picobc_float_t
+picorb_float_t
 ADC_read_voltage(uint8_t input)
 {
   uint32_t raw = ADC_read_raw(input);

--- a/mrbgems/picoruby-io-console/ports/esp32/io-console.c
+++ b/mrbgems/picoruby-io-console/ports/esp32/io-console.c
@@ -2,8 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#include <mrubyc.h>
-
 /*-------------------------------------
  *
  *  IO::Console
@@ -15,115 +13,47 @@ static bool raw_mode_saved = false;
 static bool echo_mode = true;
 static bool echo_mode_saved = true;
 
-void
-c_raw_bang(mrb_vm *vm, mrb_value *v, int argc)
+bool
+io_raw_q(void)
 {
+  return raw_mode;
+}
+
+void
+io_raw_bang(bool nonblock)
+{
+  (void)nonblock;
   raw_mode_saved = raw_mode;
   raw_mode = true;
 }
 
 void
-c_cooked_bang(mrb_vm *vm, mrb_value *v, int argc)
+io_cooked_bang(void)
 {
   raw_mode_saved = raw_mode;
   raw_mode = false;
 }
 
-static void
-c_echo_eq(mrb_vm *vm, mrb_value *v, int argc)
+void
+io_echo_eq(bool flag)
 {
   echo_mode_saved = echo_mode;
-  if (v[1].tt == MRBC_TT_FALSE) {
+  if (flag) {
     echo_mode = false;
   } else {
     echo_mode = true;
   }
 }
 
-static void
-c_echo_q(mrb_vm *vm, mrb_value *v, int argc)
+bool
+io_echo_q(void)
 {
-  if (echo_mode) {
-    SET_TRUE_RETURN();
-  } else {
-    SET_FALSE_RETURN();
-  }
+  return echo_mode;
 }
 
 void
-c__restore_termios(mrb_vm *vm, mrb_value *v, int argc)
+io__restore_termios(void)
 {
   raw_mode = raw_mode_saved;
   echo_mode = echo_mode_saved;
 }
-
-static void
-c_gets(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  mrb_value str = mrbc_string_new(vm, NULL, 0);
-  char buf[2];
-  buf[1] = '\0';
-  while (true) {
-    int c = hal_getchar();
-    if (c == 3) { // Ctrl-C
-      mrbc_raise(vm, MRBC_CLASS(IOError), "Interrupted");
-      return;
-    }
-    if (c == 27) { // ESC
-      continue;
-    }
-    if (c == 8 || c == 127) { // Backspace
-      if (0 < str.string->size) {
-        str.string->size--;
-        mrbc_realloc(vm, str.string->data, str.string->size);
-        hal_write(1, "\b \b", 3);
-      }
-    } else
-    if (-1 < c) {
-      buf[0] = c;
-      mrbc_string_append_cstr(&str, buf);
-      hal_write(1, buf, 1);
-      if (c == '\n' || c == '\r') {
-        break;
-      }
-    }
-  }
-  SET_RETURN(str);
-}
-
-static void
-c_getc(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  if (raw_mode) {
-    char buf[1];
-    int c = hal_getchar();
-    if (-1 < c) {
-      buf[0] = c;
-      mrb_value str = mrbc_string_new(vm, buf, 1);
-      SET_RETURN(str);
-    } else {
-      SET_NIL_RETURN();
-    }
-  }
-  else {
-    c_gets(vm, v, argc);
-    mrbc_value str = v[0];
-    if (1 < str.string->size) {
-      mrbc_realloc(vm, str.string->data, 1);
-      str.string->size = 1;
-    }
-  }
-}
-
-void
-io_console_port_init(mrbc_vm *vm, mrbc_class *class_IO)
-{
-  mrbc_define_method(vm, class_IO, "raw!", c_raw_bang);
-  mrbc_define_method(vm, class_IO, "cooked!", c_cooked_bang);
-  mrbc_define_method(vm, class_IO, "echo?", c_echo_q);
-  mrbc_define_method(vm, class_IO, "echo=", c_echo_eq);
-  mrbc_define_method(vm, class_IO, "_restore_termios", c__restore_termios);
-  mrbc_define_method(vm, class_IO, "getc", c_getc);
-  mrbc_define_method(vm, mrbc_class_object, "gets", c_gets);
-}
-

--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -163,3 +163,24 @@ Machine_get_unique_id(char *id_str)
   sprintf(id_str, "%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
   return 1;
 }
+
+uint32_t
+Machine_stack_usage(void)
+{
+  // Not implemented
+  return 0;
+}
+
+bool
+Machine_set_hwclock(const struct timespec *ts)
+{
+  // Not implemented
+  return false;
+}
+
+bool
+Machine_get_hwclock(struct timespec *ts)
+{
+  // Not implemented
+  return false;
+}

--- a/mrbgems/picoruby-rng/ports/esp32/rng.c
+++ b/mrbgems/picoruby-rng/ports/esp32/rng.c
@@ -2,7 +2,7 @@
 #include "esp_random.h"
 
 uint8_t
-c_rng_random_byte_impl(void)
+rng_random_byte_impl(void)
 {
   uint32_t random = esp_random();
   return (uint8_t)random;


### PR DESCRIPTION
I made modifications to make ESP32-R2P2 work with the current `master` branch.

- For `io-console.c`, I used the one from the RP2040 implementation.
- For `Machine_stack_usage`, I’m considering using `uxTaskGetStackHighWaterMark` to implement it, but it is currently unimplemented.
- `Machine_set_hwclock` and `Machine_get_hwclock` will be implemented after SNTP support is added.
