### PR TITLE
Port MicroRuby to ESP32 RISC-V.

### DIFF
--- a/build_config/riscv-esp-microruby.rb
+++ b/build_config/riscv-esp-microruby.rb
@@ -1,0 +1,27 @@
+MRuby::CrossBuild.new('esp32-microruby') do |conf|
+  conf.toolchain('gcc')
+
+  conf.cc.command = 'riscv32-esp-elf-gcc'
+  conf.linker.command = 'riscv32-esp-elf-ld'
+  conf.archiver.command = 'riscv32-esp-elf-ar'
+
+  conf.cc.host_command = 'gcc'
+  conf.cc.flags << '-Wall'
+  conf.cc.flags << '-Wno-format'
+  conf.cc.flags << '-Wno-unused-function'
+  conf.cc.flags << '-Wno-maybe-uninitialized'
+
+  conf.cc.defines << 'MRBC_TICK_UNIT=10'
+  conf.cc.defines << 'MRBC_TIMESLICE_TICK_COUNT=1'
+  conf.cc.defines << 'MRBC_USE_FLOAT=2'
+  conf.cc.defines << 'MRBC_CONVERT_CRLF=1'
+  conf.cc.defines << 'USE_FAT_FLASH_DISK'
+  conf.cc.defines << 'NDEBUG'
+  conf.cc.defines << 'PICORB_ALLOC_ESTALLOC'
+  conf.cc.defines << 'ESTALLOC_DEBUG'
+
+  conf.gem core: 'mruby-compiler2'
+  conf.gem core: "picoruby-mruby"
+  conf.gem core: 'picoruby-machine'
+  conf.microruby
+end

--- a/mrbgems/picoruby-filesystem-fat/ports/esp32/flash_disk.c
+++ b/mrbgems/picoruby-filesystem-fat/ports/esp32/flash_disk.c
@@ -9,7 +9,7 @@
 
 #define BLOCK_SIZE   (16 * SPI_FLASH_SEC_SIZE)
 #define FLASH_SIZE   (1024 * 1024)
-#define FLASH_OFFSET (0x110000)
+#define FLASH_OFFSET (0x210000)
 
 static void *mapped_addr = NULL;
 static spi_flash_mmap_handle_t handle = 0;

--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -22,17 +22,32 @@
   #error "MRBC_NO_TIMER is not supported"
 #endif
 
+#if defined(PICORB_VM_MRUBY)
+static mrb_state *mrb_;
+#endif
+
 static esp_timer_handle_t periodic_timer;
 
 static void
 alarm_handler(void *arg)
 {
+#if defined(PICORB_VM_MRUBYC)
   mrbc_tick();
+#else
+  mrb_tick(mrb_);
+#endif
 }
 
 void
+#if defined(PICORB_VM_MRUBY)
+hal_init(mrb_state *mrb)
+#elif defined(PICORB_VM_MRUBYC)
 hal_init(void)
+#endif
 {
+#if defined(PICORB_VM_MRUBY)
+  mrb_ = (mrb_state *)mrb;
+#endif
   esp_timer_create_args_t timer_create_args;
   timer_create_args.callback = &alarm_handler;
   timer_create_args.arg = NULL;


### PR DESCRIPTION
I ported MicroRuby to run on the ESP32 RISC-V microcontroller.

## Verification Status

I have confirmed that the Hello world sample program runs on the M5StampC3 Mate (ESP32 RISC-V).  
The operation of mrbgems such as `picoruby-require` and `picoruby-shell` has not yet been verified.  
Operation on ESP32 Xtensa has also not been confirmed.

## Changes to Existing Code

When building MicroRuby, the factory area size of 1MB was insufficient.  
Therefore, I expanded the factory area to 2MB.  
The same change applies when using mruby/c: the factory area on FlashROM is increased to 2MB.
