### PR TITLE
Fix memory leak in `Sandbox`

### DIFF
--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -171,6 +171,10 @@ mrb_sandbox_result(mrb_state *mrb, mrb_value self)
       }
     }
   }
+  if (ss->options) {
+    pm_options_free(ss->options);
+    mrc_free(ss->cc, ss->options);
+  }
   ss->options = options;
 
   return mrb_task_value(mrb, ss->task);


### PR DESCRIPTION
This PR fixes memory leaking in `Sandbox` with mruby.