### PR TITLE
refactor(mrbgems): Relocate IO implementation to picoruby-machine

### DIFF
--- a/mrbgems/picoruby-io-console/include/io-console.h
+++ b/mrbgems/picoruby-io-console/include/io-console.h
@@ -6,9 +6,6 @@ extern "C" {
 #endif
 
 int hal_getchar(void);
-#if defined(PICORB_VM_MRUBY)
-int hal_write(int fd, const void *buf, int nbytes);
-#endif
 
 bool io_raw_q(void);
 void io_raw_bang(bool nonblock);

--- a/mrbgems/picoruby-io-console/src/mruby/io-console.c
+++ b/mrbgems/picoruby-io-console/src/mruby/io-console.c
@@ -90,60 +90,6 @@ mrb_io_echo_q(mrb_state *mrb, mrb_value self)
   }
 }
 
-#if !defined(PICORB_PLATFORM_POSIX)
-static mrb_value
-mrb_io_gets(mrb_state *mrb, mrb_value self)
-{
-  mrb_value str = mrb_str_new(mrb, "", 0);
-  char buf[2];
-  buf[1] = '\0';
-  while (true) {
-    int c = hal_getchar();
-    if (c == 3) { // Ctrl-C
-      raise_interrupt(mrb); // mrb_noreturn
-    } if (c == 27) { // ESC continue;
-    }
-    if (c == 8 || c == 127) { // Backspace
-      if (0 < RSTRING_LEN(str)) { mrb_str_resize(mrb, str, RSTRING_LEN(str) - 1); hal_write(1, "\b \b", 3);
-      }
-    } else
-    if (-1 < c) {
-      buf[0] = c;
-      mrb_str_cat(mrb, str, (const char *)buf, 1);
-      hal_write(1, buf, 1);
-      if (c == '\n' || c == '\r') {
-        break;
-      }
-    }
-  }
-  return str;
-}
-
-static mrb_value
-mrb_io_getc(mrb_state *mrb, mrb_value self)
-{
-  if (io_raw_q()) {
-    char buf[1];
-    int c = hal_getchar();
-    if (c == 3) {
-      raise_interrupt(mrb); // mrb_noreturn
-    } else if (-1 < c) {
-      buf[0] = c;
-      return mrb_str_new(mrb, buf, 1);
-    } else {
-      return mrb_nil_value();
-    }
-  }
-  else {
-    mrb_value str = mrb_io_gets(mrb, self);
-    if (1 < RSTRING_LEN(str)) {
-      mrb_str_resize(mrb, str, 1);
-    }
-    return str;
-  }
-}
-#endif
-
 
 void
 mrb_picoruby_io_console_gem_init(mrb_state* mrb)
@@ -156,10 +102,6 @@ mrb_picoruby_io_console_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_IO, MRB_SYM(_restore_termios), mrb_io__restore_termios, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_IO, MRB_SYM_E(echo), mrb_io_echo_e, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_IO, MRB_SYM_Q(echo), mrb_io_echo_q, MRB_ARGS_NONE());
-#if !defined(PICORB_PLATFORM_POSIX)
-  mrb_define_method_id(mrb, class_IO, MRB_SYM(gets), mrb_io_gets, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_IO, MRB_SYM(getc), mrb_io_getc, MRB_ARGS_NONE());
-#endif
 }
 
 void

--- a/mrbgems/picoruby-io/mrblib/3_kernel.rb
+++ b/mrbgems/picoruby-io/mrblib/3_kernel.rb
@@ -13,35 +13,8 @@ module Kernel
     end
   end
 
-  def print(*args)
-    $stdout.print(*args)
-  end
-
-  def puts(*args)
-    $stdout.puts(*args)
-  end
-
   def printf(*args)
     $stdout.printf(*args)
-  end
-
-  def gets(rs = nil)
-    $stdin.gets(rs)
-  end
-
-  def p(*args)
-    case args.size
-    when 0
-      return nil
-    when 1
-      $stdout.puts args[0].inspect
-      args[0]
-    else
-      args.each do|arg|
-        $stdout.puts arg.inspect
-      end
-      args
-    end
   end
 
 end

