### PR TITLE
Fix error when using MbedTLS::CMAC.new on mruby.

### DIFF
--- a/mrbgems/picoruby-mbedtls/mrblib/cmac.rb
+++ b/mrbgems/picoruby-mbedtls/mrblib/cmac.rb
@@ -9,7 +9,7 @@ module MbedTLS
         unless key.length == 16
           raise ArgumentError, "Invalid key length: `#{key.inspect}`"
         end
-        instance = self._init_aes(key)
+        instance = _init_aes(key)
         instance._digest = "aes"
         return instance
       else

--- a/mrbgems/picoruby-mbedtls/src/mruby/cmac.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/cmac.c
@@ -17,9 +17,10 @@ struct mrb_data_type mrb_cipher_context_type = {
 };
 
 static mrb_value
-mrb__init_aes(mrb_state *mrb, mrb_value self)
+mrb__init_aes(mrb_state *mrb, mrb_value klass)
 {
   mbedtls_cipher_context_t *ctx = (mbedtls_cipher_context_t *)mrb_malloc(mrb, sizeof(mbedtls_cipher_context_t));
+  mrb_value self = mrb_obj_new(mrb, mrb_class_ptr(klass), 0, NULL);
   DATA_PTR(self) = ctx;
   DATA_TYPE(self) = &mrb_cipher_context_type;
   mbedtls_cipher_init(ctx);
@@ -86,7 +87,7 @@ gem_mbedtls_cmac_init(mrb_state *mrb, struct RClass *module_MbedTLS)
 
   MRB_SET_INSTANCE_TT(class_MbedTLS_CMAC, MRB_TT_CDATA);
 
-  mrb_define_method_id(mrb, class_MbedTLS_CMAC, MRB_SYM(_init_aes),  mrb__init_aes, MRB_ARGS_REQ(1));
+  mrb_define_class_method_id(mrb, class_MbedTLS_CMAC, MRB_SYM(_init_aes),  mrb__init_aes, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_MbedTLS_CMAC, MRB_SYM(update),     mrb_update, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_MbedTLS_CMAC, MRB_SYM(reset),      mrb_reset, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_MbedTLS_CMAC, MRB_SYM(digest),     mrb_digest, MRB_ARGS_NONE());


### PR DESCRIPTION
## Issue

An error occurs when running the following sample program on a Raspberry Pi Pico2 with MicroRuby:

```ruby
require 'mbedtls'

key = 'thisisasecretkey'
cmac = MbedTLS::CMAC.new(key, 'aes')

data = 'Hello, World!'
cmac.update(data)
puts cmac.digest
```

The error message is as follows:

```
undefined method '_init_aes' for Class (undefined method '_init_aes' for Class)
```

## Fix

`MbedTLS::CMAC.new` calls `self._init_aes`, but at that time, `self` refers to `Class`.  
This fix changes `_init_aes` to be a singleton method so that it can be called properly from `self.new`.