### PR TITLE
Make picoruby-mbedtls digest module portable across platforms.

### DIFF
--- a/mrbgems/picoruby-mbedtls/include/digest.h
+++ b/mrbgems/picoruby-mbedtls/include/digest.h
@@ -1,0 +1,23 @@
+#ifndef DIGEST_DEFINED_H_
+#define DIGEST_DEFINED_H_
+
+#include <stdbool.h>
+#include <string.h>
+#include <stddef.h>
+
+enum {
+  DIGEST_SUCCESS = 0,
+  DIGEST_BAD_INPUT_DATA,
+  DIGEST_FAILED_TO_SETUP,
+  DIGEST_FAILED_TO_START,
+};
+
+int MbedTLS_digest_algorithm_name(const char * name);
+int MbedTLS_digest_instance_size(void);
+int MbedTLS_digest_new(unsigned char *data, int alg);
+int MbedTLS_digest_update(unsigned char *data, const unsigned char *input, size_t ilen);
+size_t MbedTLS_digest_get_size(unsigned char *data);
+int MbedTLS_digest_finish(unsigned char *data, unsigned char *output);
+void MbedTLS_digest_free(unsigned char *data);
+
+#endif /* DIGEST_DEFINED_H_ */

--- a/mrbgems/picoruby-mbedtls/ports/common/digest.c
+++ b/mrbgems/picoruby-mbedtls/ports/common/digest.c
@@ -1,0 +1,76 @@
+#include "digest.h"
+#include "mbedtls/md.h"
+#include "mbedtls/sha256.h"
+#include <string.h>
+
+int
+MbedTLS_digest_algorithm_name(const char * name)
+{
+  int ret;
+  if (strcmp(name, "sha256") == 0) {
+    ret = (int)MBEDTLS_MD_SHA256;
+  } else if (strcmp(name, "none") == 0) {
+    ret = (int)MBEDTLS_MD_NONE;
+  } else {
+    ret = -1;
+  }
+  return ret;
+}
+
+int
+MbedTLS_digest_instance_size(void)
+{
+  return sizeof(mbedtls_md_context_t);
+}
+
+int
+MbedTLS_digest_new(unsigned char *data, int alg)
+{
+  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)data;
+  mbedtls_md_init(ctx);
+
+  const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type((mbedtls_md_type_t)alg);
+  int ret;
+  ret = mbedtls_md_setup(ctx, md_info, 0);
+  if (ret != 0) {
+    mbedtls_md_free(ctx);
+    return DIGEST_FAILED_TO_SETUP;
+  }
+  ret = mbedtls_md_starts(ctx);
+  if (ret != 0) {
+    mbedtls_md_free(ctx);
+    return DIGEST_FAILED_TO_START;
+  }
+  return DIGEST_SUCCESS;
+}
+
+int
+MbedTLS_digest_update(unsigned char *data, const unsigned char *input, size_t ilen)
+{
+  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)data;
+  return mbedtls_md_update(ctx, input, ilen);
+}
+
+size_t
+MbedTLS_digest_get_size(unsigned char *data)
+{
+  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)data;
+  const mbedtls_md_info_t *md_info = mbedtls_md_info_from_ctx(ctx);
+  return mbedtls_md_get_size(md_info);
+}
+
+int
+MbedTLS_digest_finish(unsigned char *data, unsigned char *output)
+{
+  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)data;
+  return mbedtls_md_finish(ctx, output);
+}
+
+void
+MbedTLS_digest_free(unsigned char *data)
+{
+  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)data;
+  if (ctx != NULL) {
+    mbedtls_md_free(ctx);
+  }
+}

--- a/mrbgems/picoruby-mbedtls/ports/common/md.c
+++ b/mrbgems/picoruby-mbedtls/ports/common/md.c
@@ -1,0 +1,7 @@
+#include <mbedtls/md.h>
+
+void
+MbedTLS_md_free(void *p)
+{
+  mbedtls_md_free(p);
+}

--- a/mrbgems/picoruby-mbedtls/src/digest.c
+++ b/mrbgems/picoruby-mbedtls/src/digest.c
@@ -1,20 +1,4 @@
-#include "mbedtls/md.h"
-#include "mbedtls/sha256.h"
-#include <string.h>
-
-static int
-mbedtls_digest_algorithm_name(const char * name)
-{
-  int ret;
-  if (strcmp(name, "sha256") == 0) {
-    ret = (int)MBEDTLS_MD_SHA256;
-  } else if (strcmp(name, "none") == 0) {
-    ret = (int)MBEDTLS_MD_NONE;
-  } else {
-    ret = -1;
-  }
-  return ret;
-}
+#include "digest.h"
 
 #if defined(PICORB_VM_MRUBY)
 
@@ -25,4 +9,3 @@ mbedtls_digest_algorithm_name(const char * name)
 #include "mrubyc/digest.c"
 
 #endif
-

--- a/mrbgems/picoruby-mbedtls/src/mruby/digest.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/digest.c
@@ -1,9 +1,10 @@
 #include "mruby.h"
 #include "mruby/presym.h"
 #include "mruby/string.h"
