### PR TITLE
Namespace error enum constants for GPIO, I2C , SPI and UART gems

### DIFF
--- a/mrbgems/picoruby-gpio/mrblib/gpio.rb
+++ b/mrbgems/picoruby-gpio/mrblib/gpio.rb
@@ -2,29 +2,29 @@ class GPIO
   class Error
     # This is a mimic of pico_error_codes
     # from pico-sdk/src/common/pico_base/include/pico/error.h
-    ERROR_NONE = 0
-    ERROR_TIMEOUT = -1
-    ERROR_GENERIC = -2
-    ERROR_NO_DATA = -3
-    ERROR_NOT_PERMITTED = -4
-    ERROR_INVALID_ARG = -5
-    ERROR_IO = -6
+    GPIO_ERROR_NONE = 0
+    GPIO_ERROR_TIMEOUT = -1
+    GPIO_ERROR_GENERIC = -2
+    GPIO_ERROR_NO_DATA = -3
+    GPIO_ERROR_NOT_PERMITTED = -4
+    GPIO_ERROR_INVALID_ARG = -5
+    GPIO_ERROR_IO = -6
 
     def self.peripheral_error(code, name = "unknown peripheral")
       case code
-      when ERROR_NONE
+      when GPIO_ERROR_NONE
         return 0
-      when ERROR_TIMEOUT
+      when GPIO_ERROR_TIMEOUT
         raise(IOError.new "Timeout error in #{name}")
-      when ERROR_GENERIC
+      when GPIO_ERROR_GENERIC
         raise(IOError.new "Generic error in #{name}")
-      when ERROR_NO_DATA
+      when GPIO_ERROR_NO_DATA
         raise(IOError.new "No data error in #{name}")
-      when ERROR_NOT_PERMITTED
+      when GPIO_ERROR_NOT_PERMITTED
         raise(IOError.new "Not permitted error in #{name}")
-      when ERROR_INVALID_ARG
+      when GPIO_ERROR_INVALID_ARG
         raise(IOError.new "Invalid arg error in #{name}")
-      when ERROR_IO
+      when GPIO_ERROR_IO
         raise(IOError.new "IO error in #{name}")
       else
         raise(IOError.new "Unknown error in #{name}. code: #{code}")

--- a/mrbgems/picoruby-gpio/sig/gpio.rbs
+++ b/mrbgems/picoruby-gpio/sig/gpio.rbs
@@ -3,13 +3,13 @@ class GPIO
 
   # @sidebar error
   class Error
-    ERROR_NONE:           0
-    ERROR_TIMEOUT:       -1
-    ERROR_GENERIC:       -2
-    ERROR_NO_DATA:       -3
-    ERROR_NOT_PERMITTED: -4
-    ERROR_INVALID_ARG:   -5
-    ERROR_IO:            -6
+    GPIO_ERROR_NONE:           0
+    GPIO_ERROR_TIMEOUT:       -1
+    GPIO_ERROR_GENERIC:       -2
+    GPIO_ERROR_NO_DATA:       -3
+    GPIO_ERROR_NOT_PERMITTED: -4
+    GPIO_ERROR_INVALID_ARG:   -5
+    GPIO_ERROR_IO:            -6
 
     def self.peripheral_error: (Integer code, ?String name) -> void
   end

