### PR TITLE
Kernel#require for MicroRuby

### DIFF
--- a/build_config/microruby.rb
+++ b/build_config/microruby.rb
@@ -13,6 +13,7 @@ MRuby::Build.new do |conf|
   conf.gem core: 'picoruby-bin-microruby'
   conf.gem core: 'picoruby-net'
   conf.gem core: 'picoruby-mbedtls'
+  conf.gem core: 'picoruby-require'
   conf.gembox "stdlib-microruby"
   conf.gembox "posix-microruby"
   conf.gembox "r2p2"

--- a/mrbgems/picoruby-metaprog/mrbgem.rake
+++ b/mrbgems/picoruby-metaprog/mrbgem.rake
@@ -2,4 +2,6 @@ MRuby::Gem::Specification.new('picoruby-metaprog') do |spec|
   spec.license = 'MIT'
   spec.author  = 'HASUMI Hitoshi'
   spec.summary = 'Meta Programming for PicoRuby'
+
+  spec.add_conflict 'picoruby-mruby'
 end

--- a/mrbgems/picoruby-mruby/mrblib/kernel.rb
+++ b/mrbgems/picoruby-mruby/mrblib/kernel.rb
@@ -1,0 +1,5 @@
+module Kernel
+  def require(name)
+    false
+  end
+end

--- a/mrbgems/picoruby-mruby/mrblib/require.rb
+++ b/mrbgems/picoruby-mruby/mrblib/require.rb
@@ -1,7 +1,0 @@
-module Kernel
-  def require(path)
-    ## noop
-  end
-  def load(path)
-  end
-end

--- a/mrbgems/picoruby-require/include/require.h
+++ b/mrbgems/picoruby-require/include/require.h
@@ -9,9 +9,6 @@
 extern "C" {
 #endif
 
-bool picoruby_load_model(const uint8_t *mrb);
-bool picoruby_load_model_by_name(const char *gem);
-void picoruby_init_require(mrbc_vm *vm);
 
 #ifdef __cplusplus
 }