-#include "mbedtls/md.h"
-#include "mbedtls/sha256.h"
+#include "mruby/data.h"
+#include "mruby/class.h"
 
+#include "digest.h"
 #include "md_context.h"
 
 static mrb_value
@@ -12,22 +13,19 @@ mrb_mbedtls_digest_initialize(mrb_state *mrb, mrb_value self)
   mrb_value algorithm;
   mrb_get_args(mrb, "n", &algorithm);
 
-  int alg = mbedtls_digest_algorithm_name((const char *)mrb_sym_name(mrb, mrb_symbol(algorithm)));
+  int alg = MbedTLS_digest_algorithm_name((const char *)mrb_sym_name(mrb, mrb_symbol(algorithm)));
   if (alg == -1) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid algorithm");
   }
 
-  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)mrb_malloc(mrb, sizeof(mbedtls_md_context_t));
+  unsigned char *ctx = (unsigned char *)mrb_malloc(mrb, MbedTLS_digest_instance_size());
   DATA_PTR(self) = ctx;
   DATA_TYPE(self) = &mrb_md_context_type;
-  mbedtls_md_init(ctx); const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type((mbedtls_md_type_t)alg);
-  int ret;
-  ret = mbedtls_md_setup(ctx, md_info, 0);
-  if (ret != 0) {
+
+  int ret = MbedTLS_digest_new(ctx, alg);
+  if (ret == DIGEST_FAILED_TO_SETUP) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "mbedtls_md_setup failed");
-  }
-  ret = mbedtls_md_starts(ctx);
-  if (ret != 0) {
+  } else if (ret == DIGEST_FAILED_TO_START) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "mbedtls_md_starts failed");
   }
   return self;
@@ -46,33 +44,27 @@ mrb_mbedtls_digest_update(mrb_state *mrb, mrb_value self)
   mrb_value input;
   mrb_get_args(mrb, "S", &input);
 
-  int ret;
-  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)mrb_data_get_ptr(mrb, self, &mrb_md_context_type);
-  ret = mbedtls_md_update(ctx, (const unsigned char *)RSTRING_PTR(input), RSTRING_LEN(input));
-  if (ret != 0) {
+  unsigned char *ctx = (unsigned char *)mrb_data_get_ptr(mrb, self, &mrb_md_context_type);
+  if (MbedTLS_digest_update(ctx, (const unsigned char *)RSTRING_PTR(input), RSTRING_LEN(input)) != 0) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "mbedtls_md_update failed");
   }
-  //mrb_incref(&v[0]);
   return self;
 }
 
 static mrb_value
 mrb_mbedtls_digest_finish(mrb_state *mrb, mrb_value self)
 {
-  mbedtls_md_context_t *ctx = (mbedtls_md_context_t *)mrb_data_get_ptr(mrb, self, &mrb_md_context_type);
+  unsigned char *ctx = (unsigned char *)mrb_data_get_ptr(mrb, self, &mrb_md_context_type);
 
-  const mbedtls_md_info_t *md_info = mbedtls_md_info_from_ctx(ctx);
-  size_t out_len = mbedtls_md_get_size(md_info);
-  unsigned char* output = mrb_malloc(mrb, out_len); // need at least block size
-  int ret;
+  size_t out_len = MbedTLS_digest_get_size(ctx);
+  unsigned char* output = mrb_malloc(mrb, out_len);
 
-  ret = mbedtls_md_finish(ctx, output);
-  if (ret != 0) {
+  if (MbedTLS_digest_finish(ctx, output) != 0) {
+    mrb_free(mrb, output);
     mrb_raise(mrb, E_RUNTIME_ERROR, "mbedtls_digest_finish failed");
   }
   mrb_value ret_value = mrb_str_new(mrb, (const char *)output, (mrb_int)out_len);
   mrb_free(mrb, output);
-  //mrb_incref(&v[0]);
   return ret_value;
 }
 
@@ -88,4 +80,3 @@ gem_mbedtls_digest_init(mrb_state *mrb, struct RClass *module_MbedTLS)
   mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(finish),      mrb_mbedtls_digest_finish, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(free),        mrb_mbedtls_digest_free, MRB_ARGS_NONE());
 }
-

--- a/mrbgems/picoruby-mbedtls/src/mruby/md_context.h
+++ b/mrbgems/picoruby-mbedtls/src/mruby/md_context.h
@@ -8,10 +8,12 @@
 extern "C" {
 #endif
 
+void MbedTLS_md_free(void *p);
+
 static void
 mrb_md_context_free(mrb_state *mrb, void *ptr)
 {
-  mbedtls_md_free(ptr);
+  MbedTLS_md_free(ptr);
   mrb_free(mrb, ptr);
 }
 


### PR DESCRIPTION
This is a continuation of work on picoruby-mbedtls https://github.com/picoruby/picoruby/pull/257.
To enable portability for digest, I moved the processing dependent on mbedtls to ports/common.