### PR TITLE
Fix comment for IRQ.register_gpio

### DIFF
--- a/mrbgems/picoruby-irq/src/mruby/irq.c
+++ b/mrbgems/picoruby-irq/src/mruby/irq.c
@@ -8,7 +8,7 @@
 #include "../../include/irq.h"
 
 /*
- * IRQ.register_gpio(event_type, opts)
+ * IRQ.register_gpio(pin, event_type, opts)
  */
 static mrb_value
 mrb_s_register_gpio(mrb_state *mrb, mrb_value self)


### PR DESCRIPTION
`IRQ.register_gpio` receives 3 arguments: pin, event_type, opts.
I was a little confused when read this wrong comment, so fixed.