### PR TITLE
Improve picoruby-net

### DIFF
--- a/mrbgems/picoruby-net/include/lwipopts.h
+++ b/mrbgems/picoruby-net/include/lwipopts.h
@@ -88,4 +88,8 @@
 #define LWIP_ALTCP_TLS 1
 #define LWIP_ALTCP_TLS_MBEDTLS 1
 
+#ifndef LWIP_DEBUG
+#define LWIP_DEBUG 1
+#endif
+
 #endif /* __LWIPOPTS_H__ */

--- a/mrbgems/picoruby-net/include/net.h
+++ b/mrbgems/picoruby-net/include/net.h
@@ -32,9 +32,12 @@ typedef struct {
   bool is_tls;
 } net_request_t;
 
+#define NET_ERROR_MESSAGE_SIZE 128
+
 typedef struct {
   char *recv_data;
   size_t recv_data_len;
+  char error_message[NET_ERROR_MESSAGE_SIZE];
 } net_response_t;
 
 void DNS_resolve(const char *name, bool is_tcp, char *outbuf, size_t outlen);

--- a/mrbgems/picoruby-net/src/mruby/net.c
+++ b/mrbgems/picoruby-net/src/mruby/net.c
@@ -38,9 +38,14 @@ mrb_net_tcpclient_s__request_impl(mrb_state *mrb, mrb_value self)
     .recv_data = mrb_calloc(mrb, 1, 1),
     .recv_data_len = 0
   };
+  res.error_message[0] = '\0';
   if (TCPClient_send(mrb, &req, &res)) {
     ret = mrb_str_new(mrb, (const char*)res.recv_data, res.recv_data_len);
   } else {
+    if (res.error_message[0] != '\0') {
+      mrb_free(mrb, res.recv_data);
+      mrb_raise(mrb, E_RUNTIME_ERROR, res.error_message);
+    }
     ret = mrb_nil_value();
   }
   mrb_free(mrb, res.recv_data);
@@ -67,9 +72,14 @@ mrb_net_udpclient_s__send_impl(mrb_state *mrb, mrb_value self)
     .recv_data = mrb_calloc(mrb, 1, 1),
     .recv_data_len = 0
   };
+  res.error_message[0] = '\0';
   if (UDPClient_send(mrb, &req, &res)) {
     ret = mrb_str_new(mrb, (const char*)res.recv_data, res.recv_data_len);
   } else {
+    if (res.error_message[0] != '\0') {
+      mrb_free(mrb, res.recv_data);
+      mrb_raise(mrb, E_RUNTIME_ERROR, res.error_message);
+    }
     ret = mrb_nil_value();
   }
   mrb_free(mrb, res.recv_data);

--- a/mrbgems/picoruby-net/src/mrubyc/net.c
+++ b/mrbgems/picoruby-net/src/mrubyc/net.c
@@ -65,11 +65,17 @@ c_net_tcpclient__request_impl(mrbc_vm *vm, mrbc_value *v, int argc)
     .recv_data = mrbc_raw_calloc(1, 1),
     .recv_data_len = 0
   };
+  res.error_message[0] = '\0';
 
   if (TCPClient_send(vm, &req, &res)) {
     mrb_value ret = mrbc_string_new(vm, res.recv_data, res.recv_data_len);
     SET_RETURN(ret);
   } else {
+    if (res.error_message[0] != '\0') {
+      mrbc_free(vm, res.recv_data);
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), res.error_message);
+      return;
+    }
     SET_NIL_RETURN();
   }
   mrbc_free(vm, res.recv_data);
@@ -114,11 +120,17 @@ c_net_udpclient__send_impl(mrbc_vm *vm, mrbc_value *v, int argc)
     .recv_data = mrbc_raw_calloc(1, 1),
     .recv_data_len = 0
   };
+  res.error_message[0] = '\0';
 
   if (UDPClient_send(vm, &req, &res)) {
     mrb_value ret = mrbc_string_new(vm, res.recv_data, res.recv_data_len);
     SET_RETURN(ret);
   } else {
+    if (res.error_message[0] != '\0') {
+      mrbc_free(vm, res.recv_data);
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), res.error_message);
+      return;
+    }
     SET_NIL_RETURN();
   }
   mrbc_free(vm, res.recv_data);


### PR DESCRIPTION
This pull request improves error handling and reporting in the TCP and UDP networking code by introducing structured error messages that propagate detailed error information from the C layer up to the Ruby layer. It also adds a debug configuration option for LWIP. The most important changes are grouped below.

**Error Handling and Propagation Improvements:**

* Added an `error_message` buffer to the `net_response_t` struct and ensured it is initialized and checked in all relevant places in both TCP and UDP client implementations. Now, when a network error occurs, a descriptive error message is set and raised as a runtime error in Ruby, rather than returning `nil` or logging a warning. [[1]](diffhunk://#diff-019ac5e75895b6a5f18773ce97fcd5d8457b718e3f50bacde9fc566da54ff48dR35-R40) [[2]](diffhunk://#diff-46804e674f8d0a6573cfb810b29e2527bab51992894d19a6d13174f4071df97bR41-R48) [[3]](diffhunk://#diff-46804e674f8d0a6573cfb810b29e2527bab51992894d19a6d13174f4071df97bR75-R82) [[4]](diffhunk://#diff-0a44ffd5a5ba8493d5016b0843b68088f9b9435a4685ad88f702b1d40f971d1fR68-R78) [[5]](diffhunk://#diff-0a44ffd5a5ba8493d5016b0843b68088f9b9435a4685ad88f702b1d40f971d1fR123-R133)
* Updated TCP and UDP C implementations to populate `error_message` with specific error descriptions (e.g., connection failures, memory allocation failures, send/receive errors, timeouts) using `lwip_strerr` for clarity. [[1]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L53-R59) [[2]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L70-R94) [[3]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22R106-R112) [[4]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L117-R144) [[5]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L129-R159) [[6]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L140-R230) [[7]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L207-R251) [[8]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L239-R286) [[9]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L273-R323) [[10]](diffhunk://#diff-1fe0d1db16500ce84809c1d7710d00b2788595fc76665a507cba716752f84307L66-R72) [[11]](diffhunk://#diff-1fe0d1db16500ce84809c1d7710d00b2788595fc76665a507cba716752f84307L83-R93) [[12]](diffhunk://#diff-1fe0d1db16500ce84809c1d7710d00b2788595fc76665a507cba716752f84307L102-R122) [[13]](diffhunk://#diff-1fe0d1db16500ce84809c1d7710d00b2788595fc76665a507cba716752f84307L164-R183)

**Code Structure and Maintenance:**

* Refactored TCP connection state and initialization logic to associate the `net_response_t` with the connection state, enabling all callbacks to access and set error messages directly. [[1]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22R30) [[2]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22L140-R230)
* Added necessary includes (`lwip/err.h`, `<stdio.h>`) in TCP and UDP C source files to support error string formatting and reporting. [[1]](diffhunk://#diff-bc1f2719538e153cd509e6fa40fd32f50144ddea8af560b3ea7f530ba300ff22R4-R5) [[2]](diffhunk://#diff-1fe0d1db16500ce84809c1d7710d00b2788595fc76665a507cba716752f84307R3-R4)
* Added a macro definition to enable LWIP debugging if not already set, making debugging easier in development environments.