--- a/mrbgems/picoruby-i2c/include/i2c.h
+++ b/mrbgems/picoruby-i2c/include/i2c.h
@@ -12,8 +12,8 @@ extern "C" {
 #define PICORUBY_I2C_RP2040_I2C1      1
 
 typedef enum {
- ERROR_NONE              =  0,
- ERROR_INVALID_UNIT      = -1,
+ I2C_ERROR_NONE          =  0,
+ I2C_ERROR_INVALID_UNIT  = -1,
 } i2c_status_t;
 
 int I2C_unit_name_to_unit_num(const char *);

--- a/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/esp32/i2c.c
@@ -17,7 +17,7 @@ int
 I2C_read_timeout_us(int unit_num, uint8_t addr, uint8_t* dst, size_t len, bool nostop, uint32_t timeout_us)
 {
   if (!i2c_contexts[unit_num].initialized) {
-    return ERROR_INVALID_UNIT;
+    return I2C_ERROR_INVALID_UNIT;
   }
 
   i2c_device_config_t dev_cfg = {
@@ -53,7 +53,7 @@ int
 I2C_write_timeout_us(int unit_num, uint8_t addr, uint8_t* src, size_t len, bool nostop, uint32_t timeout_us)
 {
   if (!i2c_contexts[unit_num].initialized) {
-    return ERROR_INVALID_UNIT;
+    return I2C_ERROR_INVALID_UNIT;
   }
 
   i2c_device_config_t dev_cfg = {
@@ -93,7 +93,7 @@ I2C_unit_name_to_unit_num(const char *unit_name)
   } else if (strcmp(unit_name, "ESP32_I2C1") == 0) {
     return 1;
   } else {
-    return ERROR_INVALID_UNIT;
+    return I2C_ERROR_INVALID_UNIT;
   }
 }
 
@@ -116,11 +116,11 @@ I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin)
 
   esp_err_t err = i2c_new_master_bus(&i2c_mst_config, &i2c_contexts[unit_num].bus_handle);
   if (err != ESP_OK) {
-    return ERROR_INVALID_UNIT;
+    return I2C_ERROR_INVALID_UNIT;
   }
 
   i2c_contexts[unit_num].initialized = true;
   i2c_contexts[unit_num].frequency = frequency;
 
-  return ERROR_NONE;
+  return I2C_ERROR_NONE;
 }

--- a/mrbgems/picoruby-i2c/ports/rp2040/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/rp2040/i2c.c
@@ -11,7 +11,7 @@
     switch (unit_num) { \
       case PICORUBY_I2C_RP2040_I2C0: { unit = i2c0; break; } \
       case PICORUBY_I2C_RP2040_I2C1: { unit = i2c1; break; } \
-      default: { return ERROR_INVALID_UNIT; } \
+      default: { return I2C_ERROR_INVALID_UNIT; } \
     } \
   } while (0)
 
@@ -39,7 +39,7 @@ I2C_unit_name_to_unit_num(const char *unit_name)
   } else if (strcmp(unit_name, "RP2040_I2C1") == 0) {
     return PICORUBY_I2C_RP2040_I2C1;
   } else {
-    return ERROR_INVALID_UNIT;
+    return I2C_ERROR_INVALID_UNIT;
   }
 }
 
@@ -57,6 +57,6 @@ I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin)
   gpio_pull_up(sda_pin);
   gpio_pull_up(scl_pin);
 
-  return ERROR_NONE;
+  return I2C_ERROR_NONE;
 }
 

