### PR TITLE
Add HMAC tests and fix argument order issue in microruby implementation

### DIFF
--- a/mrbgems/picoruby-mbedtls/src/mruby/hmac.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/hmac.c
@@ -14,7 +14,7 @@ mrb_initialize(mrb_state *mrb, mrb_value self)
 {
   const char *algorithm;
   mrb_value key;
-  mrb_get_args(mrb, "zS", &algorithm, &key);
+  mrb_get_args(mrb, "Sz", &key, &algorithm);
 
   if (strcmp(algorithm, "sha256") != 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "unsupported hash algorithm");

--- a/mrbgems/picoruby-mbedtls/test/hmac_test.rb
+++ b/mrbgems/picoruby-mbedtls/test/hmac_test.rb
@@ -1,0 +1,14 @@
+class HmacTest < Picotest::Test
+  def test_hmac_update_digest
+    hmac = MbedTLS::HMAC.new('thisisasecretkey', 'sha256')
+    hmac.update('Hello, World!')
+    hex = hmac.digest.bytes.map { |b| b.to_s(16).rjust(2, '0') }.join
+    assert_equal('4ad891fdfc32ebe14c466c138de6d9ea96129a11a139401f81ef9c0165c43608', hex)
+  end
+
+  def test_hmac_update_hex_digest
+    hmac = MbedTLS::HMAC.new('thisisasecretkey', 'sha256')
+    hmac.update('Hello, World!')
+    assert_equal('4ad891fdfc32ebe14c466c138de6d9ea96129a11a139401f81ef9c0165c43608', hmac.hexdigest)
+  end
+end


### PR DESCRIPTION
### Description:

This pull request adds tests for the HMAC in the picoruby-mbedtls to prepare for future porting to RP2040 and ESP32 platforms.

During the process of adding these tests, an incorrect argument order was found in the HMAC implementation for microruby.
This issue has been corrected in this commit.

### Summary of changes:

- Added test cases for HMAC
- Fixed argument order issue in microruby HMAC implementation

This is an excerpt containing only the commit for HMAC in #277 .
