### PR TITLE
Avoid floating-point operations in RMT encoder callback for WS2812 LED control

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -33,5 +33,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+  conf.gem core: "picoruby-adafruit_ws2812"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -34,5 +34,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+  conf.gem core: "picoruby-adafruit_ws2812"
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-adafruit_ws2812/mrbgem.rake
+++ b/mrbgems/picoruby-adafruit_ws2812/mrbgem.rake
@@ -1,0 +1,7 @@
+MRuby::Gem::Specification.new('picoruby-adafruit_ws2812') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'Miyuki Koshiba'
+  spec.summary = 'Adafruit WS2812 LED driver'
+
+  spec.add_dependency 'picoruby-rmt'
+end

--- a/mrbgems/picoruby-adafruit_ws2812/mrblib/ws2812.rb
+++ b/mrbgems/picoruby-adafruit_ws2812/mrblib/ws2812.rb
@@ -1,0 +1,33 @@
+require 'rmt'
+
+class WS2812
+  def initialize(pin)
+    @rmt = RMT.new(
+      pin,
+      t0h_ns: 350,
+      t0l_ns: 800,
+      t1h_ns: 700,
+      t1l_ns: 600,
+      reset_ns: 60000)
+  end
+
+  # ex. show(0xff0000, 0x00ff00, 0x0000ff)  # Hexadecimal RGB values
+  # or show([255, 0, 0], [0, 255, 0], [0, 0, 255]) # Array of RGB values
+  def show(*colors)
+    bytes = []
+    colors.each do |color|
+      r, g, b = parse_color(color)
+      bytes << g << r << b
+    end
+
+    @rmt.write(bytes)
+  end
+
+  def parse_color(color)
+    if color.is_a?(Integer)
+      [(color>>16)&0xFF, (color>>8)&0xFF, color&0xFF]
+    else
+      color
+    end
+  end
+end

--- a/mrbgems/picoruby-adafruit_ws2812/sig/WS2812.rbs
+++ b/mrbgems/picoruby-adafruit_ws2812/sig/WS2812.rbs
@@ -1,0 +1,8 @@
+class WS2812
+  def initialize: (Integer pin) -> void
+
+  def show: (*[Integer | [Integer, Integer, Integer]]) -> void
+
+  def parse_color: (Integer color) -> [Integer, Integer, Integer]
+               | ([Integer, Integer, Integer] color) -> [Integer, Integer, Integer]
+end

--- a/mrbgems/picoruby-rmt/ports/esp32/rmt.c
+++ b/mrbgems/picoruby-rmt/ports/esp32/rmt.c
@@ -22,21 +22,21 @@ encoder_callback(const void *data, size_t data_size,
 
   const rmt_symbol_word_t symbol_zero = {
     .level0 = 1,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t0h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t0h_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t0l_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t0l_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
   const rmt_symbol_word_t symbol_one = {
     .level0 = 1,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t1h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t1h_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t1l_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t1l_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
   const rmt_symbol_word_t symbol_reset = {
     .level0 = 0,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
 
   size_t data_pos = symbols_written / 8;


### PR DESCRIPTION
### Summary
This PR introduces an mrbgem to control the full-color LED on the ATOM Matrix and modifies the ESP32 port of the picoruby-rmt library to replace floating-point operations with integer arithmetic in the RMT encoder callback function.

- ATOM Matrix Product reference: https://www.switch-science.com/products/6260
- The LED uses the adafruit_ws2812 chip Datasheet https://cdn-shop.adafruit.com/datasheets/WS2812.pdf

### Motivation

On ESP32, performing floating-point arithmetic inside interrupt context (such as RMT encoder callbacks) can lead to a Coprocessor exception (Guru Meditation Error). This occurs because the FPU context is not preserved during interrupt execution.
This issue can cause runtime crashes when controlling WS2812 LEDs, which require precise timing.

For example, the following runtime error was observed during WS2812 LED control:

```
Guru Meditation Error: Core  0 panic'ed (Coprocessor exception). 
EXCCAUSE: 0x00000004
Backtrace: 0x4010ebd6:0x3ffb1ac0 ...
```

This error indicates that floating-point operations in the encoder_callback function caused a crash. To prevent such runtime crashes, floating-point arithmetic was replaced with integer-based calculations.

### Impact

* Prevents runtime crashes caused by FPU access in ISR.
* Maintains calculation accuracy equivalent to the original implementation.
* No changes in external behavior.
* Adds support for WS2812 LEDs, enabling precise control of full-color LEDs on devices like the ATOM Matrix.