### PR TITLE
Add dual CDC USB support for separate stdout and stderr

### DIFF
--- a/mrbgems/picoruby-machine/include/machine.h
+++ b/mrbgems/picoruby-machine/include/machine.h
@@ -9,6 +9,12 @@
 #include <signal.h>
 #endif
 
+/* File descriptor to CDC instance mapping for dual CDC configuration */
+#define FD_STDOUT 1
+#define FD_STDERR 2
+#define CDC_INSTANCE_STDOUT 0
+#define CDC_INSTANCE_STDERR 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mrbgems/picoruby-machine/sig/machine.rbs
+++ b/mrbgems/picoruby-machine/sig/machine.rbs
@@ -11,4 +11,5 @@ class Machine
   def self.set_hwclock: (Integer tv_sec, Integer tv_nsec) -> Integer
   def self.get_hwclock: () -> [Integer, Integer]
   def self.exit: (Integer status) -> void
+  def self.debug_puts: (String str) -> nil
 end

--- a/mrbgems/picoruby-machine/src/machine.c
+++ b/mrbgems/picoruby-machine/src/machine.c
@@ -13,12 +13,12 @@ debug_printf(const char *format, ...)
   va_list args;
   va_start(args, format);
 #if defined(PICORB_PLATFORM_POSIX)
-  int len = vprintf(format, args);
+  int len = vfprintf(stderr, format, args);
 #else
   char buffer[256];
   int len = vsnprintf(buffer, sizeof(buffer), format, args);
-  hal_write(1, buffer, len);
-  hal_flush(1);
+  hal_write(2, buffer, len);
+  hal_flush(2);
 #endif
   va_end(args);
   return len;

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -187,6 +187,23 @@ c_Machine_get_hwclock(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
+c_Machine_debug_puts(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc == 0) {
+    hal_write(2, "\n", 1);
+  } else {
+    for (int i = 1; i <= argc; i++) {
+      mrbc_value arg = GET_ARG(i);
+      mrbc_value str = mrbc_send(vm, v, argc, &arg, "to_s", 0);
+      if (str.tt == MRBC_TT_STRING) {
+        hal_write(2, (const char *)str.string->data, str.string->size);
+        hal_write(2, "\n", 1);
+      }
+    }
+  }
+}
+
+static void
 c_Machine_exit(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   int status;
@@ -282,6 +299,7 @@ mrbc_machine_init(mrbc_vm *vm)
   mrbc_define_method(vm, mrbc_class_Machine, "get_hwclock", c_Machine_get_hwclock);
 
   mrbc_define_method(vm, mrbc_class_Machine, "exit", c_Machine_exit);
+  mrbc_define_method(vm, mrbc_class_Machine, "debug_puts", c_Machine_debug_puts);
 
 #if !defined(PICORB_PLATFORM_POSIX)
   mrbc_class *class_IO = mrbc_define_class(vm, "IO", mrbc_class_object);

--- a/mrbgems/picoruby-mbedtls/src/mruby/cipher.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/cipher.c
@@ -4,6 +4,7 @@
 #include "mruby/array.h"
 #include "mruby/data.h"
 #include "mruby/class.h"
+#include "picoruby/debug.h"
 
 static void
 mrb_cipher_free(mrb_state *mrb, void *ptr)
@@ -23,17 +24,11 @@ mrb_mbedtls_cipher_initialize(mrb_state *mrb, mrb_value self)
 
   int cipher_type;
   uint8_t key_len, iv_len;
-#ifdef PICORUBY_DEBUG
-  printf("Cipher.new: cipher_name='%s'\n", cipher_name);
-#endif
+  D("Cipher.new: cipher_name='%s'\n", cipher_name);
   Mbedtls_cipher_type_key_iv_len(cipher_name, &cipher_type, &key_len, &iv_len);
-#ifdef PICORUBY_DEBUG
-  printf("Cipher.new: cipher_type=%d, key_len=%d, iv_len=%d\n", cipher_type, key_len, iv_len);
-#endif
+  D("Cipher.new: cipher_type=%d, key_len=%d, iv_len=%d\n", cipher_type, key_len, iv_len);
   if (cipher_type == 0) {
-#ifdef PICORUBY_DEBUG
-    printf("Cipher.new: unsupported cipher suite '%s'\n", cipher_name);
-#endif
+    D("Cipher.new: unsupported cipher suite '%s'\n", cipher_name);
     mrb_raise(mrb, E_ARGUMENT_ERROR, "unsupported cipher suite");
   }
 

--- a/mrbgems/picoruby-mbedtls/src/mrubyc/cipher.c
+++ b/mrbgems/picoruby-mbedtls/src/mrubyc/cipher.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "mrubyc.h"
+#include "picoruby/debug.h"
 
 static void
 c_mbedtls_cipher_new(mrbc_vm *vm, mrbc_value *v, int argc)
@@ -20,11 +21,11 @@ c_mbedtls_cipher_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   int cipher_type;
   uint8_t key_len, iv_len;
-  printf("Cipher.new: cipher_name='%s'\n", cipher_name);
+  D("Cipher.new: cipher_name='%s'\n", cipher_name);
   Mbedtls_cipher_type_key_iv_len(cipher_name, &cipher_type, &key_len, &iv_len);
-  printf("Cipher.new: cipher_type=%d, key_len=%d, iv_len=%d\n", cipher_type, key_len, iv_len);
+  D("Cipher.new: cipher_type=%d, key_len=%d, iv_len=%d\n", cipher_type, key_len, iv_len);
   if (cipher_type == 0) {
-    printf("Cipher.new: unsupported cipher suite '%s'\n", cipher_name);
+    D("Cipher.new: unsupported cipher suite '%s'\n", cipher_name);
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "unsupported cipher suite");
     return;
   }
