### PR TITLE
IRQ module

### DIFF
--- a/mrbgems/peripherals.gembox
+++ b/mrbgems/peripherals.gembox
@@ -5,5 +5,6 @@ MRuby::GemBox.new do |conf|
   conf.gem core: 'picoruby-adc'
   conf.gem core: 'picoruby-uart'
   conf.gem core: 'picoruby-pwm'
+  conf.gem core: 'picoruby-irq'
 end
 

--- a/mrbgems/picoruby-gpio/mrblib/gpio.rb
+++ b/mrbgems/picoruby-gpio/mrblib/gpio.rb
@@ -43,6 +43,8 @@ class GPIO
     @initializing = false
   end
 
+  attr_reader :pin
+
   def setmode(flags, alt_function = 0)
     set_dir(flags)
     set_pull(flags)

--- a/mrbgems/picoruby-gpio/sig/gpio.rbs
+++ b/mrbgems/picoruby-gpio/sig/gpio.rbs
@@ -1,4 +1,7 @@
 # @sidebar io_peripheral
+
+type gpio_pin_t = (Integer|String|Symbol)
+
 class GPIO
 
   # @sidebar error
@@ -22,10 +25,10 @@ class GPIO
   OPEN_DRAIN: 32 # 0b0100000
   ALT:        64 # 0b1000000
 
-  type gpio_pin_t = (Integer|String|Symbol)
   type gpio_logic_t = (0 | 1)
 
-  @pin: gpio_pin_t
+  attr_reader pin: gpio_pin_t
+
   @dir: (Integer|nil)
   @alt_function: (Integer|nil)
   @pull: (Integer|nil)

--- a/mrbgems/picoruby-irq/README.md
+++ b/mrbgems/picoruby-irq/README.md
@@ -1,0 +1,112 @@
+# picoruby-irq
+
+Interrupt Request (IRQ) handling for PicoRuby, providing asynchronous event processing for GPIO pins and other peripherals.
+
+## Features
+
+- **GPIO Interrupt Support**: Handle level and edge-triggered interrupts on GPIO pins
+- **Event Queue**: Non-blocking event queue with configurable size
+- **Debounce Support**: Built-in debouncing to filter out rapid, repeated events
+- **Multiple Event Types**: Support for `LEVEL_LOW`, `LEVEL_HIGH`, `EDGE_FALL`, and `EDGE_RISE`
+- **Resource Management**: Automatic registration and cleanup of interrupt handlers
+
+## Usage
+
+### Basic GPIO IRQ
+
+```ruby
+require 'irq'
+
+gpio = GPIO.new(17, GPIO::IN|GPIO::PULL_UP)  # GPIO pin
+
+# Register IRQ handler for falling edge
+irq_instance = gpio.irq(GPIO::EDGE_FALL) do |peripheral, event_type|
+  puts "Button pressed! Event: #{event_type}"
+end
+
+# Process IRQ events in main loop
+loop do
+  count = IRQ.process  # Process up to 5 events
+  sleep_ms(10)
+end
+```
+
+### IRQ with Debouncing
+
+```ruby
+# Register IRQ with 50ms debounce to filter out button bounce
+irq_instance = gpio.irq(GPIO::EDGE_FALL, debounce: 50) do |peripheral, event_type|
+  puts "Debounced button press detected"
+end
+```
+
+### Multiple Event Types
+
+```ruby
+# Handle both rising and falling edges
+irq_instance = gpio.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE) do |peripheral, event_type|
+  case event_type
+  when GPIO::EDGE_FALL
+    puts "Button pressed"
+  when GPIO::EDGE_RISE  
+    puts "Button released"
+  end
+end
+```
+
+### Level-Triggered IRQs
+
+```ruby
+# Handle low level (useful for active-low sensors)
+irq_instance = gpio.irq(GPIO::LEVEL_LOW) do |peripheral, event_type|
+  puts "Sensor active"
+end
+```
+
+### IRQ Management
+
+```ruby
+# Check if IRQ is enabled
+puts irq_instance.enabled?  # => true
+
+# Temporarily disable IRQ
+previous_state = irq_instance.disable
+puts irq_instance.enabled?  # => false
+
+# Re-enable IRQ
+irq_instance.enable
+puts irq_instance.enabled?  # => true
+
+# Unregister IRQ completely
+irq_instance.unregister
+```
+
+### Manual Event Processing
+
+```ruby
+# Process specific number of events
+processed_count = IRQ.process(10)  # Process up to 10 events
+puts "Processed #{processed_count} events"
+```
+
+## Constants
+
+### GPIO Event Types
+
+- `GPIO::LEVEL_LOW` (1): Trigger when pin is at low level
+- `GPIO::LEVEL_HIGH` (2): Trigger when pin is at high level
+- `GPIO::EDGE_FALL` (4): Trigger on falling edge (high → low)
+- `GPIO::EDGE_RISE` (8): Trigger on rising edge (low → high)
+
+Event types can be combined using bitwise OR:
+```ruby
+gpio.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE) { |gpio, event| ... }
+```
+
+## Example: Button with LED
+
+See [example/irq_gpio.rb](example/irq_gpio.rb)
+
+## License
+
+MIT License

