### PR TITLE
feat: Add custom RO data support for mruby

### DIFF
--- a/build_config/r2p2-microruby-cortex-m33.rb
+++ b/build_config/r2p2-microruby-cortex-m33.rb
@@ -16,6 +16,8 @@ MRuby::CrossBuild.new("r2p2-microruby-cortex-m33") do |conf|
   conf.cc.defines << "PICORB_ALLOC_ALIGN=8"
   conf.cc.defines << "ESTALLOC_DEBUG"
   conf.cc.defines << "USE_FAT_FLASH_DISK=1"
+  conf.cc.defines << "MRB_USE_CUSTOM_RO_DATA_P"
+  conf.cc.defines << "MRB_LINK_TIME_RO_DATA_P"
 
   conf.cc.command = "arm-none-eabi-gcc"
   conf.linker.command = "arm-none-eabi-ld"

--- a/build_config/r2p2_w-microruby-cortex-m33.rb
+++ b/build_config/r2p2_w-microruby-cortex-m33.rb
@@ -17,6 +17,8 @@ MRuby::CrossBuild.new("r2p2_w-microruby-cortex-m33") do |conf|
   conf.cc.defines << "ESTALLOC_DEBUG"
   conf.cc.defines << "USE_FAT_FLASH_DISK=1"
   conf.cc.defines << "USE_WIFI"
+  conf.cc.defines << "MRB_USE_CUSTOM_RO_DATA_P"
+  conf.cc.defines << "MRB_LINK_TIME_RO_DATA_P"
 
   conf.cc.command = "arm-none-eabi-gcc"
   conf.linker.command = "arm-none-eabi-ld"

--- a/mrbgems/picoruby-mruby/include/custom_ro_data.h
+++ b/mrbgems/picoruby-mruby/include/custom_ro_data.h
@@ -1,0 +1,13 @@
+#ifndef MRUBY_CUSTOM_RO_DATA_H
+#define MRUBY_CUSTOM_RO_DATA_H
+
+#include <picoruby.h>
+#include <stdbool.h>
+
+MRB_BEGIN_DECL
+
+bool PORT_mrb_ro_data_p(const char *p);
+
+MRB_END_DECL
+
+#endif

--- a/mrbgems/picoruby-mruby/ports/rp2040/custom_ro_data.c
+++ b/mrbgems/picoruby-mruby/ports/rp2040/custom_ro_data.c
@@ -1,0 +1,9 @@
+#include "../../include/custom_ro_data.h"
+
+extern char __etext; // pico-sdk symbol
+
+bool
+PORT_mrb_ro_data_p(const char *p)
+{
+  return p < &__etext;
+}

--- a/mrbgems/picoruby-mruby/src/custom_ro_data.c
+++ b/mrbgems/picoruby-mruby/src/custom_ro_data.c
@@ -1,0 +1,10 @@
+#include "mruby.h"
+#include "../include/custom_ro_data.h"
+
+#if defined(MRB_USE_CUSTOM_RO_DATA_P)
+mrb_bool
+mrb_ro_data_p(const char *p)
+{
+  return PORT_mrb_ro_data_p(p) ? TRUE : FALSE;
+}
+#endif


### PR DESCRIPTION
Add custom RO data implementation to support ROM or RAM memory distinction:
- Add `MRB_USE_CUSTOM_RO_DATA_P` and `MRB_LINK_TIME_RO_DATA_P` defines
- Implement `mrb_ro_data_p` function with platform-specific port
- Add RP2040/RP2350-specific implementation using `__etext` symbol