### PR TITLE
Make require work in MicroRuby

### DIFF
--- a/mrbgems/picoruby-env/mrbgem.rake
+++ b/mrbgems/picoruby-env/mrbgem.rake
@@ -3,9 +3,9 @@ MRuby::Gem::Specification.new('picoruby-env') do |spec|
   spec.author  = 'HASUMI Hitoshi'
   spec.summary = 'ENV'
 
-  if build.gems.map(&:name).include?('picoruby-mruby')
+  if build.vm_mruby?
     # Workaround:
-    #   Locate picoruby-mruby at the top of gem_init.c
+    #   Locate picoruby-mruby at the (almost) top of gem_init.c
     #   to define Kernel#require earlier than other gems
     spec.add_dependency 'picoruby-mruby'
   end

--- a/mrbgems/picoruby-mruby/mrblib/kernel.rb
+++ b/mrbgems/picoruby-mruby/mrblib/kernel.rb
@@ -1,5 +1,0 @@
-module Kernel
-  def require(name)
-    false
-  end
-end

--- a/mrbgems/picoruby-mruby/mrblib/require.rb
+++ b/mrbgems/picoruby-mruby/mrblib/require.rb
@@ -1,0 +1,7 @@
+# Kernel#require will be overridden by picoruby-require.
+# But this implementation is necessary not to raise LoadError during picogem_init
+module Kernel
+  def require(path)
+    false
+  end
+end

--- a/mrbgems/picoruby-require/mrbgem.rake
+++ b/mrbgems/picoruby-require/mrbgem.rake
@@ -21,6 +21,7 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
 
   # picogems to be required in Ruby
   picogems = Hash.new
+  mgems = Array.new
   task :collect_gems => "#{mrbgems_dir}/gem_init.c" do
     build.gems.each do |gem|
       if gem.name.start_with?("picoruby-") && !gem.name.start_with?("picoruby-bin-")
@@ -49,6 +50,8 @@ MRuby::Gem::Specification.new('picoruby-require') do |spec|
             end
           end
         end
+      elsif gem.name.start_with?("mruby-")
+        mgems << gem.name.sub(/\Amruby-?/,'')
       end
     end
   end

--- a/mrbgems/picoruby-require/mrblib/require.rb
+++ b/mrbgems/picoruby-require/mrblib/require.rb
@@ -67,11 +67,12 @@ module Kernel
 
 end
 
+$LOADED_FEATURES = ["require"]
+
 if RUBY_ENGINE == 'mruby/c'
   class Object
     include Kernel
   end
-  $LOADED_FEATURES = ["require"]
   begin
     require "posix-io"
   rescue LoadError

--- a/mrbgems/picoruby-require/templates/mruby/picogem_init.c.erb
+++ b/mrbgems/picoruby-require/templates/mruby/picogem_init.c.erb
@@ -6,5 +6,9 @@ const char *prebuilt_gems[] = {
   "<%= require_name %>",
 <%- end -%>
 <%- end -%>
+  // mgems
+<%- mgems.each do |require_name| -%>
+  "<%= require_name %>",
+<%- end -%>
   NULL
 };

--- a/mrbgems/picoruby-shell/mrbgem.rake
+++ b/mrbgems/picoruby-shell/mrbgem.rake
@@ -6,9 +6,7 @@ MRuby::Gem::Specification.new('picoruby-shell') do |spec|
   spec.author  = 'HASUMI Hitoshi'
   spec.summary = 'PicoRuby Shell library'
 
-  if build.vm_mrubyc?
-    spec.add_dependency 'picoruby-require'
-  end
+  spec.add_dependency 'picoruby-require'
   spec.add_dependency 'picoruby-editor'
   spec.add_dependency 'picoruby-sandbox'
   spec.add_dependency 'picoruby-env'

--- a/mrbgems/picoruby-shell/mrblib/0_out_of_steep.rb
+++ b/mrbgems/picoruby-shell/mrblib/0_out_of_steep.rb
@@ -1,1 +1,0 @@
-$LOAD_PATH = ["/lib"]

--- a/mrbgems/picoruby-shell/mrblib/kernel.rb
+++ b/mrbgems/picoruby-shell/mrblib/kernel.rb
@@ -3,7 +3,3 @@ module Kernel
     Shell::Job.new(*command.split).exec
   end
 end
-
-class Object
-  include Kernel
-end

--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -99,6 +99,7 @@ class Shell
       Dir.mkdir(root)
       puts "Created root directory: #{root}"
     end
+    $LOAD_PATH = ["#{root}/lib"]
     ENV['HOME'] = "#{root}/home"
     ENV['PATH'] = "#{root}/bin"
     ENV['WIFI_CONFIG_PATH'] = "#{root}/etc/network/wifi.yml"

--- a/mrbgems/picoruby-shinonome/mrbgem.rake
+++ b/mrbgems/picoruby-shinonome/mrbgem.rake
@@ -11,7 +11,7 @@ MRuby::Gem::Specification.new('picoruby-shinonome') do |spec|
   directory include_dir
 
   SHINONOME_DIR = File.join(dir, "lib", "shinonome-0.9.11", "bdf")