--- a/mrbgems/picoruby-irq/example/irq_gpio.rb
+++ b/mrbgems/picoruby-irq/example/irq_gpio.rb
@@ -1,0 +1,23 @@
+require 'irq'
+
+button = GPIO.new(17, GPIO::IN|GPIO::PULL_UP)
+
+$led = GPIO.new(16, GPIO::OUT)
+
+button.irq(GPIO::EDGE_FALL, debounce: 100) do |gpio, event|
+  puts "Button pressed, toggling LED"
+  $led.write($led.high? ? 0 : 1)
+end
+
+# Main loop
+loop do
+  IRQ.process
+  sleep_ms(10)
+end
+
+# Note:
+# For mruby/c's technical reasons, local variables outside
+# irq block are not accessible inside the irq block.
+# Thsi is why we use `$led` global variable here.
+# On the other hand, you can use `led` local variable in
+# mruby-based PicoRuby (MicroRuby)

--- a/mrbgems/picoruby-irq/include/irq.h
+++ b/mrbgems/picoruby-irq/include/irq.h
@@ -1,0 +1,21 @@
+#ifndef PICORUBY_IRQ_H_
+#define PICORUBY_IRQ_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* IRQ management functions */
+int IRQ_register_gpio(int pin, int event_type);
+bool IRQ_unregister_gpio(int irq_id);
+bool IRQ_peek_event(int *irq_id, int *event_type);
+void IRQ_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PICORUBY_IRQ_H_ */

--- a/mrbgems/picoruby-irq/include/irq.h
+++ b/mrbgems/picoruby-irq/include/irq.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /* IRQ management functions */
-int IRQ_register_gpio(int pin, int event_type);
+int IRQ_register_gpio(int pin, int event_type, uint32_t debounce_ms);
 bool IRQ_unregister_gpio(int irq_id);
 bool IRQ_peek_event(int *irq_id, int *event_type);
 void IRQ_init(void);

--- a/mrbgems/picoruby-irq/mrbgem.rake
+++ b/mrbgems/picoruby-irq/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('picoruby-irq') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'HASUMI Hitoshi'
+  spec.summary = 'IRQ module'
+end

