### PR TITLE
Add VRAM#erase and SSD1306#erase methods for selective area clearing

### DIFF
--- a/mrbgems/picoruby-ssd1306/example/ssd1306_demo.rb
+++ b/mrbgems/picoruby-ssd1306/example/ssd1306_demo.rb
@@ -52,15 +52,43 @@ display.update_display
 sleep 2
 GC.start
 
-puts "Test 6: Performance test with optimized dirty page updates"
+puts "Test 6: Bouncing rectangle animation using erase method"
 display.clear
-11.times do |i|
-  # Only update a small area
-  display.draw_rect(i * 10, i * 5, 15, 10, 1, true)
-  display.update_display_optimized  # Only update dirty pages
-  sleep 0.1
+
+# Rectangle properties
+rect_w = 12
+rect_h = 8
+rect_x = 10.0
+rect_y = 10.0
+velocity_x = 2.5
+velocity_y = 1.8
+
+# Animation loop
+60.times do |frame|
+  # Erase previous rectangle position
+  display.erase(rect_x.to_i, rect_y.to_i, rect_w, rect_h) unless frame == 0
+  # Update position
+  rect_x += velocity_x
+  rect_y += velocity_y
+  # Bounce off edges
+  if rect_x <= 0 || rect_x >= (width - rect_w)
+    velocity_x = -velocity_x
+    rect_x = rect_x <= 0 ? 0 : width - rect_w
+  end
+  if rect_y <= 0 || rect_y >= (height - rect_h)
+    velocity_y = -velocity_y
+    rect_y = rect_y <= 0 ? 0 : height - rect_h
+  end
+
+  # Draw rectangle at new position
+  display.draw_rect(rect_x.to_i, rect_y.to_i, rect_w, rect_h, 1, true)
+  display.update_display_optimized
+
+  sleep 0.08  # ~12 FPS animation
+  GC.start if frame % 10 == 0  # Periodic garbage collection
 end
-sleep 2
+
+sleep 1
 GC.start
 
 puts "Test 7: Custom bitmap with draw_bytes (bytes method)"
@@ -74,7 +102,7 @@ GC.start
 
 puts "Test 8: Text display with shinonome font"
 display.clear
-display.draw_text(:termius_6x12, 0, 0, "Hello PicoRubyWorld!!")
+display.draw_text(:terminus_6x12, 0, 0, "Hello PicoRubyWorld!!")
 display.update_display_optimized
 display.draw_text(:shinonome_min16, 0, 16, "黒暗森林", 2)
 display.update_display_optimized

--- a/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
+++ b/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
@@ -67,6 +67,18 @@ class SSD1306
     update_display
   end
 
+  def erase(x, y, w, h)
+    return if x < 0 || y < 0 || w <= 0 || h <= 0
+    return if x >= @width || y >= @height
+    # Clip the erase area to display bounds
+    w = [@width - x, w].min
+    h = [@height - y, h].min
+    # @type var w: Integer
+    # @type var h: Integer
+    @vram.erase(x, y, w, h)
+    nil
+  end
+
   def fill_screen(pattern = 0xFF)
     @vram.fill(pattern)
     update_display

--- a/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
+++ b/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
@@ -29,6 +29,7 @@ class SSD1306
   def initialize: (i2c: I2C, address: Integer, w: Integer, h: Integer) -> void
   private def init_display: () -> void
   def clear: () -> Integer
+  def erase: (Integer x, Integer y, Integer w, Integer h) -> nil
   def fill_screen: (?Integer pattern) -> Integer
   def set_pixel: (Integer x, Integer y, ?Integer color) -> void
   def draw_line: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color) -> nil

--- a/mrbgems/picoruby-vram/sig/vram.rbs
+++ b/mrbgems/picoruby-vram/sig/vram.rbs
@@ -11,4 +11,5 @@ class VRAM
   def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> self
   def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> self
   def fill: (Integer color) -> self
