### PR TITLE
Add mrbgems for nmcli to esp32 build config.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -29,5 +29,9 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-watchdog"
   conf.gem core: "picoruby-rmt"
   conf.gem core: "picoruby-adafruit_sk6812"
+  conf.gem core: "picoruby-yaml"
+  conf.gem core: "picoruby-picoline"
+  conf.gem core: "picoruby-base64"
+  conf.gem core: "picoruby-mbedtls"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -30,5 +30,9 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-watchdog"
   conf.gem core: "picoruby-rmt"
   conf.gem core: "picoruby-adafruit_sk6812"
+  conf.gem core: "picoruby-yaml"
+  conf.gem core: "picoruby-picoline"
+  conf.gem core: "picoruby-base64"
+  conf.gem core: "picoruby-mbedtls"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-mbedtls/ports/esp32/timing_alt.c
+++ b/mrbgems/picoruby-mbedtls/ports/esp32/timing_alt.c
@@ -1,0 +1,67 @@
+#include <time.h>
+#include <stdint.h>
+#include <sys/time.h>
+
+typedef struct {
+  struct timespec end_time;
+  int             int_ms;
+  int             fin_ms;
+  int             active;
+} timing_delay_context;
+
+void
+mbedtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
+{
+  timing_delay_context *ctx = (timing_delay_context *)data;
+
+  ctx->int_ms = (int)int_ms;
+  ctx->fin_ms = (int)fin_ms;
+  ctx->active = 1;
+
+  if (fin_ms == 0) {
+    // Cancel
+    ctx->active = 0;
+    return;
+  }
+
+  // current time + fin_ms = end_time
+  struct timeval now;
+  gettimeofday( &now, NULL );
+  ctx->end_time.tv_sec = now.tv_sec + fin_ms / 1000;
+  ctx->end_time.tv_nsec = (now.tv_usec * 1000) + (fin_ms % 1000) * 1000000;
+  if (ctx->end_time.tv_nsec >= 1000000000) {
+    ctx->end_time.tv_sec += 1;
+    ctx->end_time.tv_nsec -= 1000000000;
+  }
+}
+
+int
+mbedtls_timing_get_delay(void *data)
+{
+  timing_delay_context *ctx = (timing_delay_context *)data;
+
+  if (ctx->fin_ms == 0 || !ctx->active) return -1;
+
+  struct timeval now;
+  gettimeofday( &now, NULL );
+
+  int64_t elapsed_ms = (ctx->end_time.tv_sec - now.tv_sec) * 1000 +
+                       ((ctx->end_time.tv_nsec / 1000) - now.tv_usec) / 1000;
+
+  if (elapsed_ms <= -ctx->fin_ms) {
+    return 2; // Final delay has passed
+  } else if (elapsed_ms <= -ctx->int_ms) {
+    return 1; // Intermediate delay has passed
+  } else {
+    return 0; // Still active, but no delay
+  }
+}
+
+// Stub
+unsigned long
+mbedtls_timing_hardclock(void)
+{
+  static unsigned long counter = 0;
+  return ++counter;
+}
+


### PR DESCRIPTION
I want to enable R2P2-ESP32 to connect to Wi-Fi.
To do this, I first added mrbgems to get nmcli working.

I ported the files in the ports directory of mbedtls to ESP32.
However, this function does not seem to be used.