--- a/mrbgems/picoruby-irq/mrblib/irq.rb
+++ b/mrbgems/picoruby-irq/mrblib/irq.rb
@@ -1,0 +1,94 @@
+module IRQ
+  MAX_PROCESS_COUNT = 5
+  HANDLER = {}
+
+  class << self
+    def unregister(id)
+      unless irq = HANDLER.delete(id)
+        raise "IRQ not registered: #{id}"
+      end
+      prev_registered_p = case irq.peripheral
+      when GPIO
+        unregister_gpio(id)
+      else
+        raise "Fatal: This should not happen"
+      end
+      return prev_registered_p
+    end
+
+    def register(irq, opts)
+      id = case irq.peripheral
+      when GPIO
+        register_gpio(irq.peripheral.pin, irq.event_type, opts)
+      else
+        raise "Unsupported peripheral for IRQ: #{irq.peripheral.class}"
+      end
+      HANDLER[id] = irq
+      return id
+    end
+
+    def process(max_count = MAX_PROCESS_COUNT)
+      count = 0
+      while true
+        id, event_type = peek_event
+        break if id.nil? || max_count <= count
+        if irq = HANDLER[id]
+          irq.call(event_type)
+          count += 1
+        end
+      end
+      return count
+    end
+  end
+
+  def irq(event_type, **opts, &callback)
+    instance = IRQInstance.new(self, event_type, opts, callback)
+    return instance
+  end
+
+  class IRQInstance
+    def initialize(peripheral, event_type, opts, callback)
+      @peripheral = peripheral
+      @callback = callback
+      @event_type = event_type
+      @enabled = true
+      @id = IRQ.register(self, opts)
+    end
+
+    attr_reader :peripheral, :event_type
+
+    def call(event_type)
+      return unless @enabled
+      @callback&.call(@peripheral, event_type)
+    end
+
+    def enabled?
+      @enabled
+    end
+
+    def enable
+      previous = @enabled
+      @enabled = false
+      return previous
+    end
+
+    def disable
+      previous = @enabled
+      @enabled = true
+      return previous
+    end
+
+    def unregister
+      IRQ.unregister(@id)
+    end
+  end
+end
+
+class GPIO
+  include IRQ
+  # pico-sdk/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+  LEVEL_LOW = 1
+  LEVEL_HIGH = 2
+  EDGE_FALL = 4
+  EDGE_RISE = 8
+end

--- a/mrbgems/picoruby-irq/mrblib/irq.rb
+++ b/mrbgems/picoruby-irq/mrblib/irq.rb
@@ -1,3 +1,5 @@
+require 'gpio'
+
 module IRQ
   MAX_PROCESS_COUNT = 5
   HANDLER = {}

