### PR TITLE
Enable reboot command support for ESP32 platform

### DIFF
--- a/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
+++ b/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
@@ -20,7 +20,8 @@ Watchdog_disable(void)
 void
 Watchdog_reboot(uint32_t delay_ms)
 {
-  /* Not implemented */
+  vTaskDelay(pdMS_TO_TICKS(delay_ms));
+  esp_restart();
 }
 
 void


### PR DESCRIPTION
Added reboot command functionality to ESP32 platform by implementing the `Watchdog_reboot()` function.

This enables ESP32 to also support reboot from shell.

# Not Implemented
https://github.com/user-attachments/assets/6aa79c17-9f7c-4799-9dd6-cd200149c38c

# Implemented
https://github.com/user-attachments/assets/5ec09400-5f5b-4c2f-a662-92ab503392a1

