### PR TITLE
In picotest, check standard error only when the status code is not 0.

### DIFF
--- a/mrbgems/picoruby-picotest/mrblib/picotest/runner.rb
+++ b/mrbgems/picoruby-picotest/mrblib/picotest/runner.rb
@@ -99,19 +99,20 @@ module Picotest
               @result[klass.to_s] = JSON.parse(outputs[1])
             end
           end
-          if $?.exitstatus != 0
-            raise "Crash in running #{klass.to_s} tests. See #{error_file} for details."
-          end
         end
-        if FileTest.size?(error_file)
-          @result[klass.to_s] = {
-            "success_count" => 0,
-            "failures" => [],
-            "exceptions" => [],
-            "crashes" => []
-          }
-          File.open(error_file) do |error|
-            @result[klass.to_s]["crashes"] << error.read
+        if $?.exitstatus != 0
+          raise "Crash in running #{klass.to_s} tests. See #{error_file} for details."
+
+          if FileTest.size?(error_file)
+            @result[klass.to_s] = {
+              "success_count" => 0,
+              "failures" => [],
+              "exceptions" => [],
+              "crashes" => []
+            }
+            File.open(error_file) do |error|
+              @result[klass.to_s]["crashes"] << error.read
+            end
           end
         end
       end


### PR DESCRIPTION
The test in https://github.com/picoruby/picoruby/pull/272 is failing.

It appears the cause is that picotest considers it a crash if standard error exists, even when the status code is 0.

Therefore, I modified it to check for standard error only when the status code is not 0.