--- a/mrbgems/picoruby-irq/ports/rp2040/irq.c
+++ b/mrbgems/picoruby-irq/ports/rp2040/irq.c
@@ -1,0 +1,125 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "hardware/gpio.h"
+#include "hardware/irq.h"
+
+#include "../../include/irq.h"
+
+#define MAX_IRQ_HANDLERS 16
+#define IRQ_EVENT_QUEUE_SIZE (1<<5)
+
+typedef struct {
+  int pin;
+  uint32_t event_mask;
+  bool enabled;
+} mrb_irq_handler_t;
+
+typedef struct {
+  int irq_id;
+  int event_type;
+} irq_event_t;
+
+static mrb_irq_handler_t irq_handlers[MAX_IRQ_HANDLERS];
+static irq_event_t event_queue[IRQ_EVENT_QUEUE_SIZE];
+static int queue_head = 0;
+static int queue_tail = 0;
+static int next_irq_id = 1;
+
+static void
+gpio_irq_callback(uint gpio, uint32_t events)
+{
+  /* Find handler for this GPIO pin and matching event */
+  for (int i = 0; i < MAX_IRQ_HANDLERS; i++) {
+    if (irq_handlers[i].enabled && irq_handlers[i].pin == gpio && (events & irq_handlers[i].event_mask)) {
+      /* Add event to queue */
+      int next_tail = (queue_tail + 1) & (IRQ_EVENT_QUEUE_SIZE - 1);
+      if (next_tail != queue_head) {  /* Queue not full */
+        event_queue[queue_tail].irq_id = i + 1;  /* IRQ ID is 1-based */
+        event_queue[queue_tail].event_type = events;
+        queue_tail = next_tail;
+      }
+      break;
+    }
+  }
+}
+
+int
+IRQ_register_gpio(int pin, int event_type)
+{
+  /* Find free slot */
+  int slot = -1;
+  for (int i = 0; i < MAX_IRQ_HANDLERS; i++) {
+    if (!irq_handlers[i].enabled) {
+      slot = i;
+      break;
+    }
+  }
+
+  if (slot < 0) {
+    return -1;  /* No free slots */
+  }
+
+  /* Convert event_type to GPIO event mask */
+  uint32_t event_mask = 0;
+  if (event_type & 1) event_mask |= GPIO_IRQ_LEVEL_LOW;   /* LEVEL_LOW = 1 */
+  if (event_type & 2) event_mask |= GPIO_IRQ_LEVEL_HIGH;  /* LEVEL_HIGH = 2 */
+  if (event_type & 4) event_mask |= GPIO_IRQ_EDGE_FALL;   /* EDGE_FALL = 4 */
+  if (event_type & 8) event_mask |= GPIO_IRQ_EDGE_RISE;   /* EDGE_RISE = 8 */
+
+  /* Configure GPIO IRQ */
+  gpio_set_irq_enabled_with_callback(pin, event_mask, true, &gpio_irq_callback);
+
+  /* Store handler info */
+  irq_handlers[slot].pin = pin;
+  irq_handlers[slot].event_mask = event_mask;
+  irq_handlers[slot].enabled = true;
+
+  return slot + 1;  /* Return 1-based ID */
+}
+
+bool
+IRQ_unregister_gpio(int irq_id)
+{
+  int slot = irq_id - 1;  /* Convert to 0-based index */
+
+  if (slot < 0 || slot >= MAX_IRQ_HANDLERS || !irq_handlers[slot].enabled) {
+    return false;  /* Invalid ID or not registered */
+  }
+
+  bool prev_state = irq_handlers[slot].enabled;
+
+  /* Disable GPIO IRQ */
+  gpio_set_irq_enabled(irq_handlers[slot].pin, irq_handlers[slot].event_mask, false);
+
+  /* Clear handler */
+  memset(&irq_handlers[slot], 0, sizeof(mrb_irq_handler_t));
+
+  return prev_state;
+}
+
+bool
+IRQ_peek_event(int *irq_id, int *event_type)
+{
+  if (queue_head == queue_tail) {
+    return false;  /* Queue empty */
+  }
+
+  *irq_id = event_queue[queue_head].irq_id;
+  *event_type = event_queue[queue_head].event_type;
+
+  queue_head = (queue_head + 1) & (IRQ_EVENT_QUEUE_SIZE - 1);
+
+  return true;
+}
+
+void
+IRQ_init(void)
+{
+  /* Initialize data structures */
+  memset(irq_handlers, 0, sizeof(irq_handlers));
+  memset(event_queue, 0, sizeof(event_queue));
+  queue_head = 0;
+  queue_tail = 0;
+  next_irq_id = 1;
+}

--- a/mrbgems/picoruby-irq/sig/irq.rbs
+++ b/mrbgems/picoruby-irq/sig/irq.rbs
@@ -1,0 +1,41 @@
+module IRQ
+  type irq_id_t = Integer
+  type irq_event_type_t = Integer
+  type irq_peri_t = GPIO
+
+  MAX_PROCESS_COUNT: Integer
+  HANDLER: Hash[irq_id_t, IRQInstance]
+
+  private def self.peek_event: () -> [(irq_id_t | nil), irq_event_type_t]
+  def self.process: (?Integer max_count) -> Integer
+  def self.register: (IRQInstance irq, Hash[Symbol, untyped] opts) -> irq_id_t
+  def self.unregister: (irq_id_t id) -> bool
+  private def self.register_gpio: (gpio_pin_t pin, irq_event_type_t event_type, Hash[Symbol, untyped] opts) -> irq_id_t
+  private def self.unregister_gpio: (irq_id_t id) -> bool
+  def irq: (irq_event_type_t event_type, **untyped opts) { (irq_peri_t peri, irq_event_type_t event_type) -> void } -> void
+
+  class IRQInstance
+    @id: irq_id_t
+    @opts: Hash[untyped, untyped]
+    @callback: Proc
+    @enabled: bool
+
+    attr_reader peripheral: irq_peri_t
+    attr_reader event_type: irq_event_type_t
+
+    def initialize: (irq_peri_t peripheral, irq_event_type_t event_type, Hash[Symbol, untyped] opts, Proc callback) -> void
+    def disable: () -> bool   # returns previous state
+    def enable: () -> bool    # returns previous state
+    def enabled?: () -> bool  # returns current state
+    def call: (irq_event_type_t event_type) -> void
+    def unregister: () -> bool
+  end
+end
+
+class GPIO
+  include IRQ
+  LEVEL_LOW: Integer
+  LEVEL_HIGH: Integer
+  EDGE_FALL: Integer
+  EDGE_RISE: Integer
+end

