### PR TITLE
Resolving ESP32 build errors with IQR.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -18,7 +18,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"
 
-  conf.gembox 'peripherals'
   conf.gembox 'r2p2'
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-picorubyvm"
@@ -31,5 +30,14 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+
+  # peripherals
+  conf.gem core: 'picoruby-gpio'
+  conf.gem core: 'picoruby-i2c'
+  conf.gem core: 'picoruby-spi'
+  conf.gem core: 'picoruby-adc'
+  conf.gem core: 'picoruby-uart'
+  conf.gem core: 'picoruby-pwm'
+
   conf.picoruby(alloc_libc: false)
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -19,7 +19,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "USE_FAT_FLASH_DISK"
   conf.cc.defines << "NDEBUG"
 
-  conf.gembox 'peripherals'
   conf.gembox 'r2p2'
   conf.gem core: "picoruby-machine"
   conf.gem core: "picoruby-picorubyvm"
@@ -32,5 +31,14 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: "picoruby-picoline"
   conf.gem core: "picoruby-base64"
   conf.gem core: "picoruby-mbedtls"
+
+  # peripherals
+  conf.gem core: 'picoruby-gpio'
+  conf.gem core: 'picoruby-i2c'
+  conf.gem core: 'picoruby-spi'
+  conf.gem core: 'picoruby-adc'
+  conf.gem core: 'picoruby-uart'
+  conf.gem core: 'picoruby-pwm'
+
   conf.picoruby(alloc_libc: false)
 end

--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -44,13 +44,21 @@ hal_init(void)
 }
 
 void
+#if defined(PICORB_VM_MRUBYC)
+hal_enable_irq(void)
+#elif defined(PICORB_VM_MRUBY)
 mrb_task_enable_irq()
+#endif
 {
   portENABLE_INTERRUPTS();
 }
 
 void
+#if defined(PICORB_VM_MRUBYC)
+hal_disable_irq(void)
+#elif defined(PICORB_VM_MRUBY)
 mrb_task_disable_irq()
+#endif
 {
   portDISABLE_INTERRUPTS();
 }


### PR DESCRIPTION
Using the latest version of PicoRuby, I encountered build errors on [R2P2-ESP32](https://github.com/picoruby/R2P2-ESP32/) .  
To address this, I made the following two modifications:

1. Made the symbol names `hal_enable_irq` and `hal_disable_irq` configurable  
2. Disabled the use of `picoruby-irq`