--- a/mrbgems/picoruby-i2c/src/mruby/i2c.c
+++ b/mrbgems/picoruby-i2c/src/mruby/i2c.c
@@ -64,7 +64,7 @@ mrb__init(mrb_state *mrb, mrb_value self)
   if (status < 0) {
     const char *message;
     switch (status) {
-      case ERROR_INVALID_UNIT: message = "Invalid I2C unit"; break;
+      case I2C_ERROR_INVALID_UNIT: message = "Invalid I2C unit"; break;
       default: message = "Unknows I2C error"; break;
     }
     struct RClass *IOError = mrb_define_class_id(mrb, MRB_SYM(IOError), E_STANDARD_ERROR);

--- a/mrbgems/picoruby-i2c/src/mrubyc/i2c.c
+++ b/mrbgems/picoruby-i2c/src/mrubyc/i2c.c
@@ -53,7 +53,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
   if (status < 0) {
     char message[30];
     switch (status) {
-      case ERROR_INVALID_UNIT: { strcpy(message, "Invalid I2C unit"); break; }
+      case I2C_ERROR_INVALID_UNIT: { strcpy(message, "Invalid I2C unit"); break; }
       default: { strcpy(message, "Unknows I2C error"); }
       mrbc_raise(vm, MRBC_CLASS(IOError), message);
       return;

--- a/mrbgems/picoruby-spi/include/spi.h
+++ b/mrbgems/picoruby-spi/include/spi.h
@@ -18,18 +18,18 @@ extern "C" {
       case PICORUBY_SPI_BITBANG:     { unit = NULL; break; } \
       case PICORUBY_SPI_RP2040_SPI0: { unit = spi0; break; } \
       case PICORUBY_SPI_RP2040_SPI1: { unit = spi1; break; } \
-      default: { return ERROR_INVALID_UNIT; } \
+      default: { return SPI_ERROR_INVALID_UNIT; } \
     } \
   } while (0)
 
 typedef enum {
-  ERROR_NONE              =  0,
-  ERROR_INVALID_UNIT      = -1,
-  ERROR_INVALID_MODE      = -2,
-  ERROR_INVALID_FIRST_BIT = -3,
-  ERROR_NOT_IMPLEMENTED   = -4,
-  ERROR_FAILED_TO_INIT    = -5,
-  ERROR_FAILED_TO_ADD_DEV = -6,
+  SPI_ERROR_NONE              =  0,
+  SPI_ERROR_INVALID_UNIT      = -1,
+  SPI_ERROR_INVALID_MODE      = -2,
+  SPI_ERROR_INVALID_FIRST_BIT = -3,
+  SPI_ERROR_NOT_IMPLEMENTED   = -4,
+  SPI_ERROR_FAILED_TO_INIT    = -5,
+  SPI_ERROR_FAILED_TO_ADD_DEV = -6,
 } spi_status_t;
 
 typedef struct spi_unit_info {

--- a/mrbgems/picoruby-spi/ports/esp32/spi.c
+++ b/mrbgems/picoruby-spi/ports/esp32/spi.c
@@ -63,7 +63,7 @@ SPI_unit_name_to_unit_num(const char *unit_name)
     return SPI3_HOST;
 #endif
   } else {
-    return ERROR_INVALID_UNIT;
+    return SPI_ERROR_INVALID_UNIT;
   }
 }
 
@@ -71,7 +71,7 @@ spi_status_t
 SPI_gpio_init(spi_unit_info_t *unit_info)
 {
   if (spi_handles[unit_info->unit_num] != NULL) {
-    return ERROR_NONE;
+    return SPI_ERROR_NONE;
   }
 
   spi_bus_config_t buscfg = {
@@ -84,7 +84,7 @@ SPI_gpio_init(spi_unit_info_t *unit_info)
 
   esp_err_t ret = spi_bus_initialize(unit_info->unit_num, &buscfg, SPI_DMA_CH_AUTO);
   if (ret != ESP_OK) {
-    return ERROR_FAILED_TO_INIT;
+    return SPI_ERROR_FAILED_TO_INIT;
   }
 
   spi_device_interface_config_t devcfg = {
@@ -98,7 +98,7 @@ SPI_gpio_init(spi_unit_info_t *unit_info)
   if (ret != ESP_OK) {
     spi_bus_free(unit_info->unit_num);
     spi_handles[unit_info->unit_num] = NULL;
-    return ERROR_FAILED_TO_ADD_DEV;
+    return SPI_ERROR_FAILED_TO_ADD_DEV;
   }
-  return ERROR_NONE;
+  return SPI_ERROR_NONE;
 }

--- a/mrbgems/picoruby-spi/ports/rp2040/spi.c
+++ b/mrbgems/picoruby-spi/ports/rp2040/spi.c
@@ -80,7 +80,7 @@ SPI_transfer(spi_unit_info_t *unit_info, uint8_t *txdata, uint8_t *rxdata, size_
   if (PICORUBY_SPI_BITBANG < unit) {
     return spi_write_read_blocking(unit, txdata, rxdata, len);
   } else {
-    return ERROR_NOT_IMPLEMENTED;
+    return SPI_ERROR_NOT_IMPLEMENTED;
   }
 }
 
@@ -92,7 +92,7 @@ SPI_unit_name_to_unit_num(const char *unit_name)
   } else if (strcmp(unit_name, "RP2040_SPI1") == 0) {
     return PICORUBY_SPI_RP2040_SPI1;
   } else {
-    return ERROR_INVALID_UNIT;
+    return SPI_ERROR_INVALID_UNIT;
   }
 }
 
@@ -115,7 +115,7 @@ SPI_gpio_init(spi_unit_info_t *unit_info)
     /* mode */
     if (unit_info->first_bit != SPI_MSB_FIRST) {
       /* RP2040 supports only MSB first */
-      return ERROR_INVALID_FIRST_BIT;
+      return SPI_ERROR_INVALID_FIRST_BIT;
     }
     spi_cpol_t cpol;
     spi_cpha_t cpha;
@@ -124,7 +124,7 @@ SPI_gpio_init(spi_unit_info_t *unit_info)
       case 1: { cpol = 0; cpha = 1; break; }
       case 2: { cpol = 1; cpha = 0; break; }
       case 3: { cpol = 1; cpha = 1; break; }
-      default: { return ERROR_INVALID_MODE; }
+      default: { return SPI_ERROR_INVALID_MODE; }
     }
     spi_set_format(unit, unit_info->data_bits, cpol, cpha, unit_info->first_bit);
   } else {
@@ -140,6 +140,6 @@ SPI_gpio_init(spi_unit_info_t *unit_info)
     }
   }
 
-  return ERROR_NONE;
+  return SPI_ERROR_NONE;
 }
 