@@ -92,7 +93,7 @@ c_mbedtls_cipher_key_eq(mrbc_vm *vm, mrbc_value *v, int argc)
   int ret = MbedTLS_cipher_set_key(cipher_instance, (const uint8_t *)key.string->data, key.string->size * 8);
 
   if (ret == CIPHER_ALREADY_SET) {
-    printf("[WARN] key should be set once per instance, ignoring\n");
+    D("[WARN] key should be set once per instance, ignoring\n");
   } else if (ret == CIPHER_OPERATION_NOT_SET) {
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "operation is not set");
   } else if (ret == CIPHER_INVALID_LENGTH) {
@@ -131,7 +132,7 @@ c_mbedtls_cipher_iv_eq(mrbc_vm *vm, mrbc_value *v, int argc)
   int ret = MbedTLS_cipher_set_iv(cipher_instance, (const uint8_t *)iv.string->data, iv.string->size);
 
   if (ret == CIPHER_ALREADY_SET) {
-    printf("[WARN] iv should be set once per instance, ignoring\n");
+    D("[WARN] iv should be set once per instance, ignoring\n");
   } else if (ret == CIPHER_OPERATION_NOT_SET) {
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "operation is not set");
   } else if (ret == CIPHER_INVALID_LENGTH) {

--- a/mrbgems/picoruby-shinonome/src/mruby/shinonome.c
+++ b/mrbgems/picoruby-shinonome/src/mruby/shinonome.c
@@ -2,6 +2,7 @@
 #include <mruby/presym.h>
 #include <mruby/string.h>
 #include <mruby/array.h>
+#include "picoruby/debug.h"
 
 static void
 test_print(mrb_state *mrb, mrb_int size)
@@ -27,7 +28,7 @@ test_print(mrb_state *mrb, mrb_int size)
         }
       }
     } else {
-      printf("unicode: %04X\n", c);
+      D("unicode: %04X\n", c);
     }
   }
 }

--- a/mrbgems/picoruby-shinonome/src/mrubyc/shinonome.c
+++ b/mrbgems/picoruby-shinonome/src/mrubyc/shinonome.c
@@ -1,4 +1,5 @@
 #include <mrubyc.h>
+#include "picoruby/debug.h"
 
 static void
 test_print(mrbc_vm *vm, mrbc_value *v, mrbc_int_t size)
@@ -23,7 +24,7 @@ test_print(mrbc_vm *vm, mrbc_value *v, mrbc_int_t size)
         }
       }
     } else {
-      printf("unicode: %04X\n", c);
+      D("unicode: %04X\n", c);
     }
   }
 }


### PR DESCRIPTION
This commit enables dual CDC (Communications Device Class) USB ports to separate standard output and debug output on embedded platforms.

Changes:
- picoruby-machine: Add hal_write/hal_flush support for dual CDC
  - Define FD_STDOUT/FD_STDERR and CDC_INSTANCE_* macros
  - Route fd=1 (stdout) to CDC0, fd=2 (stderr) to CDC1
  - Update debug_printf() to use stderr (fd=2)
- Add Machine.debug_puts method for Ruby code debug output
- Replace printf() with D() macro in picoruby-mbedtls and picoruby-shinonome

This allows developers to view application output on CDC0 (/dev/ttyACM0) and debug messages on CDC1 (/dev/ttyACM1) simultaneously.