### PR TITLE
Fixed build error in mrubyc's pitchdetector.c

### DIFF
--- a/mrbgems/picoruby-pitchdetector/src/mrubyc/pitchdetector.c
+++ b/mrbgems/picoruby-pitchdetector/src/mrubyc/pitchdetector.c
@@ -4,7 +4,7 @@ static void
 c_volume_threshold_set(mrbc_vm *vm, mrbc_value v[], int argc)
 {
   mrbc_int_t volume_threshold = GET_INT_ARG(1);
-  PITCHDETECTOR_set_volume_threshold((uint16_t)value);
+  PITCHDETECTOR_set_volume_threshold((uint16_t)volume_threshold);
   SET_INT_RETURN(volume_threshold);
 }
 


### PR DESCRIPTION
When I tried to build by entering the command `rake mrubyc:pico_w:production`, the following error occurred.

```
In file included from /Users/yuhei/ghq/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-pitchdetector/src/pitchdetector.c:9:
/Users/yuhei/ghq/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-pitchdetector/src/mrubyc/pitchdetector.c: In function 'c_volume_threshold_set':
/Users/yuhei/ghq/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-pitchdetector/src/mrubyc/pitchdetector.c:7:48: error: 'value' undeclared (first use in this function)
    7 |   PITCHDETECTOR_set_volume_threshold((uint16_t)value);
```

I am making corrections based on mruby's pitchdetector.c as a reference.