--- a/mrbgems/picoruby-spi/src/mruby/spi.c
+++ b/mrbgems/picoruby-spi/src/mruby/spi.c
@@ -137,9 +137,9 @@ mrb__init(mrb_state *mrb, mrb_value self)
   if (status < 0) {
     const char *message;
     switch (status) {
-      case ERROR_INVALID_UNIT: message = "Invalid SPI unit"; break;
-      case ERROR_INVALID_MODE: message = "Invalid SPI mode"; break;
-      case ERROR_INVALID_FIRST_BIT: message = "Invalid SPI first bit"; break;
+      case SPI_ERROR_INVALID_UNIT: message = "Invalid SPI unit"; break;
+      case SPI_ERROR_INVALID_MODE: message = "Invalid SPI mode"; break;
+      case SPI_ERROR_INVALID_FIRST_BIT: message = "Invalid SPI first bit"; break;
       default: message = "Unknown SPI error"; break;
     }
     struct RClass *IOError = mrb_exc_get_id(mrb, MRB_SYM(IOError));

--- a/mrbgems/picoruby-spi/src/mrubyc/spi.c
+++ b/mrbgems/picoruby-spi/src/mrubyc/spi.c
@@ -110,9 +110,9 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
   if (status < 0) {
     char message[30];
     switch (status) {
-      case ERROR_INVALID_UNIT: { strcpy(message, "Invalid SPI unit"); break; }
-      case ERROR_INVALID_MODE: { strcpy(message, "Invalid SPI mode"); break; }
-      case ERROR_INVALID_FIRST_BIT: { strcpy(message, "Invalid SPI firt bit"); break; }
+      case SPI_ERROR_INVALID_UNIT: { strcpy(message, "Invalid SPI unit"); break; }
+      case SPI_ERROR_INVALID_MODE: { strcpy(message, "Invalid SPI mode"); break; }
+      case SPI_ERROR_INVALID_FIRST_BIT: { strcpy(message, "Invalid SPI firt bit"); break; }
       default: { strcpy(message, "Unknows SPI error"); }
       mrbc_raise(vm, MRBC_CLASS(IOError), message);
       return;

--- a/mrbgems/picoruby-uart/include/uart.h
+++ b/mrbgems/picoruby-uart/include/uart.h
@@ -20,8 +20,8 @@ extern "C" {
 #define PICORUBY_UART_RP2040_UART1      1
 
 typedef enum {
- ERROR_NONE              =  0,
- ERROR_INVALID_UNIT      = -1,
+ UART_ERROR_NONE          =  0,
+ UART_ERROR_INVALID_UNIT  = -1,
 } uart_status_t;
 
 typedef struct {

--- a/mrbgems/picoruby-uart/ports/esp32/uart.c
+++ b/mrbgems/picoruby-uart/ports/esp32/uart.c
@@ -63,7 +63,7 @@ UART_unit_name_to_unit_num(const char *name)
     return PICORUBY_UART_ESP32_UART2;
   }
 #endif
-  return ERROR_INVALID_UNIT;
+  return UART_ERROR_INVALID_UNIT;
 }
 
 

--- a/mrbgems/picoruby-uart/ports/rp2040/uart.c
+++ b/mrbgems/picoruby-uart/ports/rp2040/uart.c
@@ -44,7 +44,7 @@ UART_unit_name_to_unit_num(const char *name)
   } else if (strcmp(name, "RP2040_UART1") == 0) {
     return PICORUBY_UART_RP2040_UART1;
   } else {
-    return ERROR_INVALID_UNIT;
+    return UART_ERROR_INVALID_UNIT;
   }
 }
 


### PR DESCRIPTION
I'm writing a driver for a small OLED screen that comes in both I2C and SPI versions. I call methods on `I2C` or `SPI` instances (from `picoruby-i2c` and `picoruby-spi`) to initialize and configure it, but I want to be as efficient as possible when drawing the frame, so I'm writing that in C.

The procedure is mostly the same for both bus types, except I need to call either `I2C_write_timeout_us` or `SPI_write_blocking`. That means I need both:

```C
#include "picoruby-i2c/include/i2c.h"
#include "picoruby-spi/include/spi.h"
```

Currently, doing this causes a compile error, since their error enums reuse constant names, so one is trying to redefine the other. This change fixes that, and I extend the pattern to `picoruby-gpio` and `picoruby-uart` too.

I'm handling chip select and other pins in mruby, but that could also be done in C, and I would run into the same problem trying to include `gpio.h`.