### PR TITLE
Fixed build error for pico_w.

### DIFF
--- a/build_config/r2p2_w-microruby-cortex-m0plus.rb
+++ b/build_config/r2p2_w-microruby-cortex-m0plus.rb
@@ -1,0 +1,57 @@
+MRuby::CrossBuild.new("r2p2_w-microruby-cortex-m0plus") do |conf|
+
+  ###############################################################
+  # You need following tools:
+  #   arm-none-eabi       | to make libmruby.a
+  ###############################################################
+
+  conf.toolchain("gcc")
+
+  # MicroRuby specific defines (MRB_ prefix, not MRBC_)
+  conf.cc.defines << "MRB_TICK_UNIT=1"
+  conf.cc.defines << "MRB_TIMESLICE_TICK_COUNT=10"
+
+  conf.cc.defines << "MRB_INT64"
+  conf.cc.defines << "MRB_32BIT"
+  conf.cc.defines << "PICORB_ALLOC_ESTALLOC"
+  conf.cc.defines << "ESTALLOC_DEBUG"
+  conf.cc.defines << "USE_FAT_FLASH_DISK=1"
+  conf.cc.defines << "USE_WIFI"
+
+  # Cortex-M0+ toolchain settings
+  conf.cc.command = "arm-none-eabi-gcc"
+  conf.linker.command = "arm-none-eabi-ld"
+  conf.linker.flags << "-static"
+  conf.archiver.command = "arm-none-eabi-ar"
+
+  conf.cc.host_command = "gcc"
+
+  conf.cc.flags.flatten!
+  conf.cc.flags << "-mcpu=cortex-m0plus"
+  conf.cc.flags << "-mthumb"
+  conf.cc.flags << "-fshort-enums"
+  conf.cc.flags << "-Wall"
+  conf.cc.flags << "-Wno-format"
+  conf.cc.flags << "-Wno-unused-function"
+  conf.cc.flags << "-ffunction-sections"
+  conf.cc.flags << "-fdata-sections"
+
+  # gemboxesとgemsの設定
+  conf.gembox "stdlib-microruby"
+  conf.gembox "baremetal"
+  conf.gembox "peripherals"
+  conf.gembox "r2p2"
+  conf.gembox "cyw43"
+  conf.gembox "peripheral_utils"
+  conf.gembox "utils"
+
+  # ワイヤレス接続関連のgem
+  conf.gem core: 'picoruby-jwt'
+  conf.gem core: 'picoruby-net'
+  conf.gem core: 'picoruby-mbedtls'
+  conf.gem core: 'picoruby-cyw43'
+  conf.gem core: 'picoruby-ble'
+
+  # MicroRuby設定の有効化
+  conf.microruby
+end


### PR DESCRIPTION
## Overview
Added this file because there was a load error for `r2p2_w-microruby-cortex-m0plus.rb` when executing

```sh
rake mruby:pico_w:production.
````

## Error Details
```
MRUBY_CONFIG=r2p2_w-microruby-cortex-m0plus  rake
rake aborted!
LoadError: cannot load such file -- /Users/ryosk7/src/github.com/picoruby/R2P2/lib/picoruby/build_config/r2p2_w-microruby-cortex-m0plus.rb (LoadError)
/Users/ryosk7/src/github.com/picoruby/R2P2/lib/picoruby/Rakefile:19:in `load'
/Users/ryosk7/src/github.com/picoruby/R2P2/lib/picoruby/Rakefile:19:in `<top (required)>'
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [MRUBY_CONFIG=r2p2_w-microruby-cortex-m0plus  rake]
/Users/ryosk7/src/github.com/picoruby/R2P2/Rakefile:85:in `block (7 levels) in <top (required)>'
/Users/ryosk7/src/github.com/picoruby/R2P2/Rakefile:83:in `block (6 levels) in <top (required)>'
Tasks: TOP => mruby:pico_w:production
(See full trace by running task with --trace)
```

Added r2p2_w-microruby-cortex-m0plus.rb to make the build succeed.