--- a/mrbgems/picoruby-io/sig/io.rbs
+++ b/mrbgems/picoruby-io/sig/io.rbs
@@ -39,6 +39,7 @@ class IO
   def write: (String input) -> Integer
   private def hash: () -> Integer
   def <<: (String input) -> self
+  def p: (*untyped objs) -> Object
   def puts: (*_ToS line) -> nil
   def print: (*_ToS args) -> nil
   def printf: (*String str) -> nil

--- a/mrbgems/picoruby-machine/mrblib/0_io.rb
+++ b/mrbgems/picoruby-machine/mrblib/0_io.rb
@@ -1,0 +1,7 @@
+class IO
+  if RUBY_ENGINE == "mruby"
+    def self.open(*args)
+      self.new # TODO
+    end
+  end
+end

--- a/mrbgems/picoruby-machine/mrblib/3_kernel.rb
+++ b/mrbgems/picoruby-machine/mrblib/3_kernel.rb
@@ -1,0 +1,32 @@
+module Kernel
+
+  private
+
+  def print(*args)
+    $stdout.print(*args)
+  end
+
+  def puts(*args)
+    $stdout.puts(*args)
+  end
+
+  def getc
+    $stdin.getc
+  end
+
+  def gets
+    $stdin.gets
+  end
+
+  def p(*args)
+    $stdout.p(*args)
+  end
+end
+
+STDIN  = IO.open(0, "r")
+STDOUT = IO.open(1, "w")
+#STDERR = IO.open(2, "w")
+
+$stdin = STDIN
+$stdout = STDOUT
+#$stderr = STDERR

--- a/mrbgems/picoruby-machine/mrblib/machine.rb
+++ b/mrbgems/picoruby-machine/mrblib/machine.rb
@@ -1,2 +1,0 @@
-class Machine
-end

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -205,6 +205,70 @@ c_Machine_exit(mrbc_vm *vm, mrbc_value *v, int argc)
   SET_NIL_RETURN();
 }
 
+#if !defined(PICORB_PLATFORM_POSIX)
+static void
+c_gets(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrb_value str = mrbc_string_new(vm, NULL, 0);
+  char buf[2];
+  buf[1] = '\0';
+  while (true) {
+    int c = hal_getchar();
+    if (c == 3) { // Ctrl-C
+      raise_interrupt(vm);
+      return;
+    }
+    if (c == 27) { // ESC
+      continue;
+    }
+    if (c == 8 || c == 127) { // Backspace
+      if (0 < str.string->size) {
+        str.string->size--;
+        mrbc_realloc(vm, str.string->data, str.string->size);
+        hal_write(1, "\b \b", 3);
+      }
+    } else
+    if (-1 < c) {
+      buf[0] = c;
+      mrbc_string_append_cstr(&str, buf);
+      hal_write(1, buf, 1);
+      if (c == '\n' || c == '\r') {
+        break;
+      }
+    }
+  }
+  SET_RETURN(str);
+}
+
+static void
+c_getc(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (io_raw_q()) {
+    char buf[1];
+    int c = hal_getchar();
+    if (c == 3) { // Ctrl-C
+      raise_interrupt(vm);
+      return;
+    } else if (-1 < c) {
+      buf[0] = c;
+      mrb_value str = mrbc_string_new(vm, buf, 1);
+      SET_RETURN(str);
+    } else {
+      SET_NIL_RETURN();
+    }
+  }
+  else {
+    c_gets(vm, v, argc);
+    mrbc_value str = v[0];
+    if (1 < str.string->size) {
+      mrbc_realloc(vm, str.string->data, 1);
+      str.string->size = 1;
+    }
+  }
+}
+#endif
+
+
 void
 mrbc_machine_init(mrbc_vm *vm)
 {
@@ -226,4 +290,10 @@ mrbc_machine_init(mrbc_vm *vm)
   mrbc_define_method(vm, mrbc_class_Machine, "get_hwclock", c_Machine_get_hwclock);
 
   mrbc_define_method(vm, mrbc_class_Machine, "exit", c_Machine_exit);
+
+#if !defined(PICORB_PLATFORM_POSIX)
+  mrbc_class *class_IO = mrbc_define_class(vm, "IO", mrbc_class_object);
+  mrbc_define_method(vm, class_IO, "gets", c_gets);
+  mrbc_define_method(vm, class_IO, "getc", c_getc);
+#endif
 }


