### PR TITLE
Use peripherals and r2p2 gembox in build config for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -18,15 +18,11 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"
 
+  conf.gembox 'peripherals'
+  conf.gembox 'r2p2'
   conf.gem core: "picoruby-machine"
-  conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
-  conf.gem core: "picoruby-gpio"
-  conf.gem core: "picoruby-adc"
   conf.gem core: "picoruby-rng"
-  conf.gem core: "picoruby-spi"
-  conf.gem core: "picoruby-uart"
-  conf.gem core: "picoruby-pwm"
   conf.gem core: "picoruby-watchdog"
   conf.gem core: "picoruby-rmt"
   conf.gem core: "picoruby-adafruit_sk6812"
@@ -35,6 +31,5 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
-  conf.gem core: "picoruby-i2c"
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -19,15 +19,11 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"
 
+  conf.gembox 'peripherals'
+  conf.gembox 'r2p2'
   conf.gem core: "picoruby-machine"
-  conf.gem core: "picoruby-shell"
   conf.gem core: "picoruby-picorubyvm"
-  conf.gem core: "picoruby-gpio"
-  conf.gem core: "picoruby-adc"
   conf.gem core: "picoruby-rng"
-  conf.gem core: "picoruby-spi"
-  conf.gem core: "picoruby-uart"
-  conf.gem core: "picoruby-pwm"
   conf.gem core: "picoruby-watchdog"
   conf.gem core: "picoruby-rmt"
   conf.gem core: "picoruby-adafruit_sk6812"
@@ -36,6 +32,5 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
-  conf.gem core: "picoruby-i2c"
   conf.picoruby(alloc_libc: false)
 end


### PR DESCRIPTION
I have modified the build config for ESP32 to use peripherals and r2p2 gembox.