--- a/mrbgems/picoruby-irq/src/irq.c
+++ b/mrbgems/picoruby-irq/src/irq.c
@@ -1,0 +1,12 @@
+#include "../include/irq.h"
+
+#if defined(PICORB_VM_MRUBY)
+
+#include "mruby/irq.c"
+
+#elif defined(PICORB_VM_MRUBYC)
+
+#include "mrubyc/irq.c"
+
+#endif
+

--- a/mrbgems/picoruby-irq/src/mruby/irq.c
+++ b/mrbgems/picoruby-irq/src/mruby/irq.c
@@ -1,0 +1,82 @@
+#include <mruby.h>
+#include <mruby/presym.h>
+#include <mruby/variable.h>
+#include <mruby/string.h>
+#include <mruby/hash.h>
+#include <mruby/array.h>
+
+#include "../../include/irq.h"
+
+/*
+ * IRQ.register_gpio(event_type, opts)
+ */
+static mrb_value
+mrb_s_register_gpio(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pin;
+  mrb_int event_type;
+  mrb_value opts;
+  mrb_get_args(mrb, "iiH", &pin, &event_type, &opts);
+
+  (void)opts; // Currently unused, but can be used for future options
+
+  int irq_id = IRQ_register_gpio(pin, event_type);
+
+  if (irq_id < 0) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "Failed to register GPIO IRQ");
+  }
+
+  return mrb_fixnum_value(irq_id);
+}
+
+/*
+ * IRQ.unregister_gpio(id)
+ */
+static mrb_value
+mrb_s_unregister_gpio(mrb_state *mrb, mrb_value self)
+{
+  mrb_int irq_id;
+  mrb_get_args(mrb, "i", &irq_id);
+
+  bool prev_state = IRQ_unregister_gpio(irq_id);
+  return mrb_bool_value(prev_state);
+}
+
+/*
+ * IRQ.peek_event()
+ */
+static mrb_value
+mrb_s_peek_event(mrb_state *mrb, mrb_value self)
+{
+  int irq_id, event_type;
+  bool has_event = IRQ_peek_event(&irq_id, &event_type);
+
+  mrb_value result = mrb_ary_new_capa(mrb, 2);
+  if (has_event) {
+    mrb_ary_push(mrb, result, mrb_fixnum_value(irq_id));
+  } else {
+    mrb_ary_push(mrb, result, mrb_nil_value());
+  }
+  mrb_ary_push(mrb, result, mrb_fixnum_value(event_type));
+
+  return result;
+}
+
+void
+mrb_picoruby_irq_gem_init(mrb_state *mrb)
+{
+  struct RClass *irq_module = mrb_define_module(mrb, "IRQ");
+
+  /* Define singleton methods */
+  mrb_define_module_function_id(mrb, irq_module, "register_gpio", mrb_s_register_gpio, MRB_ARGS_REQ(3));
+  mrb_define_module_function_id(mrb, irq_module, "unregister_gpio", mrb_s_unregister_gpio, MRB_ARGS_REQ(1));
+  mrb_define_class_method_id(mrb, irq_module, "peek_event", mrb_s_peek_event, MRB_ARGS_NONE());
+
+  IRQ_init(); // Initialize the IRQ system
+}
+
+void
+mrb_picoruby_irq_gem_final(mrb_state *mrb)
+{
+  /* Cleanup if needed */
+}

