### PR TITLE
Fix inverted logic in IRQ enable/disable methods

### DIFF
--- a/mrbgems/picoruby-irq/mrblib/irq.rb
+++ b/mrbgems/picoruby-irq/mrblib/irq.rb
@@ -72,13 +72,13 @@ module IRQ
 
     def enable
       previous = @enabled
-      @enabled = false
+      @enabled = true
       return previous
     end
 
     def disable
       previous = @enabled
-      @enabled = true
+      @enabled = false
       return previous
     end
 


### PR DESCRIPTION
Fixes a bug where `enable` and `disable` methods had inverted logic, causing opposite behavior from what's documented in the README.

The current implementation has the logic backwards:
- `enable` method sets `@enabled = false`
- `disable` method sets `@enabled = true`

This contradicts the documented behavior in README.md:

```ruby
puts irq_instance.enabled?  # => true
irq_instance.disable
puts irq_instance.enabled?  # => false  # Expected, but was true
irq_instance.enable
puts irq_instance.enabled?  # => true   # Expected, but was false
```