### PR TITLE
Add custom http/https port to client classes

### DIFF
--- a/mrbgems/picoruby-net/mrblib/net.rb
+++ b/mrbgems/picoruby-net/mrblib/net.rb
@@ -112,10 +112,18 @@ module Net
   end
 
   class HTTPClient < HTTPClientBase
+    DEFAULT_HTTP_PORT = 80
+
+    def initialize(host, port = DEFAULT_HTTP_PORT)
+      @port = port
+
+      super(host)
+    end
+
     private
 
     def port
-      80
+      @port
     end
 
     def use_tls
@@ -124,10 +132,18 @@ module Net
   end
 
   class HTTPSClient < HTTPClientBase
+    DEFAULT_HTTPS_PORT = 443
+
+    def initialize(host, port = DEFAULT_HTTPS_PORT)
+      @port = port
+
+      super(host)
+    end
+
     private
 
     def port
-      443
+      @port
     end
 
     def use_tls

--- a/mrbgems/picoruby-net/sig/net.rbs
+++ b/mrbgems/picoruby-net/sig/net.rbs
@@ -38,11 +38,17 @@ module Net
   end
 
   class HTTPClient < HTTPClientBase
+    DEFAULT_HTTP_PORT: Integer
+    @port: Integer
+    def initialize: (String host, Integer port) -> void
     private def port: -> Integer
     private def use_tls: -> bool
   end
 
   class HTTPSClient < HTTPClientBase
+    DEFAULT_HTTPS_PORT: Integer
+    @port: Integer
+    def initialize: (String host, Integer port) -> void
     private def port: -> Integer
     private def use_tls: -> bool
   end

--- a/mrbgems/picoruby-net/test/http_client_test.rb
+++ b/mrbgems/picoruby-net/test/http_client_test.rb
@@ -1,0 +1,25 @@
+class HttpClientTest < Picotest::Test
+  def test_http_default_port
+    client = Net::HTTPClient.new("localhost")
+
+    assert_equal(80, client.send(:port))
+  endl
+
+  def test_https_default_port
+    client = Net::HTTPSClient.new("localhost")
+
+    assert_equal(443, client.send(:port))
+  end
+
+  def test_custom_http_port
+    client = Net::HTTPClient.new("localhost", 8888)
+
+    assert_equal(8888, client.send(:port))
+  end
+
+  def test_custom_https_port
+    client = Net::HTTPSClient.new("localhost", 8443)
+
+    assert_equal(8443, client.send(:port))
+  end
+end


### PR DESCRIPTION
It's common to have services running on custom http/https ports when self-hosting IoT services.

This PR updates both `Net::HTTPClient` and `Net::HTTPSClient` so they accept custom port while defaulting to port 80 for http and 443 for https.