### PR TITLE
Avoid float in RMT timing calculation to prevent FPU exception on ESP32

### DIFF
--- a/mrbgems/picoruby-rmt/ports/esp32/rmt.c
+++ b/mrbgems/picoruby-rmt/ports/esp32/rmt.c
@@ -22,21 +22,21 @@ encoder_callback(const void *data, size_t data_size,
 
   const rmt_symbol_word_t symbol_zero = {
     .level0 = 1,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t0h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t0h_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t0l_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t0l_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
   const rmt_symbol_word_t symbol_one = {
     .level0 = 1,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.t1h_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t1h_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.t1l_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.t1l_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
   const rmt_symbol_word_t symbol_reset = {
     .level0 = 0,
-    .duration0 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration0 = (uint16_t)(((uint64_t)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ) / 1000000000),
     .level1 = 0,
-    .duration1 = (uint16_t)((float)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ / 1000000000),
+    .duration1 = (uint16_t)(((uint64_t)rmt_symbol_dulation.reset_ns * RMT_RESOLUTION_HZ) / 1000000000),
   };
 
   size_t data_pos = symbols_written / 8;


### PR DESCRIPTION
## Summary
This PR modifies the ESP32 port of the picoruby-rmt library to replace floating-point operations with integer arithmetic in the RMT encoder callback function.

## Motivation
On ESP32, performing floating-point arithmetic inside interrupt context (such as RMT encoder callbacks) can lead to a Coprocessor exception (Guru Meditation Error). This occurs because the FPU context is not preserved during interrupt execution.

For example, the following runtime error was observed:
```
Guru Meditation Error: Core  0 panic'ed (Coprocessor exception). 
EXCCAUSE: 0x00000004
Backtrace: 0x4010ebd6:0x3ffb1ac0 ...
```

This error indicates that floating-point operations in the encoder_callback function caused a crash. To prevent such runtime crashes, floating-point arithmetic was replaced with integer-based calculations.

## Impact
- Prevents runtime crashes caused by FPU access in ISR
- Maintains calculation accuracy equivalent to the original implementation
- No changes in external behavior