### PR TITLE
picoruby-irq ESP32 Porting 

### DIFF
--- a/mrbgems/picoruby-irq/ports/esp32/irq.c
+++ b/mrbgems/picoruby-irq/ports/esp32/irq.c
@@ -10,6 +10,13 @@
 #define MAX_IRQ_HANDLERS 16
 #define IRQ_EVENT_QUEUE_SIZE (1<<5)
 
+enum gpio_irq_level {
+  GPIO_IRQ_LEVEL_LOW = 1,
+  GPIO_IRQ_LEVEL_HIGH = 2,
+  GPIO_IRQ_EDGE_FALL = 4,
+  GPIO_IRQ_EDGE_RISE = 8
+};
+
 typedef struct {
   int pin;
   uint32_t event_mask;
@@ -49,10 +56,10 @@ gpio_isr_handler(void* arg)
 
   if (current_level == 0) {
     /* Pin is LOW */
-    if (handler->event_mask & 4) {
-      events = 4;  /* EDGE_FALL */
-    } else if (handler->event_mask & 1) {
-      events = 1;  /* LEVEL_LOW */
+    if (handler->event_mask & GPIO_IRQ_EDGE_FALL) {
+      events = GPIO_IRQ_EDGE_FALL;
+    } else if (handler->event_mask & GPIO_IRQ_LEVEL_LOW) {
+      events = GPIO_IRQ_LEVEL_LOW;
     } else {
       gpio_set_intr_type(handler->pin, GPIO_INTR_HIGH_LEVEL);
       return;
@@ -60,10 +67,10 @@ gpio_isr_handler(void* arg)
     next_intr_type = GPIO_INTR_HIGH_LEVEL;
   } else {
     /* Pin is HIGH */
-    if (handler->event_mask & 8) {
-      events = 8;  /* EDGE_RISE */
-    } else if (handler->event_mask & 2) {
-      events = 2;  /* LEVEL_HIGH */
+    if (handler->event_mask & GPIO_IRQ_EDGE_RISE) {
+      events = GPIO_IRQ_EDGE_RISE;
+    } else if (handler->event_mask & GPIO_IRQ_LEVEL_HIGH) {
+      events = GPIO_IRQ_LEVEL_HIGH;
     } else {
       gpio_set_intr_type(handler->pin, GPIO_INTR_LOW_LEVEL);
       return;


### PR DESCRIPTION
This PR introduces full support for ESP32 to `picoruby-irq`, enabling robust IRQ handling using the ESP-IDF/FreeRTOS environment while preserving the original API.

#  Limitation: ESP32 GPIO Interrupt Triggers and PicoRuby Events

Because each ESP32 pin is limited to a single interrupt trigger setting, the following combinations of EventType are possible:

Trigger Condition | PicoRuby Corresponding Event | gpio_int_type_t (ESP-IDF) | Note
-- | -- | -- | --
Rising Edge | EDGE_RISE | GPIO_INTR_RISING | Interrupt on LOW to HIGH transition.
Falling Edge | EDGE_FALL | GPIO_INTR_FALLING | Interrupt on HIGH to LOW transition.
Any Edge | EDGE_RISE \| EDGE_FALL | GPIO_INTR_ANYEDGE | Interrupt immediately when the state changes.
HIGH Level | LEVEL_HIGH | GPIO_INTR_HIGH_LEVEL | Interrupt continuously while the pin is HIGH.
LOW Level | LEVEL_LOW | GPIO_INTR_LOW_LEVEL | Interrupt continuously while the pin is LOW.


# Demo and Verification

Functionality is confirmed by running [picoruby-irq README.md](https://github.com/picoruby/picoruby/blob/master/mrbgems/picoruby-irq/README.md) usage on [Atom-Matrix](https://docs.m5stack.com/ja/core/ATOM%20Matrix).

https://github.com/user-attachments/assets/ef857460-b797-4d84-9ccd-c992154ba0b7



## code

```ruby
require 'irq'
require 'ws2812'

gpio = GPIO.new(39, GPIO::IN|GPIO::PULL_UP)  # GPIO pin

class Led
  def initialize(pin, count)
    @ws2812 = WS2812.new(RMTDriver.new(pin))
    @colors = Array.new(count)

    neutral!
  end

  def neutral!
    @colors.size.times do |i|
      @colors[i] = [5, 10, 5] 
    end
    @ws2812.show_rgb(*@colors)
  end

  def active!
    @colors.size.times do |i|
      @colors[i] = [50, 5, 5] 
    end
    @ws2812.show_rgb(*@colors)
  end

  def deactive!
    @colors.size.times do |i|
      @colors[i] = [5, 5, 50] 
    end
    @ws2812.show_rgb(*@colors)
  end

  def off!
    @colors.size.times do |i|
      @colors[i] = [0, 0, ] 
    end
    @ws2812.show_rgb(*@colors)
  end
end
led = Led.new(27, 25)

puts "Basic GPIO IRQ"

irq_instance = gpio.irq(GPIO::EDGE_FALL, capture: "My IRQ") do |peripheral, event_type, capture|
  puts "#{capture} -- Button pressed! Event: #{event_type}"
  led.active!
end

30.times do |i|
  puts i if i % 5 == 0
  IRQ.process
  sleep_ms(100)
  led.neutral!
end

puts "IRQ with Debouncing"
irq_instance.unregister

irq_instance = gpio.irq(GPIO::EDGE_FALL, debounce: 50) do |peripheral, event_type|
  puts "Debounced button press detected"
  led.active!
end

30.times do |i|
  puts i if i % 5 == 0
  IRQ.process
  sleep_ms(100)
  led.neutral!
end

puts "Multiple Event Types"

irq_instance = gpio.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE) do |peripheral, event_type, capture|
  case event_type
  when GPIO::EDGE_FALL
    puts "Button pressed"
    led.active!
  when GPIO::EDGE_RISE  
    puts "Button released"
    led.deactive!
  end
end

30.times do |i|
  puts i if i % 5 == 0
  IRQ.process
  sleep_ms(100)
end

puts "Level-Triggered IRQs"
irq_instance.unregister

irq_instance = gpio.irq(GPIO::LEVEL_LOW) do |peripheral, event_type|
  puts "Sensor active"
  led.active!
end

30.times do |i|
  puts i if i % 5 == 0
  IRQ.process 
  sleep_ms(100)
  led.neutral!
end

puts "IRQ Management"

# Check if IRQ is enabled
puts irq_instance.enabled?  # => true

puts "-----------"

# Temporarily disable IRQ
previous_state = irq_instance.disable
puts previous_state # => true
puts irq_instance.enabled?  # => false

puts "-----------"

# Re-enable IRQ
previous_state = irq_instance.enable
puts previous_state # => false
puts irq_instance.enabled?  # => true

puts "Manual Event Processing"
irq_instance.unregister

irq_instance = gpio.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE) do |peripheral, event_type, capture|
  case event_type
  when GPIO::EDGE_FALL
    puts "Button pressed"
    led.active!
  when GPIO::EDGE_RISE  
    puts "Button released"
    led.deactive!
  end
end

5.times do |i|
  puts i if i % 5 == 0
  count = IRQ.process(3)
  puts "Processed #{count} events"
  sleep_ms(1000)
end

led.off!
```