### PR TITLE
Separate the output of picoruby-machine for ESP32 into stdout and stderr.

### DIFF
--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -87,15 +87,17 @@ hal_idle_cpu()
 int
 hal_write(int fd, const void *buf, int nbytes)
 {
+  FILE *stream = (fd == 1) ? stdout : stderr;
   for (int i = 0 ; i < nbytes ; i++) {
-    putchar(((char*)buf)[i]);
+    fputc(((char*)buf)[i], stream);
   }
-  fflush(stdout);
+  fflush(stream);
   return nbytes;
 }
 
 int hal_flush(int fd) {
-  return fflush(stdout);
+  FILE *stream = (fd == 1) ? stdout : stderr;
+  return fflush(stream);
 }
 
 int


### PR DESCRIPTION
To follow #269, the picoruby-machine for ESP32 has also implemented support for separating stdout and stderr.