--- a/mrbgems/picoruby-irq/src/mrubyc/irq.c
+++ b/mrbgems/picoruby-irq/src/mrubyc/irq.c
@@ -1,0 +1,105 @@
+#include <mrubyc.h>
+#include "../../include/irq.h"
+
+/*
+ * IRQ.register_gpio(pin, event_type, opts)
+ */
+static void
+c_register_gpio(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 3) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+
+  if (v[1].tt != MRBC_TT_INTEGER || v[2].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "pin and event_type must be integers");
+    return;
+  }
+
+  int pin = v[1].i;
+  int event_type = v[2].i;
+
+  /* Extract debounce from opts hash */
+  uint32_t debounce_ms = 0;
+  if (argc >= 3 && v[3].tt == MRBC_TT_HASH) {
+    mrbc_value debounce_key = mrbc_symbol_value(mrbc_str_to_symid("debounce"));
+    mrbc_value debounce_val = mrbc_hash_get(&v[3], &debounce_key);
+    if (debounce_val.tt == MRBC_TT_INTEGER) {
+      debounce_ms = (uint32_t)debounce_val.i;
+    }
+  }
+
+  int irq_id = IRQ_register_gpio(pin, event_type, debounce_ms);
+
+  if (irq_id < 0) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "Failed to register GPIO IRQ");
+    return;
+  }
+
+  SET_INT_RETURN(irq_id);
+}
+
+/*
+ * IRQ.unregister_gpio(id)
+ */
+static void
+c_unregister_gpio(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+
+  if (v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "irq_id must be integer");
+    return;
+  }
+
+  int irq_id = v[1].i;
+  bool prev_state = IRQ_unregister_gpio(irq_id);
+
+  if (prev_state) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+/*
+ * IRQ.peek_event()
+ */
+static void
+c_peek_event(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  int irq_id, event_type;
+  bool has_event = IRQ_peek_event(&irq_id, &event_type);
+
+  mrbc_value result = mrbc_array_new(vm, 2);
+
+  if (has_event) {
+    mrbc_array_set(&result, 0, &mrbc_integer_value(irq_id));
+  } else {
+    mrbc_array_set(&result, 0, &mrbc_nil_value());
+  }
+  mrbc_array_set(&result, 1, &mrbc_integer_value(event_type));
+
+  SET_RETURN(result);
+}
+
+#define SET_MODULE_CONST(mod, cst) \
+  mrbc_set_const(mod, mrbc_str_to_symid(#cst), &mrbc_integer_value(cst))
+
+void
+mrbc_irq_init(mrbc_vm *vm)
+{
+  mrbc_class *module_IRQ = mrbc_define_module(vm, "IRQ");
+
+  /* Define module methods */
+  mrbc_define_method(vm, module_IRQ, "register_gpio", c_register_gpio);
+  mrbc_define_method(vm, module_IRQ, "unregister_gpio", c_unregister_gpio);  
+  mrbc_define_method(vm, module_IRQ, "peek_event", c_peek_event);
+
+  /* Initialize the IRQ system */
+  IRQ_init();
+}


### PR DESCRIPTION
This pull request introduces a new IRQ (Interrupt Request) subsystem for PicoRuby, enabling asynchronous event handling for GPIO pins and other peripherals. It adds a new `picoruby-irq` gem, complete with Ruby and C APIs, documentation, type signatures, and an example. Additionally, it enhances the GPIO API with IRQ support and makes some minor improvements to type signatures.

**Key changes:**

### New IRQ Subsystem

* Added the `picoruby-irq` gem, providing IRQ (interrupt) support for GPIO and peripherals, including C and Ruby implementations, documentation (`README.md`), and an example (`example/irq_gpio.rb`). This includes debouncing, event queueing, and IRQ management APIs. [[1]](diffhunk://#diff-29ed617c4f8c245402bf53effe5797c85b92e566972ae9fe1b823a20d3097788R1-R112) [[2]](diffhunk://#diff-9cb5d51f31add2ad80885ff2208d442620b6d35d2614bebf79db2d2c270ba8ebR1-R23) [[3]](diffhunk://#diff-a5e4cc8dc336bcab79528527d7296c9f77f331383feec8d5f6efa67180bdd444R1-R21) [[4]](diffhunk://#diff-dc78fb25b7181afb4d9398da1268eebb1a9fc157b88d8c6dce296ceae1da96e0R1-R5) [[5]](diffhunk://#diff-f02f015cdc12faf78fa95f6d8e9321c23784683c2a6c0ecdda5772124d5c1f4bR1-R96) [[6]](diffhunk://#diff-50c73cdb83b6212e5e50c04378727ee76eff45ba64252af9f490e1d42d1b69d9R1-R147) [[7]](diffhunk://#diff-b7cb7139c8901ba22b3718cef1d627d09f9ae5e022ce90e2d0793c2311e29cb3R1-R12) [[8]](diffhunk://#diff-ea893def4bebddd0c4ab26cb940cd7e357dd139d39dd1c2503b23a98848772f8R1-R89) [[9]](diffhunk://#diff-0a32cbd3c051ddd1d0bb8cc2f393ea783eac0f326de55370961b2287455ee5e2R1-R105) [[10]](diffhunk://#diff-8793237c0389d636b9255f8512c05e19c818e171d0b2afad72988a1ccd132cffR1-R41)

* Integrated the new gem into the peripherals build by adding `picoruby-irq` to the `peripherals.gembox`.

### Enhancements to GPIO API

* Added an `attr_reader :pin` to the `GPIO` class, allowing IRQ routines to access the pin number.
* Updated the GPIO type signature (`gpio.rbs`) to use an `attr_reader` for `pin` and moved the `gpio_pin_t` type definition. [[1]](diffhunk://#diff-5c296d321d6241aed5b12b830c7e974ffcf894dc56b3799865229a033ec5bf4bR2-R4) [[2]](diffhunk://#diff-5c296d321d6241aed5b12b830c7e974ffcf894dc56b3799865229a033ec5bf4bL25-R31)

### Type Signatures

* Introduced type signatures for the new IRQ API in `sig/irq.rbs`, describing the IRQ module, its instance class, and integration with `GPIO`.

---

**References:**  
[[1]](diffhunk://#diff-29ed617c4f8c245402bf53effe5797c85b92e566972ae9fe1b823a20d3097788R1-R112) [[2]](diffhunk://#diff-9cb5d51f31add2ad80885ff2208d442620b6d35d2614bebf79db2d2c270ba8ebR1-R23) [[3]](diffhunk://#diff-a5e4cc8dc336bcab79528527d7296c9f77f331383feec8d5f6efa67180bdd444R1-R21) [[4]](diffhunk://#diff-dc78fb25b7181afb4d9398da1268eebb1a9fc157b88d8c6dce296ceae1da96e0R1-R5) [[5]](diffhunk://#diff-f02f015cdc12faf78fa95f6d8e9321c23784683c2a6c0ecdda5772124d5c1f4bR1-R96) [[6]](diffhunk://#diff-50c73cdb83b6212e5e50c04378727ee76eff45ba64252af9f490e1d42d1b69d9R1-R147) [[7]](diffhunk://#diff-b7cb7139c8901ba22b3718cef1d627d09f9ae5e022ce90e2d0793c2311e29cb3R1-R12) [[8]](diffhunk://#diff-ea893def4bebddd0c4ab26cb940cd7e357dd139d39dd1c2503b23a98848772f8R1-R89) [[9]](diffhunk://#diff-0a32cbd3c051ddd1d0bb8cc2f393ea783eac0f326de55370961b2287455ee5e2R1-R105) [[10]](diffhunk://#diff-8793237c0389d636b9255f8512c05e19c818e171d0b2afad72988a1ccd132cffR1-R41) [[11]](diffhunk://#diff-c51154d72566cd1193c722e8f33c664cfae27cf5068583d7dc5695eab7cbb770R8) [[12]](diffhunk://#diff-73f27879154f2cb47d6b0d4d9cf14bba68db9e8e5f78a74045d1931f659680cdR46-R47) [[13]](diffhunk://#diff-5c296d321d6241aed5b12b830c7e974ffcf894dc56b3799865229a033ec5bf4bR2-R4) [[14]](diffhunk://#diff-5c296d321d6241aed5b12b830c7e974ffcf894dc56b3799865229a033ec5bf4bL25-R31)