### PR DESCRIPTION
This pull request refactors how basic I/O methods (`print`, `puts`, `p`, `gets`, `getc`) are implemented and organized, especially for non-POSIX platforms. The main changes involve moving these methods from the `Kernel` module to the `IO` class, centralizing their implementations, and ensuring consistent behavior across mruby and mrubyc environments. It also introduces a new Ruby-level definition for the `IO` class and reworks how standard input/output constants are set up.

**Refactoring and consolidation of I/O methods:**

* Moved the implementations of `print`, `puts`, `p`, `gets`, and `getc` from the `Kernel` module to the `IO` class in both mruby and mrubyc C sources, and updated method registrations accordingly. This centralizes I/O logic and ensures consistency. [[1]](diffhunk://#diff-e011d00eaf3ff8242a83a565e99810f7738a7bdf58bc80425227fc0bd9696312L173-R173) [[2]](diffhunk://#diff-e011d00eaf3ff8242a83a565e99810f7738a7bdf58bc80425227fc0bd9696312L192-R192) [[3]](diffhunk://#diff-e011d00eaf3ff8242a83a565e99810f7738a7bdf58bc80425227fc0bd9696312L206-R206) [[4]](diffhunk://#diff-e011d00eaf3ff8242a83a565e99810f7738a7bdf58bc80425227fc0bd9696312R217-R271) [[5]](diffhunk://#diff-e011d00eaf3ff8242a83a565e99810f7738a7bdf58bc80425227fc0bd9696312L251-R309) [[6]](diffhunk://#diff-98633a89e42372ddb3bee8a9ba9bf5bc4183a56055c05e7dab5e9ae453a11060R208-R271) [[7]](diffhunk://#diff-98633a89e42372ddb3bee8a9ba9bf5bc4183a56055c05e7dab5e9ae453a11060R293-R298)

* Removed the previous implementations and method registrations of these I/O methods from the `picoruby-io-console` gem, as they are now handled in the machine-specific layer. [[1]](diffhunk://#diff-c9adb06592ff630739638fc3138578a7db8a6852902c24f0fb1bb04ea8b9248aL93-L146) [[2]](diffhunk://#diff-c9adb06592ff630739638fc3138578a7db8a6852902c24f0fb1bb04ea8b9248aL159-L162) [[3]](diffhunk://#diff-f100920614ad53f90555e128bd5752c804e4caf8c6c069558ba2cccb14ffb3feL97-L159) [[4]](diffhunk://#diff-f100920614ad53f90555e128bd5752c804e4caf8c6c069558ba2cccb14ffb3feL172-L175) [[5]](diffhunk://#diff-6f7b7f764fa4bc79b4bb9892eb4a7e95e5e530f639734b1f86b4e0d01afbb9eeL9-L11)

**Ruby-level and constant setup:**

* Added a new Ruby-level definition of the `IO` class in `mrbgems/picoruby-machine/mrblib/0_io.rb` and set up standard I/O constants (`STDIN`, `STDOUT`, `$stdin`, `$stdout`) in `mrbgems/picoruby-machine/mrblib/3_kernel.rb`. This ensures standard input/output streams are available and properly initialized. [[1]](diffhunk://#diff-5ce50155f09ee77d3fe4d7a58c1240dc2b06d8f6de41accaebe32309b993e690R1-R7) [[2]](diffhunk://#diff-be5cb318c18f927d334d9a28bb3a6d7a81f99647d74a302059330125ba05043aR1-R32)

* Moved the Ruby-level definitions of `print`, `puts`, `gets`, and `p` from the generic kernel file to the machine-specific kernel file, delegating their behavior to the new `IO` methods. [[1]](diffhunk://#diff-164d663e6e9a9c510c7a717b441310a2838ce4a988b3b40d2de51bee04ea1e33L16-L46) [[2]](diffhunk://#diff-be5cb318c18f927d334d9a28bb3a6d7a81f99647d74a302059330125ba05043aR1-R32)

**Type signature and cleanup:**

* Updated the type signature file to reflect the new `p` method on `IO`.

* Removed the empty `Machine` class, as it is no longer needed.

These changes make the I/O subsystem more modular, platform-aware, and maintainable, while ensuring that standard I/O methods behave consistently across different environments.