+  def erase: (Integer x, Integer y, Integer w, Integer h) -> self
 end

--- a/mrbgems/picoruby-vram/src/mruby/vram.c
+++ b/mrbgems/picoruby-vram/src/mruby/vram.c
@@ -375,6 +375,32 @@ mrb_vram_draw_bytes(mrb_state* mrb, mrb_value self)
   return self;
 }
 
+static mrb_value
+mrb_vram_erase(mrb_state* mrb, mrb_value self)
+{
+  mrb_int x, y, w, h;
+  mrb_get_args(mrb, "iiii", &x, &y, &w, &h);
+
+  display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
+
+  for (mrb_int i = 0; i < h; i++) {
+    for (mrb_int j = 0; j < w; j++) {
+      mrb_int px = x + j;
+      mrb_int py = y + i;
+      for (mrb_int k = 0; k < disp->page_count; k++) {
+        display_page_t *page = &disp->pages[k];
+        if (px >= page->x && px < page->x + page->w &&
+            py >= page->y && py < page->y + page->h) {
+          page->set_pixel(page, px - page->x, py - page->y, 0);
+          break;
+        }
+      }
+    }
+  }
+
+  return self;
+}
+
 
 void
 mrb_picoruby_vram_gem_init(mrb_state* mrb)
@@ -391,6 +417,7 @@ mrb_picoruby_vram_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(draw_bytes), mrb_vram_draw_bytes, MRB_ARGS_KEY(5, 5));
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(set_pixel), mrb_vram_set_pixel, MRB_ARGS_REQ(3));
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(fill), mrb_vram_fill, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_VRAM, MRB_SYM(erase), mrb_vram_erase, MRB_ARGS_REQ(4));
 }
 
 void

--- a/mrbgems/picoruby-vram/src/mrubyc/vram.c
+++ b/mrbgems/picoruby-vram/src/mrubyc/vram.c
@@ -415,6 +415,36 @@ c_vram_draw_bytes(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
+/*
+ * vram.erase(x, y, w, h)
+ */
+static void
+c_vram_erase(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  display_t *disp = (display_t *)v[0].instance->data;
+  if (!disp) return;
+
+  int x = GET_INT_ARG(1);
+  int y = GET_INT_ARG(2);
+  int w = GET_INT_ARG(3);
+  int h = GET_INT_ARG(4);
+
+  for (int i = 0; i < h; i++) {
+    for (int j = 0; j < w; j++) {
+      int px = x + j;
+      int py = y + i;
+      for (int k = 0; k < disp->page_count; k++) {
+        display_page_t *page = &disp->pages[k];
+        if (px >= page->x && px < page->x + page->w &&
+            py >= page->y && py < page->y + page->h) {
+          page->set_pixel(page, px - page->x, py - page->y, 0);
+          break;
+        }
+      }
+    }
+  }
+}
+
 void
 mrbc_vram_init(struct VM *vm)
 {
@@ -430,4 +460,5 @@ mrbc_vram_init(struct VM *vm)
   mrbc_define_method(0, class_VRAM, "draw_bitmap", c_vram_draw_bitmap);
   mrbc_define_method(0, class_VRAM, "draw_bytes", c_vram_draw_bytes);
   mrbc_define_method(0, class_VRAM, "fill", c_vram_fill);
+  mrbc_define_method(0, class_VRAM, "erase", c_vram_erase);
 }


### PR DESCRIPTION
Implement selective area clearing functionality to enable efficient display updates and animations by clearing specific rectangular regions instead of the entire display.

Changes:
- Add VRAM#erase(x, y, w, h) method for both mruby and mrubyc implementations
- Add SSD1306#erase(x, y, w, h) method wrapping VRAM#erase with bounds checking
- Update ssd1306_demo.rb Test 6 with bouncing rectangle animation using erase
- Add type definitions for new methods in RBS files
- Fix type annotations for Steep compatibility