### PR TITLE
Fix local variable names are overwritten in `Sandbox`

### DIFF
--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -166,6 +166,9 @@ mrb_sandbox_result(mrb_state *mrb, mrb_value self)
     for (size_t j = 0; j < nlocals; j++, v++) {
       name = mrb_sym_name(ss->cc->mrb, *v);
       pm_string_constant_init(&scope->locals[j], name, strlen(name));
+      if (name == ss->cc->mrb->symbuf) {
+        pm_string_ensure_owned(&scope->locals[j]); // copy name
+      }
     }
   }
   ss->options = options;


### PR DESCRIPTION
This PR fixes that some local variable names are overwritten in `Sandbox` with mruby. This bug will occur on variable names that are inline symbols, because unpacking inline symbols uses a shared buffer (`mrb->symbuf`).

The reproduction code on IRB is below.

Before:
```
irb> v1=1
=> 1
irb> v2=2
=> 2
irb> v1
=> #<NoMethodError: undefined method 'v1' for Class>
irb> v2
=> #<NoMethodError: undefined method 'v2' for Class>
irb> local_variables
=> [:v, :"\"_\\x00\"", :_]
```

After:
```
irb> v1=1
=> 1
irb> v2=2
=> 2
irb> v1
=> 1
irb> v2
=> 2
irb> local_variables
=> [:_, :v1, :v2]
```