-  FONTS = [
+  SHINONOME_FONTS = [
     {name: "12",     w:  6, h: 12, src: "shnm6x12a.bdf",   dst: "ascii_12_table.h",     type: :ascii},
     {name: "16",     w:  8, h: 16, src: "shnm8x16a.bdf",   dst: "ascii_16_table.h",     type: :ascii},
     {name: "12maru", w: 12, h: 12, src: "shnmk12maru.bdf", dst: "jis208_12maru_table.h",type: :jis},
@@ -20,7 +20,7 @@ MRuby::Gem::Specification.new('picoruby-shinonome') do |spec|
     {name: "16go",   w: 16, h: 16, src: "shnmk16.bdf",     dst: "jis208_16go_table.h",  type: :jis},
     {name: "16min",  w: 16, h: 16, src: "shnmk16min.bdf",  dst: "jis208_16min_table.h", type: :jis},
   ]
-  FONTS.each do |font|
+  SHINONOME_FONTS.each do |font|
     font[:src] = "#{SHINONOME_DIR}/#{font[:src]}"
     font[:dst] = "#{include_dir}/#{font[:dst]}"
     file font[:dst] => [font[:src], include_dir] do

--- a/mrbgems/picoruby-terminus/mrbgem.rake
+++ b/mrbgems/picoruby-terminus/mrbgem.rake
@@ -10,13 +10,13 @@ MRuby::Gem::Specification.new('picoruby-terminus') do |spec|
   directory include_dir
 
   TERMINUS_DIR = File.join(dir, "lib", "terminus-font-4.49.1")
-  FONTS = [
+  TERMINUS_FONTS = [
     {name: "6x12",   w:  6, h: 12, src: "ter-u12n.bdf", dst: "terminus_6x12_table.h"},
     {name: "8x16",   w:  8, h: 16, src: "ter-u16n.bdf", dst: "terminus_8x16_table.h"},
     {name: "12x24",  w: 12, h: 24, src: "ter-u24n.bdf", dst: "terminus_12x24_table.h"},
     {name: "16x32",  w: 16, h: 32, src: "ter-u32n.bdf", dst: "terminus_16x32_table.h"},
   ]
-  FONTS.each do |font|
+  TERMINUS_FONTS.each do |font|
     font[:src] = "#{TERMINUS_DIR}/#{font[:src]}"
     font[:dst] = "#{include_dir}/#{font[:dst]}"
     file font[:dst] => [font[:src], include_dir] do


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across multiple gems in the PicoRuby project, focusing on dependency management, initialization order, and code organization. The most significant changes include enhancements to how gem dependencies are handled and loaded, particularly for `picoruby-mruby` and `picoruby-require`, as well as refactoring font array definitions in the Shinonome and Terminus gems. Additionally, there are updates to environment setup and load path management in the shell library.

**Dependency and Initialization Improvements**

* The `picoruby-env` gem now uses the `build.vm_mruby?` method to determine if it should add `picoruby-mruby` as a dependency, ensuring proper initialization order for `Kernel#require`.
* The implementation of `Kernel#require` in `picoruby-mruby` has been moved to a new file (`require.rb`) and clarified as a necessary stub to avoid `LoadError` during gem initialization, with a comment explaining its purpose. [[1]](diffhunk://#diff-cb85956f4d7326302e4172a989a18fbe5a6bb4cf7fe33b233ac701534aa58849L1-L5) [[2]](diffhunk://#diff-f6133487a84fac6cf750cd66cabfbf92e35a853315f7c35deddf661dd831d5d0R1-R7)

**Gem Collection and Loading Enhancements**

* The `picoruby-require` gem now collects both `picoruby-*` gems and `mruby-*` gems (stripping the prefix) into separate arrays (`picogems` and `mgems`), and updates the template for `picogem_init.c` to include both sets in the prebuilt gem list. [[1]](diffhunk://#diff-fe5fd10d7cc077ef49a7f99c996e6397ddd05663160139f70ff53b768c6705e2R24) [[2]](diffhunk://#diff-fe5fd10d7cc077ef49a7f99c996e6397ddd05663160139f70ff53b768c6705e2R53-R54) [[3]](diffhunk://#diff-1080bf1d254512a10383f7c24415bd91dc1ea06ab4d7b9d99094df594c3dc019R8-R11)

**Shell Library Environment Setup**

* The shell library now sets `$LOAD_PATH` dynamically within its system setup, replacing the previous static assignment, and ensures environment variables are set correctly for the shell. [[1]](diffhunk://#diff-c1feef03bf864dc9379ab84c8dcb4bd640afe35b7092d43663b3cba51841b28dL1) [[2]](diffhunk://#diff-bba9bf67848b45a075ae08129d2408168199d1146796ace92f6600646c62ac47R102)

**Code Organization and Refactoring**

* Font definitions in the Shinonome and Terminus gems are now stored in arrays with more descriptive names (`SHINONOME_FONTS` and `TERMINUS_FONTS`), improving code clarity and maintainability. [[1]](diffhunk://#diff-34152178beaeda828894cf4e9874723db2487d6b92e8759a9bff4f7ae7892e48L14-R14) [[2]](diffhunk://#diff-34152178beaeda828894cf4e9874723db2487d6b92e8759a9bff4f7ae7892e48L23-R23) [[3]](diffhunk://#diff-9c476e1aac4904007a3d56bb77720c6090daa429fec687b8827659e06734ecdaL13-R19)

**Miscellaneous Cleanup**

* Unused or redundant code has been removed from several files, including the shell's `kernel.rb` and conditional dependency logic in `picoruby-shell`. [[1]](diffhunk://#diff-496e28ad33baed6461c4cd46fe3c8eefd26395a8d4a5eab7a7076c911ca4ab86L6-L9) [[2]](diffhunk://#diff-06ce43b6233a680d64283ae92e3640a7eb1b726211f29d6e14f89ee73cbc93e1L9-L11)
* The `$LOADED_FEATURES` initialization has been moved to a more appropriate location in the require library.