### PR TITLE
Add I2C for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -33,5 +33,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+  conf.gem core: "picoruby-i2c"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -34,5 +34,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+  conf.gem core: "picoruby-i2c"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/esp32/i2c.c
@@ -1,0 +1,119 @@
+#include <string.h>
+#include "driver/i2c_master.h"
+
+#include "../../include/i2c.h"
+
+// Structure to store the I2C bus handle
+typedef struct {
+    i2c_master_bus_handle_t bus_handle;
+    bool initialized;
+    uint32_t frequency;
+} i2c_bus_context_t;
+
+// Context for each I2C port (ESP32 has a maximum of 2 ports)
+static i2c_bus_context_t i2c_contexts[2] = {0};
+
+int I2C_unit_name_to_unit_num(const char *unit_name) {
+    if (strcmp(unit_name, "ESP32_I2C0") == 0) {
+        return 0;
+    } else if (strcmp(unit_name, "ESP32_I2C1") == 0) {
+        return 1;
+    } else {
+        return ERROR_INVALID_UNIT;
+    }
+}
+
+i2c_status_t I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin) {
+
+    if (i2c_contexts[unit_num].initialized) {
+        i2c_del_master_bus(i2c_contexts[unit_num].bus_handle);
+        i2c_contexts[unit_num].initialized = false;
+    }
+
+    i2c_master_bus_config_t i2c_mst_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = unit_num,
+        .scl_io_num = scl_pin,
+        .sda_io_num = sda_pin,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+
+    esp_err_t err = i2c_new_master_bus(&i2c_mst_config, &i2c_contexts[unit_num].bus_handle);
+    if (err != ESP_OK) {
+        return ERROR_INVALID_UNIT;
+    }
+
+    i2c_contexts[unit_num].initialized = true;
+    i2c_contexts[unit_num].frequency = frequency;
+    
+    return ERROR_NONE;
+}
+
+int I2C_read_timeout_us(int unit_num, uint8_t addr, uint8_t* dst, size_t len, bool nostop, uint32_t timeout_us) {
+    if (!i2c_contexts[unit_num].initialized) {
+        return ERROR_INVALID_UNIT;
+    }
+
+    i2c_device_config_t dev_cfg = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = addr,
+        .scl_speed_hz = i2c_contexts[unit_num].frequency,
+    };
+
+    i2c_master_dev_handle_t dev_handle;
+    esp_err_t err = i2c_master_bus_add_device(i2c_contexts[unit_num].bus_handle, &dev_cfg, &dev_handle);
+    if (err != ESP_OK) {
+        return -1;
+    }
+
+    // Convert timeout to milliseconds (minimum 10ms)
+    uint32_t timeout_ms = (timeout_us + 999) / 1000;
+    if (timeout_ms < 10) {
+        timeout_ms = 10;
+    }
+
+    err = i2c_master_receive(dev_handle, dst, len, timeout_ms);
+    
+    i2c_master_bus_rm_device(dev_handle);
+
+    if (err != ESP_OK) {
+        return -1;
+    }
+
+    return len;
+}
+
+int I2C_write_timeout_us(int unit_num, uint8_t addr, uint8_t* src, size_t len, bool nostop, uint32_t timeout_us) {
+    if (!i2c_contexts[unit_num].initialized) {
+        return ERROR_INVALID_UNIT;
+    }
+
+    i2c_device_config_t dev_cfg = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = addr,
+        .scl_speed_hz = i2c_contexts[unit_num].frequency,
+    };
+
+    i2c_master_dev_handle_t dev_handle;
+    esp_err_t err = i2c_master_bus_add_device(i2c_contexts[unit_num].bus_handle, &dev_cfg, &dev_handle);
+    if (err != ESP_OK) {
+        return -1;
+    }
+
+    // Convert timeout to milliseconds (minimum 10ms)
+    uint32_t timeout_ms = (timeout_us + 999) / 1000;
+    if (timeout_ms < 10) {
+        timeout_ms = 10;
+    }
+
+    err = i2c_master_transmit(dev_handle, src, len, timeout_ms);
+    
+    i2c_master_bus_rm_device(dev_handle);
+
+    if (err != ESP_OK) {
+        return -1;
+    }
+
+    return len;
+}


### PR DESCRIPTION
Ported picoruby-i2c so that Inter-Integrated Circuit (I2C) can be used with ESP32.
I use I2C Master Driver of ESP-IDF. https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/i2c.html

# Usage Example
![image](https://github.com/user-attachments/assets/1e128ff9-f3a8-427c-ab0e-11a617e8245d)

Based on https://slide.rabbit-shocker.org/authors/hasumikin/RubyConfTaiwan2023/ P.17 with modified unit name and display text.

```ruby
require 'i2c'
i2c = I2C.new(unit: "ESP32_I2C0", frequency: 100_000, sda_pin: 25, scl_pin: 21)
[0x38, 0x39, 0x14, 0x70, 0x54, 0x6c].each { |i| i2c.write(0x3e, 0, i); sleep_ms 1 }
[0x38, 0x0c, 0x01].each { |i| i2c.write(0x3e, 0, i); sleep_ms 1 }
"Hello,".bytes.each { |c| i2c.write(0x3e, 0x40, c); sleep_ms 1 }
i2c.write(0x3e, 0, 0x80|0x40)
"ESP32!".bytes.each { |c| i2c.write(0x3e, 0x40, c); sleep_ms 1 }
```