--- a/mrbgems/picoruby-require/include/require.h
+++ b/mrbgems/picoruby-require/include/require.h
@@ -1,0 +1,20 @@
+#ifndef PICORUBY_REQUIRE_H
+#define PICORUBY_REQUIRE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <mrubyc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool picoruby_load_model(const uint8_t *mrb);
+bool picoruby_load_model_by_name(const char *gem);
+void picoruby_init_require(mrbc_vm *vm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PICORUBY_REQUIRE_H */

--- a/mrbgems/picoruby-require/include/require.h
+++ b/mrbgems/picoruby-require/include/require.h
@@ -3,7 +3,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <mrubyc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/mrbgems/picoruby-require/mrbgem.rake
+++ b/mrbgems/picoruby-require/mrbgem.rake
@@ -3,6 +3,10 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
   spec.author  = 'HASUMI Hitoshi'
   spec.summary = 'PicoRuby require gem'
 
+  spec.add_dependency 'picoruby-sandbox'
+
+  next if build.vm_mruby?
+
   if cc.defines.flatten.any?{ _1.match? /\AMRBC_USE_HAL_POSIX(=\d+)?\z/ }
     # TODO: in Wasm, you may need to implement File class with File System Access API
     spec.add_dependency 'picoruby-io'
@@ -10,7 +14,6 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
     spec.add_dependency 'picoruby-vfs'
     spec.add_dependency 'picoruby-filesystem-fat'
   end
-  spec.add_dependency 'picoruby-sandbox'
 
   mrbgems_dir = File.expand_path "..", build_dir
 

--- a/mrbgems/picoruby-require/mrbgem.rake
+++ b/mrbgems/picoruby-require/mrbgem.rake
@@ -173,7 +173,8 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
         void
         picoruby_init_require(mrbc_vm *vm)
         {
-          mrbc_define_method(vm, mrbc_class_object, "extern", c_extern);
+          mrbc_class *module_Kernel = mrbc_define_module(vm, "Kernel");
+          mrbc_define_method(vm, module_Kernel, "extern", c_extern);
           mrbc_value self = mrbc_instance_new(vm, mrbc_class_object, 0);
           mrbc_instance_call_initialize(vm, &self, 0);
           mrbc_value args[2];

--- a/mrbgems/picoruby-require/mrbgem.rake
+++ b/mrbgems/picoruby-require/mrbgem.rake
@@ -1,3 +1,5 @@
+require 'erb'
+
 MRuby::Gem::Specification.new('picoruby-require') do |spec|
   spec.license = 'MIT'
   spec.author  = 'HASUMI Hitoshi'
@@ -55,137 +57,11 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
   file objfile("#{mrbgems_dir}/picogem_init") => ["#{mrbgems_dir}/picogem_init.c"]
 
   file "#{mrbgems_dir}/picogem_init.c" => [*picogems.values.map{_1[:mrbfile]}, MRUBY_CONFIG, __FILE__, :collect_gems] do |t|
-    mkdir_p File.dirname t.name
-    open(t.name, 'w+') do |f|
-      f.puts <<~PICOGEM
-        #include <stdio.h>
-        #include <stdbool.h>
-        #include <mrubyc.h>
-      PICOGEM
-      f.puts
-      picogems.each do |_require_name, v|
-        Rake::FileTask[v[:mrbfile]].invoke
-        f.puts "#include \"#{v[:mrbfile]}\"" if File.exist?(v[:mrbfile])
-      end
-      f.puts
-      f.puts <<~PICOGEM
-        typedef struct picogems {
-          const char *name;
-          const uint8_t *mrb;
-          void (*initializer)(mrbc_vm *vm);
-          bool required;
-        } picogems;
-      PICOGEM
-      f.puts
-      f.puts "static picogems prebuilt_gems[] = {"
-      picogems.each do |require_name, v|
-        name = File.basename(v[:mrbfile], ".c")
-        f.puts "  {\"#{require_name}\", #{name.gsub('-','_')}, #{v[:initializer]}, false}," if File.exist?(v[:mrbfile])
-      end
-      f.puts "  {NULL, NULL, NULL, true} /* sentinel */"
-      f.puts "};"
-      f.puts
-      f.puts <<~PICOGEM
-        /* public API */
-        bool
-        picoruby_load_model(const uint8_t *mrb)
-        {
-          mrbc_vm *vm = mrbc_vm_open(NULL);
-          if (vm == 0) {
-            console_printf("Error: Can't open VM.\\n");
-            return false;
-          }
-          if (mrbc_load_mrb(vm, mrb) != 0) {
-            console_printf("Error: %s\\n", vm->exception.exception->message);
-            mrbc_vm_close(vm);
-            return false;
-          }
-          mrbc_vm_begin(vm);
-          mrbc_vm_run(vm);
-          if (vm->exception.tt != MRBC_TT_NIL) {
-            console_printf("Error: Exception occurred.\\n");
-            mrbc_vm_end(vm);
-            mrbc_vm_close(vm);
-            return false;
-          }
-          mrbc_raw_free(vm);
-          return true;
-        }
-
-        static int
-        gem_index(const char *name)
-        {
-          if (!name) return -1;
-          for (int i = 0; ; i++) {
-            if (prebuilt_gems[i].name == NULL) {
-              return -1;
-            } else if (strcmp(name, prebuilt_gems[i].name) == 0) {
-              return i;
-            }
-          }
-        }
-
-        bool
-        picoruby_load_model_by_name(const char *gem)
-        {
-          int i = gem_index(gem);
-          if (i < 0) return false;
-          return picoruby_load_model(prebuilt_gems[i].mrb);
-        }
-
-        static void
-        c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
-        {
-          if (argc == 0 || 2 < argc) {
-            mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments (expected 1..2)");
-            return;
-          }
-          if (GET_TT_ARG(1) != MRBC_TT_STRING) {
-            mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type");
-            return;
-          }
-          const char *name = (const char *)GET_STRING_ARG(1);
-          int i = gem_index(name);
-          if (i < 0) {
-            SET_NIL_RETURN();
-            return;
-          }
-          bool force = false;
-          if (argc == 2 && GET_TT_ARG(2) == MRBC_TT_TRUE) {
-            force = true;
-          }
-          if ((force || !prebuilt_gems[i].required)) {
-            if (prebuilt_gems[i].initializer) prebuilt_gems[i].initializer(vm);
-            if (!picoruby_load_model(prebuilt_gems[i].mrb)) {
-              SET_NIL_RETURN();
-            } else {
-              prebuilt_gems[i].required = true;
-              SET_TRUE_RETURN();
-            }
-          } else {
-            SET_FALSE_RETURN();
-          }
-        }
-      PICOGEM
-      f.puts
-
-      f.puts <<~PICOGEM
-        void
-        picoruby_init_require(mrbc_vm *vm)
-        {
-          mrbc_class *module_Kernel = mrbc_define_module(vm, "Kernel");
-          mrbc_define_method(vm, module_Kernel, "extern", c_extern);
-          mrbc_value self = mrbc_instance_new(vm, mrbc_class_object, 0);
-          mrbc_instance_call_initialize(vm, &self, 0);
-          mrbc_value args[2];
-          args[0] = self;
-          args[1] = mrbc_string_new_cstr(vm, "require");
-          c_extern(vm, args, 1);
-          args[1] = mrbc_string_new_cstr(vm, "io");
-          c_extern(vm, args, 1);
-        }
-      PICOGEM
+    picogems.each do |_require_name, v|
+      Rake::FileTask[v[:mrbfile]].invoke
     end
+    template = ERB.new(File.read(File.join(spec.dir, "templates/mrubyc/picogem_init.c.erb")), trim_mode: "%-")
+    File.write(t.name, template.result(binding))
   end
 
 end

--- a/mrbgems/picoruby-require/mrblib/require.rb
+++ b/mrbgems/picoruby-require/mrblib/require.rb
@@ -20,14 +20,12 @@ module Kernel
       $LOADED_FEATURES << path
       return !!result
     end
-    unless File.file?(path)
-      if RUBY_ENGINE == 'mruby/c'
-        raise LoadError, "cannot load such file -- #{path}"
-      else
-        return nil # TODO: for microruby
-      end
+    File.file?(path) and return load_file(path)
+    if RUBY_ENGINE == 'mruby/c'
+      raise LoadError, "cannot load such file -- #{path}"
+    else
+      return false # TODO: for microruby
     end
-    load_file(path)
   end
 
   # private
@@ -64,6 +62,8 @@ module Kernel
     end
     if RUBY_ENGINE == 'mruby/c'
       raise LoadError, "cannot load such file -- #{name}"
+    else
+      false # TODO: for microruby
     end
   end
 

--- a/mrbgems/picoruby-require/mrblib/require.rb
+++ b/mrbgems/picoruby-require/mrblib/require.rb
@@ -2,7 +2,7 @@ class LoadError < StandardError; end
 
 $LOADED_FEATURES = ["require"]
 
-class Object
+module Kernel
 
   def require(name)
     return false if required?(name)
@@ -67,6 +67,10 @@ class Object
     end
   end
 
+end
+
+class Object
+  include Kernel
 end
 
 if RUBY_ENGINE == 'mruby/c'

--- a/mrbgems/picoruby-require/mrblib/require.rb
+++ b/mrbgems/picoruby-require/mrblib/require.rb
@@ -21,7 +21,11 @@ class Object
       return !!result
     end
     unless File.file?(path)
-      raise LoadError, "cannot load such file -- #{path}"
+      if RUBY_ENGINE == 'mruby/c'
+        raise LoadError, "cannot load such file -- #{path}"
+      else
+        return nil # TODO: for microruby
+      end
     end
     load_file(path)
   end
@@ -58,9 +62,13 @@ class Object
         end
       end
     end
-    raise LoadError, "cannot load such file -- #{name}"
+    if RUBY_ENGINE == 'mruby/c'
+      raise LoadError, "cannot load such file -- #{name}"
+    end
   end
 
 end
 
-require "sandbox"
+if RUBY_ENGINE == 'mruby/c'
+  require "sandbox"
+end

--- a/mrbgems/picoruby-require/mrblib/require.rb
+++ b/mrbgems/picoruby-require/mrblib/require.rb
@@ -1,7 +1,5 @@
 class LoadError < StandardError; end
 
-$LOADED_FEATURES = ["require"]
-
 module Kernel
 
   def require(name)
@@ -21,11 +19,7 @@ module Kernel
       return !!result
     end
     File.file?(path) and return load_file(path)
-    if RUBY_ENGINE == 'mruby/c'
-      raise LoadError, "cannot load such file -- #{path}"
-    else
-      return false # TODO: for microruby
-    end
+    raise LoadError, "cannot load such file -- #{path}"
   end
 
   # private
@@ -60,19 +54,15 @@ module Kernel
         end
       end
     end
-    if RUBY_ENGINE == 'mruby/c'
-      raise LoadError, "cannot load such file -- #{name}"
-    else
-      false # TODO: for microruby
-    end
+    raise LoadError, "cannot load such file -- #{name}"
   end
 
 end
 
-class Object
-  include Kernel
-end
-
 if RUBY_ENGINE == 'mruby/c'
+  class Object
+    include Kernel
+  end
+  $LOADED_FEATURES = ["require"]
   require "sandbox"
 end

--- a/mrbgems/picoruby-require/sig/require.rbs
+++ b/mrbgems/picoruby-require/sig/require.rbs
@@ -7,7 +7,7 @@ end
 
 # @sidebar builtin
 # @added_by picoruby-require
-class Object
+module Kernel
   def require: (String name) -> bool
   def load: (String path) -> bool
   private def required?: (String name) -> bool

--- a/mrbgems/picoruby-require/src/mruby/require.c
+++ b/mrbgems/picoruby-require/src/mruby/require.c
@@ -1,0 +1,22 @@
+#include <mruby.h>
+#include <mruby/presym.h>
+
+static mrb_value
+mrb_extern(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+
+void
+mrb_picoruby_require_gem_init(mrb_state* mrb)
+{
+  struct RClass *module_Kernel = mrb_define_module_id(mrb, MRB_SYM(Kernel));
+
+  mrb_define_method_id(mrb, module_Kernel, MRB_SYM(extern), mrb_extern, MRB_ARGS_REQ(1));
+}
+
+void
+mrb_picoruby_require_gem_final(mrb_state* mrb)
+{
+}
+

--- a/mrbgems/picoruby-require/src/mruby/require.c
+++ b/mrbgems/picoruby-require/src/mruby/require.c
@@ -1,9 +1,25 @@
 #include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/class.h>
+#include <mruby/error.h>
+#include <mruby/string.h>
+#include <mruby/variable.h>
 #include <mruby/presym.h>
+#include <string.h>
+
+extern const char *prebuilt_gems[];
 
 static mrb_value
 mrb_extern(mrb_state *mrb, mrb_value self)
 {
+  char *name;
+  mrb_bool force;
+  mrb_get_args(mrb, "z|b", &name, &force);
+  for (int i = 0; prebuilt_gems[i]; i++) {
+    if (strcmp(prebuilt_gems[i], name) == 0) {
+      return mrb_false_value();
+    }
+  }
   return mrb_nil_value();
 }
 
@@ -12,11 +28,16 @@ mrb_picoruby_require_gem_init(mrb_state* mrb)
 {
   struct RClass *module_Kernel = mrb_define_module_id(mrb, MRB_SYM(Kernel));
 
-  mrb_define_method_id(mrb, module_Kernel, MRB_SYM(extern), mrb_extern, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, module_Kernel, MRB_SYM(extern), mrb_extern, MRB_ARGS_ARG(1,1));
+
+  mrb_value loaded_features = mrb_ary_new(mrb);
+  mrb_gv_set(mrb, MRB_GVSYM(LOADED_FEATURES), loaded_features);
+  for (int i = 0; prebuilt_gems[i]; i++) {
+    mrb_ary_push(mrb, loaded_features, mrb_str_new_cstr(mrb, prebuilt_gems[i]));
+  }
 }
 
 void
 mrb_picoruby_require_gem_final(mrb_state* mrb)
 {
 }
-

--- a/mrbgems/picoruby-require/src/mrubyc/require.c
+++ b/mrbgems/picoruby-require/src/mrubyc/require.c
@@ -1,6 +1,118 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
 #include <mrubyc.h>
+
+typedef struct picogems {
+  const char *name;
+  const uint8_t *mrb;
+  void (*initializer)(mrbc_vm *vm);
+  bool required;
+} picogems;
+
+extern picogems prebuilt_gems[];
+
+/* public API */
+bool
+picoruby_load_model(const uint8_t *mrb)
+{
+  mrbc_vm *vm = mrbc_vm_open(NULL);
+  if (vm == 0) {
+    console_printf("Error: Can't open VM.\n");
+    return false;
+  }
+  if (mrbc_load_mrb(vm, mrb) != 0) {
+    console_printf("Error: %s\n", vm->exception.exception->message);
+    mrbc_vm_close(vm);
+    return false;
+  }
+  mrbc_vm_begin(vm);
+  mrbc_vm_run(vm);
+  if (vm->exception.tt != MRBC_TT_NIL) {
+    console_printf("Error: Exception occurred.\n");
+    mrbc_vm_end(vm);
+    mrbc_vm_close(vm);
+    return false;
+  }
+  mrbc_raw_free(vm);
+  return true;
+}
+
+static int
+gem_index(const char *name)
+{
+  if (!name) return -1;
+  for (int i = 0; ; i++) {
+    if (prebuilt_gems[i].name == NULL) {
+      return -1;
+    } else if (strcmp(name, prebuilt_gems[i].name) == 0) {
+      return i;
+    }
+  }
+}
+
+bool
+picoruby_load_model_by_name(const char *gem)
+{
+  int i = gem_index(gem);
+  if (i < 0) return false;
+  return picoruby_load_model(prebuilt_gems[i].mrb);
+}
+
+static void
+c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc == 0 || 2 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments (expected 1..2)");
+    return;
+  }
+  if (GET_TT_ARG(1) != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type");
+    return;
+  }
+  const char *name = (const char *)GET_STRING_ARG(1);
+  int i = gem_index(name);
+  if (i < 0) {
+    SET_NIL_RETURN();
+    return;
+  }
+  bool force = false;
+  if (argc == 2 && GET_TT_ARG(2) == MRBC_TT_TRUE) {
+    force = true;
+  }
+  if ((force || !prebuilt_gems[i].required)) {
+    if (prebuilt_gems[i].initializer) prebuilt_gems[i].initializer(vm);
+    if (!picoruby_load_model(prebuilt_gems[i].mrb)) {
+      SET_NIL_RETURN();
+    } else {
+      prebuilt_gems[i].required = true;
+      SET_TRUE_RETURN();
+    }
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void
+picoruby_init_require(mrbc_vm *vm)
+{
+  mrbc_class *module_Kernel = mrbc_define_module(vm, "Kernel");
+  mrbc_define_method(vm, module_Kernel, "extern", c_extern);
+  mrbc_value self = mrbc_instance_new(vm, mrbc_class_object, 0);
+  mrbc_instance_call_initialize(vm, &self, 0);
+  mrbc_value args[2];
+  args[0] = self;
+  args[1] = mrbc_string_new_cstr(vm, "require");
+  c_extern(vm, args, 1);
+  args[1] = mrbc_string_new_cstr(vm, "io");
+  c_extern(vm, args, 1);
+}
 
 void
 mrbc_require_init(mrbc_vm *vm)
 {
+  // This must be empty because `require` cannot require itself.
+  // The initialization of `require` is done in `picoruby_init_require`,
+  // which should be called from the application's main entry point
+  // after the VM is initialized.
 }

--- a/mrbgems/picoruby-require/src/mrubyc/require.c
+++ b/mrbgems/picoruby-require/src/mrubyc/require.c
@@ -12,8 +12,7 @@ typedef struct picogems {
 
 extern picogems prebuilt_gems[];
 
-/* public API */
-bool
+static bool
 picoruby_load_model(const uint8_t *mrb)
 {
   mrbc_vm *vm = mrbc_vm_open(NULL);
@@ -51,14 +50,6 @@ gem_index(const char *name)
   }
 }
 
-bool
-picoruby_load_model_by_name(const char *gem)
-{
-  int i = gem_index(gem);
-  if (i < 0) return false;
-  return picoruby_load_model(prebuilt_gems[i].mrb);
-}
-
 static void
 c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
 {
@@ -93,6 +84,16 @@ c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
+/* public API */
+
+bool
+picoruby_load_model_by_name(const char *gem)
+{
+  int i = gem_index(gem);
+  if (i < 0) return false;
+  return picoruby_load_model(prebuilt_gems[i].mrb);
+}
+
 void
 picoruby_init_require(mrbc_vm *vm)
 {
@@ -116,3 +117,4 @@ mrbc_require_init(mrbc_vm *vm)
   // which should be called from the application's main entry point
   // after the VM is initialized.
 }
+

--- a/mrbgems/picoruby-require/src/mrubyc/require.c
+++ b/mrbgems/picoruby-require/src/mrubyc/require.c
@@ -1,0 +1,6 @@
+#include <mrubyc.h>
+
+void
+mrbc_require_init(mrbc_vm *vm)
+{
+}

--- a/mrbgems/picoruby-require/src/require.c
+++ b/mrbgems/picoruby-require/src/require.c
@@ -1,0 +1,12 @@
+//#include "../include/require.h"
+
+#if defined(PICORB_VM_MRUBY)
+
+#include "mruby/require.c"
+
+#elif defined(PICORB_VM_MRUBYC)
+
+#include "mrubyc/require.c"
+
+#endif
+

--- a/mrbgems/picoruby-require/src/require.c
+++ b/mrbgems/picoruby-require/src/require.c
@@ -1,4 +1,4 @@
-//#include "../include/require.h"
+#include "../include/require.h"
 
 #if defined(PICORB_VM_MRUBY)
 

--- a/mrbgems/picoruby-require/templates/mruby/picogem_init.c.erb
+++ b/mrbgems/picoruby-require/templates/mruby/picogem_init.c.erb
@@ -1,0 +1,10 @@
+#include <mruby.h>
+
+const char *prebuilt_gems[] = {
+<%- picogems.each do |require_name, v| -%>
+<%- if File.exist?(v[:mrbfile]) -%>
+  "<%= require_name %>",
+<%- end -%>
+<%- end -%>
+  NULL
+};

--- a/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
+++ b/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
@@ -1,12 +1,11 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <mrubyc.h>
-
-<% picogems.each do |_require_name, v| %>
-<% if File.exist?(v[:mrbfile]) %>
+<%- picogems.each do |_require_name, v| -%>
+<%- if File.exist?(v[:mrbfile]) -%>
 #include "<%= v[:mrbfile] %>"
-<% end %>
-<% end %>
+<%- end -%>
+<%- end -%>
 
 typedef struct picogems {
   const char *name;
@@ -16,11 +15,11 @@ typedef struct picogems {
 } picogems;
 
 picogems prebuilt_gems[] = {
-<% picogems.each do |require_name, v| %>
-<% if File.exist?(v[:mrbfile]) %>
+<%- picogems.each do |require_name, v| -%>
+<%- if File.exist?(v[:mrbfile]) -%>
   {"<%= require_name %>", <%= File.basename(v[:mrbfile], ".c").gsub('-','_') %>, <%= v[:initializer] %>, false},
-<% end %>
-<% end %>
+<%- end -%>
+<%- end -%>
   {NULL, NULL, NULL, true} /* sentinel */
 };
 

--- a/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
+++ b/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <mrubyc.h>
+
+<% picogems.each do |_require_name, v| %>
+<% if File.exist?(v[:mrbfile]) %>
+#include "<%= v[:mrbfile] %>"
+<% end %>
+<% end %>
+
+typedef struct picogems {
+  const char *name;
+  const uint8_t *mrb;
+  void (*initializer)(mrbc_vm *vm);
+  bool required;
+} picogems;
+
+static picogems prebuilt_gems[] = {
+<% picogems.each do |require_name, v| %>
+<% if File.exist?(v[:mrbfile]) %>
+  {"<%= require_name %>", <%= File.basename(v[:mrbfile], ".c").gsub('-','_') %>, <%= v[:initializer] %>, false},
+<% end %>
+<% end %>
+  {NULL, NULL, NULL, true} /* sentinel */
+};
+
+/* public API */
+bool
+picoruby_load_model(const uint8_t *mrb)
+{
+  mrbc_vm *vm = mrbc_vm_open(NULL);
+  if (vm == 0) {
+    console_printf("Error: Can't open VM.\n");
+    return false;
+  }
+  if (mrbc_load_mrb(vm, mrb) != 0) {
+    console_printf("Error: %s\n", vm->exception.exception->message);
+    mrbc_vm_close(vm);
+    return false;
+  }
+  mrbc_vm_begin(vm);
+  mrbc_vm_run(vm);
+  if (vm->exception.tt != MRBC_TT_NIL) {
+    console_printf("Error: Exception occurred.\n");
+    mrbc_vm_end(vm);
+    mrbc_vm_close(vm);
+    return false;
+  }
+  mrbc_raw_free(vm);
+  return true;
+}
+
+static int
+gem_index(const char *name)
+{
+  if (!name) return -1;
+  for (int i = 0; ; i++) {
+    if (prebuilt_gems[i].name == NULL) {
+      return -1;
+    } else if (strcmp(name, prebuilt_gems[i].name) == 0) {
+      return i;
+    }
+  }
+}
+
+bool
+picoruby_load_model_by_name(const char *gem)
+{
+  int i = gem_index(gem);
+  if (i < 0) return false;
+  return picoruby_load_model(prebuilt_gems[i].mrb);
+}
+
+static void
+c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc == 0 || 2 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments (expected 1..2)");
+    return;
+  }
+  if (GET_TT_ARG(1) != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type");
+    return;
+  }
+  const char *name = (const char *)GET_STRING_ARG(1);
+  int i = gem_index(name);
+  if (i < 0) {
+    SET_NIL_RETURN();
+    return;
+  }
+  bool force = false;
+  if (argc == 2 && GET_TT_ARG(2) == MRBC_TT_TRUE) {
+    force = true;
+  }
+  if ((force || !prebuilt_gems[i].required)) {
+    if (prebuilt_gems[i].initializer) prebuilt_gems[i].initializer(vm);
+    if (!picoruby_load_model(prebuilt_gems[i].mrb)) {
+      SET_NIL_RETURN();
+    } else {
+      prebuilt_gems[i].required = true;
+      SET_TRUE_RETURN();
+    }
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+void
+picoruby_init_require(mrbc_vm *vm)
+{
+  mrbc_class *module_Kernel = mrbc_define_module(vm, "Kernel");
+  mrbc_define_method(vm, module_Kernel, "extern", c_extern);
+  mrbc_value self = mrbc_instance_new(vm, mrbc_class_object, 0);
+  mrbc_instance_call_initialize(vm, &self, 0);
+  mrbc_value args[2];
+  args[0] = self;
+  args[1] = mrbc_string_new_cstr(vm, "require");
+  c_extern(vm, args, 1);
+  args[1] = mrbc_string_new_cstr(vm, "io");
+  c_extern(vm, args, 1);
+}

--- a/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
+++ b/mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb
@@ -15,7 +15,7 @@ typedef struct picogems {
   bool required;
 } picogems;
 
-static picogems prebuilt_gems[] = {
+picogems prebuilt_gems[] = {
 <% picogems.each do |require_name, v| %>
 <% if File.exist?(v[:mrbfile]) %>
   {"<%= require_name %>", <%= File.basename(v[:mrbfile], ".c").gsub('-','_') %>, <%= v[:initializer] %>, false},
@@ -24,98 +24,4 @@ static picogems prebuilt_gems[] = {
   {NULL, NULL, NULL, true} /* sentinel */
 };
 
-/* public API */
-bool
-picoruby_load_model(const uint8_t *mrb)
-{
-  mrbc_vm *vm = mrbc_vm_open(NULL);
-  if (vm == 0) {
-    console_printf("Error: Can't open VM.\n");
-    return false;
-  }
-  if (mrbc_load_mrb(vm, mrb) != 0) {
-    console_printf("Error: %s\n", vm->exception.exception->message);
-    mrbc_vm_close(vm);
-    return false;
-  }
-  mrbc_vm_begin(vm);
-  mrbc_vm_run(vm);
-  if (vm->exception.tt != MRBC_TT_NIL) {
-    console_printf("Error: Exception occurred.\n");
-    mrbc_vm_end(vm);
-    mrbc_vm_close(vm);
-    return false;
-  }
-  mrbc_raw_free(vm);
-  return true;
-}
 
-static int
-gem_index(const char *name)
-{
-  if (!name) return -1;
-  for (int i = 0; ; i++) {
-    if (prebuilt_gems[i].name == NULL) {
-      return -1;
-    } else if (strcmp(name, prebuilt_gems[i].name) == 0) {
-      return i;
-    }
-  }
-}
-
-bool
-picoruby_load_model_by_name(const char *gem)
-{
-  int i = gem_index(gem);
-  if (i < 0) return false;
-  return picoruby_load_model(prebuilt_gems[i].mrb);
-}
-
-static void
-c_extern(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  if (argc == 0 || 2 < argc) {
-    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments (expected 1..2)");
-    return;
-  }
-  if (GET_TT_ARG(1) != MRBC_TT_STRING) {
-    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type");
-    return;
-  }
-  const char *name = (const char *)GET_STRING_ARG(1);
-  int i = gem_index(name);
-  if (i < 0) {
-    SET_NIL_RETURN();
-    return;
-  }
-  bool force = false;
-  if (argc == 2 && GET_TT_ARG(2) == MRBC_TT_TRUE) {
-    force = true;
-  }
-  if ((force || !prebuilt_gems[i].required)) {
-    if (prebuilt_gems[i].initializer) prebuilt_gems[i].initializer(vm);
-    if (!picoruby_load_model(prebuilt_gems[i].mrb)) {
-      SET_NIL_RETURN();
-    } else {
-      prebuilt_gems[i].required = true;
-      SET_TRUE_RETURN();
-    }
-  } else {
-    SET_FALSE_RETURN();
-  }
-}
-
-void
-picoruby_init_require(mrbc_vm *vm)
-{
-  mrbc_class *module_Kernel = mrbc_define_module(vm, "Kernel");
-  mrbc_define_method(vm, module_Kernel, "extern", c_extern);
-  mrbc_value self = mrbc_instance_new(vm, mrbc_class_object, 0);
-  mrbc_instance_call_initialize(vm, &self, 0);
-  mrbc_value args[2];
-  args[0] = self;
-  args[1] = mrbc_string_new_cstr(vm, "require");
-  c_extern(vm, args, 1);
-  args[1] = mrbc_string_new_cstr(vm, "io");
-  c_extern(vm, args, 1);
-}

--- a/mrbgems/picoruby-sandbox/mrblib/sandbox.rb
+++ b/mrbgems/picoruby-sandbox/mrblib/sandbox.rb
@@ -1,5 +1,5 @@
 require 'io/console'
-require 'metaprog'
+require 'metaprog' if RUBY_ENGINE == 'mruby/c'
 
 class Sandbox
 

--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -1,5 +1,4 @@
 require "env"
-require "metaprog"
 require "picorubyvm"
 require "sandbox"
 require "crc"
@@ -11,7 +10,7 @@ begin
   require "vfs"
 rescue LoadError
   # ignore. maybe POSIX
-  require "dir"
+  require "dir" if RUBY_ENGINE == 'mruby/c'
 end
 
 # ENV = {} # This moved to 0_out_of_steep.rb


### PR DESCRIPTION
This pull request introduces significant updates to the PicoRuby ecosystem, focusing on enhancing the `require` functionality, improving gem management, and optimizing compatibility across different VM implementations (`mruby` and `mrubyc`). The changes include adding a new gem (`picoruby-require`), restructuring `require` behavior, and introducing templates for gem initialization. Below are the most important changes grouped by theme:

### Enhancements to `require` functionality
* Added the `picoruby-require` gem to the build configuration, enabling advanced `require` functionality. (`build_config/microruby.rb`, [build_config/microruby.rbR16](diffhunk://#diff-55b6a3a16c1aeded854581ce4bb6cd4c19f27f1c03d388568145762f5a80bb95R16))
* Reimplemented the `require` method in `mruby` and `mrubyc` environments, including support for prebuilt gems and error handling. (`mrbgems/picoruby-require/src/mruby/require.c`, [[1]](diffhunk://#diff-d706137638f5ff056a22b561c52bde0ea9ffafc07a3fbbe829196c16c2356535R1-R43); `mrbgems/picoruby-require/src/mrubyc/require.c`, [[2]](diffhunk://#diff-c76af94f7c80916bafa15fe376d1275d1732a25f8c68be715ba7f81672beef4cR1-R120)
* Created a unified header file (`require.h`) for the `picoruby-require` gem to define shared structures and ensure compatibility. (`mrbgems/picoruby-require/include/require.h`, [mrbgems/picoruby-require/include/require.hR1-R16](diffhunk://#diff-390294e83bb0ccf8f3ece31120de2511242805a9e2a344ca33e226e33625e1c2R1-R16))

### Gem management improvements
* Introduced templates (`picogem_init.c.erb`) for dynamic initialization of prebuilt gems, tailored for `mruby` and `mrubyc` environments. (`mrbgems/picoruby-require/templates/mruby/picogem_init.c.erb`, [[1]](diffhunk://#diff-1080bf1d254512a10383f7c24415bd91dc1ea06ab4d7b9d99094df594c3dc019R1-R10); `mrbgems/picoruby-require/templates/mrubyc/picogem_init.c.erb`, [[2]](diffhunk://#diff-d24947a30dd1aa7f5e48f374f0ed2f9a3a50351eb66fe191781dfa4c03e33c8fR1-R26)
* Added dependencies and conditional logic to the `picoruby-require` gem specification to manage compatibility with other gems and environments. (`mrbgems/picoruby-require/mrbgem.rake`, [mrbgems/picoruby-require/mrbgem.rakeR1-R18](diffhunk://#diff-fe5fd10d7cc077ef49a7f99c996e6397ddd05663160139f70ff53b768c6705e2R1-R18))

### Compatibility adjustments
* Updated `sandbox.rb` and `shell.rb` to conditionally load the `metaprog` gem only in `mruby/c` environments to prevent conflicts. (`mrbgems/picoruby-sandbox/mrblib/sandbox.rb`, [[1]](diffhunk://#diff-f427a1a2943a69596696c239428acf390c85eecacab6e67246b3076c00029837L2-R2); `mrbgems/picoruby-shell/mrblib/shell.rb`, [[2]](diffhunk://#diff-bba9bf67848b45a075ae08129d2408168199d1146796ace92f6600646c62ac47L2) [[3]](diffhunk://#diff-bba9bf67848b45a075ae08129d2408168199d1146796ace92f6600646c62ac47L14-R13)
* Added conflict resolution in `picoruby-metaprog` gem to explicitly prevent usage alongside `picoruby-mruby`. (`mrbgems/picoruby-metaprog/mrbgem.rake`, [mrbgems/picoruby-metaprog/mrbgem.rakeR5-R6](diffhunk://#diff-b4cc7c293066d81857476f5a3a8ce4cd1041fdd4921b5a0946a79378a90d446fR5-R6))

These changes collectively enhance the modularity and functionality of PicoRuby, particularly its handling of dependencies and gem initialization across different runtime environments.