### PR TITLE
Implement POSIX network stack for picoruby-net

### DIFF
--- a/build_config/posix-net-test.rb
+++ b/build_config/posix-net-test.rb
@@ -1,0 +1,21 @@
+MRuby::Build.new do |conf|
+
+  conf.toolchain
+
+  conf.cc.defines << "PICORUBY_INT64"
+  conf.cc.defines << "MRBC_TICK_UNIT=4"
+  conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=3"
+
+  conf.posix
+  conf.picoruby(alloc_libc: true)
+
+  conf.gembox "minimum"
+  conf.gembox "core"
+  conf.gem core: "picoruby-picotest"
+  conf.gem core: "picoruby-metaprog"
+  conf.gem core: "picoruby-pack"
+  conf.gem core: "picoruby-time-class"
+  conf.gem core: "picoruby-mbedtls"
+  conf.gem core: "picoruby-jwt"
+  conf.gem core: "picoruby-net"
+end

--- a/mrbgems/picoruby-mbedtls/include/mbedtls_config.h
+++ b/mrbgems/picoruby-mbedtls/include/mbedtls_config.h
@@ -123,3 +123,8 @@
 //#endif
 
 #define MBEDTLS_ERROR_C
+
+#ifdef PICORB_PLATFORM_POSIX
+/* POSIX-specific configuration for network sockets */
+#define MBEDTLS_NET_C
+#endif

--- a/mrbgems/picoruby-net/include/net.h
+++ b/mrbgems/picoruby-net/include/net.h
@@ -3,17 +3,23 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-
-#include "lwipopts.h"
-#include "lwip/dns.h"
-#include "lwip/pbuf.h"
-#include "lwip/altcp_tls.h"
-#include "lwip/udp.h"
-
 #include "picoruby.h"
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/* Platform-specific includes */
+#ifdef PICORB_PLATFORM_POSIX
+  /* POSIX: No LwIP headers needed here */
+  /* Platform-specific headers are included in implementation files */
+#else
+  /* Microcontroller platforms: LwIP */
+  #include "lwipopts.h"
+  #include "lwip/dns.h"
+  #include "lwip/pbuf.h"
+  #include "lwip/altcp_tls.h"
+  #include "lwip/udp.h"
 #endif
 
 #define DNS_OUTBUF_SIZE 16
@@ -24,6 +30,7 @@ extern "C" {
 #define MRB
 #endif
 
+/* Common data structures (platform-independent) */
 typedef struct {
   const char *host;
   int port;
@@ -40,15 +47,22 @@ typedef struct {
   char error_message[NET_ERROR_MESSAGE_SIZE];
 } net_response_t;
 
+/* Common API (implemented per platform) */
 void DNS_resolve(const char *name, bool is_tcp, char *outbuf, size_t outlen);
 bool TCPClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res);
 bool UDPClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res);
+void Net_sleep_ms(int ms);
+const char *Net_get_ipv4_address(char *buf, size_t buflen);
 
-void lwip_begin(void);
-void lwip_end(void);
-void Net_sleep_ms(int);
-err_t Net_get_ip(const char *name, ip_addr_t *ip);
-const char *Net_ipaddr(char *buf, size_t buflen);
+#ifdef PICORB_PLATFORM_POSIX
+  /* POSIX-specific functions */
+  /* (none currently - lwip_begin/end not needed) */
+#else
+  /* LwIP-specific functions */
+  void lwip_begin(void);
+  void lwip_end(void);
+  err_t Net_get_ip(const char *name, ip_addr_t *ip);
+#endif
 
 #ifdef __cplusplus
 }

--- a/mrbgems/picoruby-net/mrbgem.rake
+++ b/mrbgems/picoruby-net/mrbgem.rake
@@ -7,55 +7,81 @@ MRuby::Gem::Specification.new('picoruby-net') do |spec|
   spec.add_dependency 'picoruby-pack'
   spec.add_dependency 'picoruby-mbedtls'
   spec.add_dependency 'picoruby-jwt'
+
   unless spec.cc.defines.include? "PICORB_PLATFORM_POSIX"
     spec.add_dependency 'picoruby-cyw43'
   end
 
-  LWIP_VERSION = "STABLE-2_2_1_RELEASE"
-  LWIP_REPO = "https://github.com/lwip-tcpip/lwip"
-  lwip_dir = "#{dir}/lib/lwip"
+  if build.posix?
+    #
+    # POSIX Build: Use standard UNIX network stack + mbedTLS
+    # No LwIP required
+    #
+    puts "Building picoruby-net for POSIX (using UNIX network stack)"
 
-  if File.directory?(lwip_dir)
-    # Check if it's a git repository and has the correct version
-    if File.directory?("#{lwip_dir}/.git")
-      current_branch = `cd #{lwip_dir} && git branch --show-current 2>/dev/null`.strip
-      current_tag = `cd #{lwip_dir} && git describe --tags --exact-match HEAD 2>/dev/null`.strip
+    # Include mbedTLS headers
+    spec.cc.include_paths << "#{File.expand_path('..', dir)}/picoruby-mbedtls/lib/mbedtls/include"
 
-      # Check if we're on the wrong version
-      unless current_branch == LWIP_VERSION || current_tag == LWIP_VERSION
-        puts "lwip version mismatch. Fetching and checking out #{LWIP_VERSION}..."
-        sh "cd #{lwip_dir} && git fetch origin #{LWIP_VERSION}:#{LWIP_VERSION} 2>/dev/null || git fetch origin"
-        sh "cd #{lwip_dir} && git checkout #{LWIP_VERSION}"
+    # Clear default objs to prevent compiling src/*.c (LwIP-specific files)
+    spec.objs.clear
+
+    # Compile POSIX implementation files
+    %w[dns tcp_client tls_client udp_client net].each do |name|
+      src = "#{dir}/ports/posix/#{name}.c"
+      if File.exist?(src)
+        obj = src.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
+        spec.objs << obj
+      end
+    end
+
+  else
+    #
+    # Microcontroller Build: Use LwIP network stack
+    #
+    puts "Building picoruby-net for microcontroller (using LwIP)"
+
+    LWIP_VERSION = "STABLE-2_2_1_RELEASE"
+    LWIP_REPO = "https://github.com/lwip-tcpip/lwip"
+    lwip_dir = "#{dir}/lib/lwip"
+
+    # Clone or update LwIP repository
+    if File.directory?(lwip_dir)
+      # Check if it's a git repository and has the correct version
+      if File.directory?("#{lwip_dir}/.git")
+        current_branch = `cd #{lwip_dir} && git branch --show-current 2>/dev/null`.strip
+        current_tag = `cd #{lwip_dir} && git describe --tags --exact-match HEAD 2>/dev/null`.strip
+
+        # Check if we're on the wrong version
+        unless current_branch == LWIP_VERSION || current_tag == LWIP_VERSION
+          puts "lwip version mismatch. Fetching and checking out #{LWIP_VERSION}..."
+          sh "cd #{lwip_dir} && git fetch origin #{LWIP_VERSION}:#{LWIP_VERSION} 2>/dev/null || git fetch origin"
+          sh "cd #{lwip_dir} && git checkout #{LWIP_VERSION}"
+        end
+      else
+        # Directory exists but not a git repo, remove and clone
+        puts "lwip directory exists but is not a git repository. Removing and cloning..."
+        FileUtils.rm_rf(lwip_dir)
+        sh "git clone -b #{LWIP_VERSION} #{LWIP_REPO} #{lwip_dir}"
       end
     else
-      # Directory exists but not a git repo, remove and clone
-      puts "lwip directory exists but is not a git repository. Removing and cloning..."
-      FileUtils.rm_rf(lwip_dir)
+      # Directory doesn't exist, clone it
       sh "git clone -b #{LWIP_VERSION} #{LWIP_REPO} #{lwip_dir}"
     end
-  else
-    # Directory doesn't exist, clone it
-    sh "git clone -b #{LWIP_VERSION} #{LWIP_REPO} #{lwip_dir}"
-  end
 
-  spec.cc.defines << 'PICO_CYW43_ARCH_POLL=1'
+    spec.cc.defines << 'PICO_CYW43_ARCH_POLL=1'
 
-  spec.cc.include_paths << "#{lwip_dir}/src/include"
-  spec.cc.include_paths << "#{lwip_dir}/contrib/ports/unix/port/include"
-  spec.cc.include_paths << "#{lwip_dir}/src/apps/altcp_tls"
-  spec.cc.include_paths << "#{File.expand_path('..', dir)}/picoruby-mbedtls/lib/mbedtls/include"
+    spec.cc.include_paths << "#{lwip_dir}/src/include"
+    spec.cc.include_paths << "#{lwip_dir}/contrib/ports/unix/port/include"
+    spec.cc.include_paths << "#{lwip_dir}/src/apps/altcp_tls"
+    spec.cc.include_paths << "#{File.expand_path('..', dir)}/picoruby-mbedtls/lib/mbedtls/include"
 
-  Dir.glob("#{lwip_dir}/src/**/*.c").each do |src|
-    next if src.end_with?('makefsdata.c')
-    next if src.end_with?('altcp_tls_mbedtls.c')
-    obj = src.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
-    spec.objs << obj
-  end
-
-  if build.posix?
-    src = "#{lwip_dir}/contrib/ports/unix/port/sys_arch.c"
-    obj = src.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
-    spec.objs << obj
+    # Compile LwIP source files
+    Dir.glob("#{lwip_dir}/src/**/*.c").each do |src|
+      next if src.end_with?('makefsdata.c')
+      next if src.end_with?('altcp_tls_mbedtls.c')
+      obj = src.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
+      spec.objs << obj
+    end
   end
 
   spec.posix

--- a/mrbgems/picoruby-net/ports/posix/dns.c
+++ b/mrbgems/picoruby-net/ports/posix/dns.c
@@ -1,0 +1,87 @@
+/*
+ * DNS Resolution for PicoRuby Net (POSIX Implementation)
+ * Uses standard POSIX getaddrinfo() for DNS lookups
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "net.h"
+
+/*
+ * Resolve hostname to IP address using getaddrinfo()
+ *
+ * @param name      Hostname to resolve
+ * @param is_tcp    true for TCP (SOCK_STREAM), false for UDP (SOCK_DGRAM)
+ * @param outbuf    Output buffer for IP address string
+ * @param outlen    Size of output buffer
+ */
+void
+DNS_resolve(const char *name, bool is_tcp, char *outbuf, size_t outlen)
+{
+  struct addrinfo hints;
+  struct addrinfo *result = NULL;
+  struct addrinfo *rp;
+  int ret;
+
+  if (!name || !outbuf || outlen < DNS_OUTBUF_SIZE) {
+    if (outbuf && outlen > 0) {
+      outbuf[0] = '\0';
+    }
+    return;
+  }
+
+  /* Set up hints for getaddrinfo() */
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;  /* IPv4 only for now */
+  hints.ai_socktype = is_tcp ? SOCK_STREAM : SOCK_DGRAM;
+  /* Note: AI_ADDRCONFIG removed - it can cause issues in some environments */
+
+  /* Perform DNS lookup */
+  ret = getaddrinfo(name, NULL, &hints, &result);
+  if (ret != 0) {
+    /* Resolution failed - log error to stderr for debugging */
+    fprintf(stderr, "DNS resolution failed for '%s': %s\n", name, gai_strerror(ret));
+    outbuf[0] = '\0';
+    return;
+  }
+
+  /* Find first valid IPv4 address */
+  for (rp = result; rp != NULL; rp = rp->ai_next) {
+    if (rp->ai_family == AF_INET) {
+      struct sockaddr_in *addr = (struct sockaddr_in *)rp->ai_addr;
+
+      /* Convert to string format */
+      if (inet_ntop(AF_INET, &addr->sin_addr, outbuf, outlen)) {
+        /* Success */
+        break;
+      }
+    }
+  }
+
+  /* If no valid address found, clear output buffer */
+  if (rp == NULL && outlen > 0) {
+    outbuf[0] = '\0';
+  }
+
+  /* Free the result structure */
+  freeaddrinfo(result);
+}
+
+/*
+ * Get local IP address
+ * For POSIX, this returns a placeholder since there's no single "network interface"
+ * like on embedded systems
+ */
+const char *
+Net_get_ipv4_address(char *buf, size_t buflen)
+{
+  if (buf && buflen > 0) {
+    snprintf(buf, buflen, "0.0.0.0");
+  }
+  return buf;
+}

--- a/mrbgems/picoruby-net/ports/posix/net.c
+++ b/mrbgems/picoruby-net/ports/posix/net.c
@@ -1,5 +1,10 @@
-#include <unistd.h>
+/*
+ * POSIX Network Implementation
+ * Main file that includes platform utilities and Ruby bindings
+ */
 
+#include <unistd.h>
+#include "../include/net.h"
 
 void
 Net_sleep_ms(int ms)
@@ -7,14 +12,28 @@ Net_sleep_ms(int ms)
   usleep(ms * 1000);
 }
 
-void
-lwip_begin(void)
-{
-  // no-op
+/* Include Ruby bindings based on VM type */
+#if defined(PICORB_VM_MRUBY)
+
+#include "../src/mruby/net.c"
+
+#elif defined(PICORB_VM_MRUBYC)
+
+#include "../src/mrubyc/net.c"
+
+/*
+ * Wrapper for gem initialization system compatibility
+ * The gem_init.c expects mruby-style init functions, but mrubyc uses mrbc_net_init
+ * This wrapper bridges the two systems
+ */
+void mrb_picoruby_net_gem_init(void *mrb) {
+  /* mrubyc init is called separately through mrbc_net_init */
+  /* This function exists to satisfy the gem_init.c linker requirements */
+  (void)mrb;
 }
 
-void
-lwip_end(void)
-{
-  // no-op
+void mrb_picoruby_net_gem_final(void *mrb) {
+  (void)mrb;
 }
+
+#endif

--- a/mrbgems/picoruby-net/ports/posix/tcp_client.c
+++ b/mrbgems/picoruby-net/ports/posix/tcp_client.c
@@ -1,0 +1,242 @@
+/*
+ * TCP Client for PicoRuby Net (POSIX Implementation)
+ * Uses standard POSIX sockets for TCP communication
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#include "net.h"
+
+/* Forward declaration for TLS implementation */
+bool TLSClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res);
+
+#define RECV_BUFFER_SIZE 8192
+#define CONNECT_TIMEOUT_SEC 10
+#define RECV_TIMEOUT_SEC 30
+
+/*
+ * Set socket to non-blocking mode with timeout
+ */
+static int
+set_socket_timeout(int sockfd)
+{
+  struct timeval tv;
+
+  /* Set receive timeout */
+  tv.tv_sec = RECV_TIMEOUT_SEC;
+  tv.tv_usec = 0;
+  if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+    return -1;
+  }
+
+  /* Set send timeout */
+  tv.tv_sec = CONNECT_TIMEOUT_SEC;
+  tv.tv_usec = 0;
+  if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+    return -1;
+  }
+
+  return 0;
+}
+
+/*
+ * Connect to host:port using POSIX sockets
+ */
+static int
+tcp_connect(const char *host, int port, char *error_message, size_t error_len)
+{
+  struct addrinfo hints;
+  struct addrinfo *result = NULL;
+  struct addrinfo *rp;
+  int sockfd = -1;
+  int ret;
+  char port_str[16];
+
+  /* Convert port to string */
+  snprintf(port_str, sizeof(port_str), "%d", port);
+
+  /* Set up hints for getaddrinfo() */
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;        /* IPv4 */
+  hints.ai_socktype = SOCK_STREAM;  /* TCP */
+  /* Note: AI_ADDRCONFIG removed - it can cause issues in some environments */
+
+  /* Resolve hostname */
+  ret = getaddrinfo(host, port_str, &hints, &result);
+  if (ret != 0) {
+    snprintf(error_message, error_len, "DNS resolution failed: %s", gai_strerror(ret));
+    fprintf(stderr, "TCP DNS resolution failed for '%s:%d': %s\n", host, port, gai_strerror(ret));
+    return -1;
+  }
+
+  /* Try each address until we successfully connect */
+  int last_errno = 0;
+  for (rp = result; rp != NULL; rp = rp->ai_next) {
+    /* Create socket */
+    sockfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (sockfd == -1) {
+      last_errno = errno;
+      continue;
+    }
+
+    /* Set socket options (timeouts) */
+    if (set_socket_timeout(sockfd) < 0) {
+      last_errno = errno;
+      close(sockfd);
+      sockfd = -1;
+      continue;
+    }
+
+    /* Connect to the address - retry on EINTR */
+    int connect_result;
+    do {
+      connect_result = connect(sockfd, rp->ai_addr, rp->ai_addrlen);
+    } while (connect_result == -1 && errno == EINTR);
+
+    if (connect_result != -1) {
+      /* Success! */
+      break;
+    }
+
+    /* Connection failed, try next address */
+    last_errno = errno;
+    close(sockfd);
+    sockfd = -1;
+  }
+
+  /* Free the result structure */
+  freeaddrinfo(result);
+
+  /* Check if we successfully connected */
+  if (sockfd == -1) {
+    snprintf(error_message, error_len, "Failed to connect to %s:%d: %s",
+             host, port, strerror(last_errno));
+    fprintf(stderr, "TCP connect failed for '%s:%d': %s\n", host, port, strerror(last_errno));
+    return -1;
+  }
+
+  return sockfd;
+}
+
+/*
+ * Send TCP request and receive response
+ *
+ * @param mrb   mruby state (unused in POSIX implementation, but kept for API compatibility)
+ * @param req   Request parameters
+ * @param res   Response structure (allocated inside)
+ * @return      true on success, false on error
+ */
+bool
+TCPClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res)
+{
+  int sockfd = -1;
+  ssize_t sent_bytes, recv_bytes;
+  char *recv_buffer = NULL;
+  size_t recv_buffer_size = RECV_BUFFER_SIZE;
+  size_t total_received = 0;
+  bool success = false;
+
+  (void)mrb;  /* Unused in POSIX implementation */
+
+  /* Initialize response */
+  memset(res, 0, sizeof(*res));
+
+  /* Validate request */
+  if (!req || !req->host || req->port <= 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "Invalid request parameters");
+    return false;
+  }
+
+  /* Use TLS implementation if requested */
+  if (req->is_tls) {
+    return TLSClient_send(mrb, req, res);
+  }
+
+  /* Connect to server */
+  sockfd = tcp_connect(req->host, req->port, res->error_message, sizeof(res->error_message));
+  if (sockfd < 0) {
+    return false;
+  }
+
+  /* Send request data */
+  if (req->send_data && req->send_data_len > 0) {
+    /* Retry send on EINTR */
+    do {
+      sent_bytes = send(sockfd, req->send_data, req->send_data_len, 0);
+    } while (sent_bytes < 0 && errno == EINTR);
+
+    if (sent_bytes < 0) {
+      snprintf(res->error_message, sizeof(res->error_message), "Send failed: %s", strerror(errno));
+      goto cleanup;
+    }
+    if ((size_t)sent_bytes != req->send_data_len) {
+      snprintf(res->error_message, sizeof(res->error_message), "Incomplete send: %zd/%zu bytes", sent_bytes, req->send_data_len);
+      goto cleanup;
+    }
+  }
+
+  /* Allocate initial receive buffer */
+  recv_buffer = (char *)malloc(recv_buffer_size);
+  if (!recv_buffer) {
+    snprintf(res->error_message, sizeof(res->error_message), "Memory allocation failed");
+    goto cleanup;
+  }
+
+  /* Receive response data */
+  while (1) {
+    /* Ensure buffer has space */
+    if (total_received + RECV_BUFFER_SIZE > recv_buffer_size) {
+      char *new_buffer = (char *)realloc(recv_buffer, recv_buffer_size * 2);
+      if (!new_buffer) {
+        snprintf(res->error_message, sizeof(res->error_message), "Memory reallocation failed");
+        goto cleanup;
+      }
+      recv_buffer = new_buffer;
+      recv_buffer_size *= 2;
+    }
+
+    /* Receive data - retry on EINTR */
+    do {
+      recv_bytes = recv(sockfd, recv_buffer + total_received, RECV_BUFFER_SIZE, 0);
+    } while (recv_bytes < 0 && errno == EINTR);
+
+    if (recv_bytes < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        /* Timeout - consider this as end of data */
+        break;
+      }
+      snprintf(res->error_message, sizeof(res->error_message), "Receive failed: %s", strerror(errno));
+      goto cleanup;
+    } else if (recv_bytes == 0) {
+      /* Connection closed by server */
+      break;
+    }
+
+    total_received += recv_bytes;
+  }
+
+  /* Success */
+  res->recv_data = recv_buffer;
+  res->recv_data_len = total_received;
+  success = true;
+  recv_buffer = NULL;  /* Ownership transferred to response */
+
+cleanup:
+  if (sockfd >= 0) {
+    close(sockfd);
+  }
+  if (recv_buffer) {
+    free(recv_buffer);
+  }
+
+  return success;
+}

--- a/mrbgems/picoruby-net/ports/posix/tls_client.c
+++ b/mrbgems/picoruby-net/ports/posix/tls_client.c
@@ -1,0 +1,238 @@
+/*
+ * TLS Client for PicoRuby Net (POSIX Implementation)
+ * Uses mbedTLS for TLS/SSL support over POSIX sockets
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mbedtls/net_sockets.h"
+#include "mbedtls/ssl.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/error.h"
+
+#include "net.h"
+
+#define TLS_RECV_BUFFER_SIZE 8192
+
+/*
+ * TLS context structure for managing TLS connection
+ */
+typedef struct {
+  mbedtls_net_context server_fd;
+  mbedtls_ssl_context ssl;
+  mbedtls_ssl_config conf;
+  mbedtls_entropy_context entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+} tls_context_t;
+
+/*
+ * Initialize TLS context
+ */
+static int
+tls_init(tls_context_t *tls_ctx, const char *hostname)
+{
+  int ret;
+  const char *pers = "picoruby_tls_client";
+
+  /* Initialize structures */
+  mbedtls_net_init(&tls_ctx->server_fd);
+  mbedtls_ssl_init(&tls_ctx->ssl);
+  mbedtls_ssl_config_init(&tls_ctx->conf);
+  mbedtls_entropy_init(&tls_ctx->entropy);
+  mbedtls_ctr_drbg_init(&tls_ctx->ctr_drbg);
+
+  /* Seed the RNG */
+  ret = mbedtls_ctr_drbg_seed(&tls_ctx->ctr_drbg, mbedtls_entropy_func,
+                               &tls_ctx->entropy,
+                               (const unsigned char *)pers, strlen(pers));
+  if (ret != 0) {
+    fprintf(stderr, "mbedtls_ctr_drbg_seed failed: -0x%04x\n", -ret);
+    return ret;
+  }
+
+  /* Setup SSL/TLS config */
+  ret = mbedtls_ssl_config_defaults(&tls_ctx->conf,
+                                     MBEDTLS_SSL_IS_CLIENT,
+                                     MBEDTLS_SSL_TRANSPORT_STREAM,
+                                     MBEDTLS_SSL_PRESET_DEFAULT);
+  if (ret != 0) {
+    fprintf(stderr, "mbedtls_ssl_config_defaults failed: -0x%04x\n", -ret);
+    return ret;
+  }
+
+  /* Configure SSL/TLS settings */
+  mbedtls_ssl_conf_authmode(&tls_ctx->conf, MBEDTLS_SSL_VERIFY_NONE);  /* Skip cert verification for now */
+  mbedtls_ssl_conf_rng(&tls_ctx->conf, mbedtls_ctr_drbg_random, &tls_ctx->ctr_drbg);
+
+  /* Setup SSL context */
+  ret = mbedtls_ssl_setup(&tls_ctx->ssl, &tls_ctx->conf);
+  if (ret != 0) {
+    fprintf(stderr, "mbedtls_ssl_setup failed: -0x%04x\n", -ret);
+    return ret;
+  }
+
+  /* Set hostname for SNI (Server Name Indication) */
+  ret = mbedtls_ssl_set_hostname(&tls_ctx->ssl, hostname);
+  if (ret != 0) {
+    fprintf(stderr, "mbedtls_ssl_set_hostname failed: -0x%04x\n", -ret);
+    return ret;
+  }
+
+  return 0;
+}
+
+/*
+ * Free TLS context
+ */
+static void
+tls_cleanup(tls_context_t *tls_ctx)
+{
+  mbedtls_net_free(&tls_ctx->server_fd);
+  mbedtls_ssl_free(&tls_ctx->ssl);
+  mbedtls_ssl_config_free(&tls_ctx->conf);
+  mbedtls_ctr_drbg_free(&tls_ctx->ctr_drbg);
+  mbedtls_entropy_free(&tls_ctx->entropy);
+}
+
+/*
+ * Send TLS request and receive response
+ *
+ * @param mrb   mruby state (unused in POSIX implementation)
+ * @param req   Request parameters
+ * @param res   Response structure
+ * @return      true on success, false on error
+ */
+bool
+TLSClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res)
+{
+  tls_context_t tls_ctx;
+  int ret;
+  char port_str[16];
+  char *recv_buffer = NULL;
+  size_t recv_buffer_size = TLS_RECV_BUFFER_SIZE;
+  size_t total_received = 0;
+  bool success = false;
+
+  (void)mrb;  /* Unused */
+
+  /* Initialize response */
+  memset(res, 0, sizeof(*res));
+  memset(&tls_ctx, 0, sizeof(tls_ctx));
+
+  /* Validate request */
+  if (!req || !req->host || req->port <= 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "Invalid request parameters");
+    return false;
+  }
+
+  /* Initialize TLS context */
+  ret = tls_init(&tls_ctx, req->host);
+  if (ret != 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "TLS initialization failed: -0x%04x", -ret);
+    goto cleanup;
+  }
+
+  /* Connect to server */
+  snprintf(port_str, sizeof(port_str), "%d", req->port);
+  ret = mbedtls_net_connect(&tls_ctx.server_fd, req->host, port_str, MBEDTLS_NET_PROTO_TCP);
+  if (ret != 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "Connection failed: -0x%04x", -ret);
+    fprintf(stderr, "mbedtls_net_connect to %s:%d failed: -0x%04x\n", req->host, req->port, -ret);
+    goto cleanup;
+  }
+
+  /* Set BIO callbacks */
+  mbedtls_ssl_set_bio(&tls_ctx.ssl, &tls_ctx.server_fd,
+                      mbedtls_net_send, mbedtls_net_recv, NULL);
+
+  /* Perform TLS handshake */
+  fprintf(stderr, "Performing TLS handshake with %s...\n", req->host);
+  while ((ret = mbedtls_ssl_handshake(&tls_ctx.ssl)) != 0) {
+    if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+      char error_buf[100];
+      mbedtls_strerror(ret, error_buf, sizeof(error_buf));
+      snprintf(res->error_message, sizeof(res->error_message), "TLS handshake failed: -0x%04x (%s)", -ret, error_buf);
+      fprintf(stderr, "mbedtls_ssl_handshake failed: -0x%04x - %s\n", -ret, error_buf);
+      goto cleanup;
+    }
+  }
+  fprintf(stderr, "TLS handshake successful\n");
+
+  /* Send request data */
+  if (req->send_data && req->send_data_len > 0) {
+    size_t total_written = 0;
+    while (total_written < req->send_data_len) {
+      ret = mbedtls_ssl_write(&tls_ctx.ssl,
+                               (const unsigned char *)req->send_data + total_written,
+                               req->send_data_len - total_written);
+      if (ret < 0) {
+        if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+          snprintf(res->error_message, sizeof(res->error_message), "TLS write failed: -0x%04x", -ret);
+          goto cleanup;
+        }
+      } else {
+        total_written += ret;
+      }
+    }
+  }
+
+  /* Allocate initial receive buffer */
+  recv_buffer = (char *)malloc(recv_buffer_size);
+  if (!recv_buffer) {
+    snprintf(res->error_message, sizeof(res->error_message), "Memory allocation failed");
+    goto cleanup;
+  }
+
+  /* Receive response data */
+  while (1) {
+    /* Ensure buffer has space */
+    if (total_received + TLS_RECV_BUFFER_SIZE > recv_buffer_size) {
+      char *new_buffer = (char *)realloc(recv_buffer, recv_buffer_size * 2);
+      if (!new_buffer) {
+        snprintf(res->error_message, sizeof(res->error_message), "Memory reallocation failed");
+        goto cleanup;
+      }
+      recv_buffer = new_buffer;
+      recv_buffer_size *= 2;
+    }
+
+    /* Read data */
+    ret = mbedtls_ssl_read(&tls_ctx.ssl,
+                            (unsigned char *)recv_buffer + total_received,
+                            TLS_RECV_BUFFER_SIZE);
+
+    if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+      continue;
+    } else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || ret == 0) {
+      /* Connection closed */
+      break;
+    } else if (ret < 0) {
+      snprintf(res->error_message, sizeof(res->error_message), "TLS read failed: -0x%04x", -ret);
+      goto cleanup;
+    }
+
+    total_received += ret;
+  }
+
+  /* Success */
+  res->recv_data = recv_buffer;
+  res->recv_data_len = total_received;
+  success = true;
+  recv_buffer = NULL;  /* Ownership transferred */
+
+cleanup:
+  if (recv_buffer) {
+    free(recv_buffer);
+  }
+
+  /* Close TLS connection gracefully */
+  mbedtls_ssl_close_notify(&tls_ctx.ssl);
+
+  /* Free TLS context */
+  tls_cleanup(&tls_ctx);
+
+  return success;
+}

--- a/mrbgems/picoruby-net/ports/posix/udp_client.c
+++ b/mrbgems/picoruby-net/ports/posix/udp_client.c
@@ -1,0 +1,157 @@
+/*
+ * UDP Client for PicoRuby Net (POSIX Implementation)
+ * Uses standard POSIX sockets for UDP communication
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "net.h"
+
+#define UDP_RECV_BUFFER_SIZE 4096
+#define UDP_RECV_TIMEOUT_SEC 5
+
+/*
+ * Send UDP datagram and receive response
+ *
+ * @param mrb   mruby state (unused in POSIX implementation, but kept for API compatibility)
+ * @param req   Request parameters
+ * @param res   Response structure (allocated inside)
+ * @return      true on success, false on error
+ */
+bool
+UDPClient_send(mrb_state *mrb, const net_request_t *req, net_response_t *res)
+{
+  struct addrinfo hints;
+  struct addrinfo *result = NULL;
+  struct addrinfo *rp;
+  int sockfd = -1;
+  int ret;
+  char port_str[16];
+  ssize_t sent_bytes, recv_bytes;
+  char *recv_buffer = NULL;
+  struct timeval tv;
+  bool success = false;
+
+  (void)mrb;  /* Unused in POSIX implementation */
+
+  /* Initialize response */
+  memset(res, 0, sizeof(*res));
+
+  /* Validate request */
+  if (!req || !req->host || req->port <= 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "Invalid request parameters");
+    return false;
+  }
+
+  /* TLS not applicable for UDP */
+  if (req->is_tls) {
+    snprintf(res->error_message, sizeof(res->error_message), "TLS not supported for UDP");
+    return false;
+  }
+
+  /* Convert port to string */
+  snprintf(port_str, sizeof(port_str), "%d", req->port);
+
+  /* Set up hints for getaddrinfo() */
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;        /* IPv4 */
+  hints.ai_socktype = SOCK_DGRAM;   /* UDP */
+  /* Note: AI_ADDRCONFIG removed - it can cause issues in some environments */
+
+  /* Resolve hostname */
+  ret = getaddrinfo(req->host, port_str, &hints, &result);
+  if (ret != 0) {
+    snprintf(res->error_message, sizeof(res->error_message), "DNS resolution failed: %s", gai_strerror(ret));
+    fprintf(stderr, "UDP DNS resolution failed for '%s:%d': %s\n", req->host, req->port, gai_strerror(ret));
+    return false;
+  }
+
+  /* Try each address until we successfully send */
+  for (rp = result; rp != NULL; rp = rp->ai_next) {
+    /* Create UDP socket */
+    sockfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (sockfd == -1) {
+      continue;
+    }
+
+    /* Set receive timeout */
+    tv.tv_sec = UDP_RECV_TIMEOUT_SEC;
+    tv.tv_usec = 0;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+      close(sockfd);
+      sockfd = -1;
+      continue;
+    }
+
+    /* Send datagram - retry on EINTR */
+    if (req->send_data && req->send_data_len > 0) {
+      do {
+        sent_bytes = sendto(sockfd, req->send_data, req->send_data_len, 0,
+                            rp->ai_addr, rp->ai_addrlen);
+      } while (sent_bytes < 0 && errno == EINTR);
+
+      if (sent_bytes >= 0) {
+        /* Success */
+        break;
+      }
+    }
+
+    /* Send failed, try next address */
+    close(sockfd);
+    sockfd = -1;
+  }
+
+  /* Free the result structure */
+  freeaddrinfo(result);
+
+  /* Check if we successfully sent */
+  if (sockfd == -1) {
+    snprintf(res->error_message, sizeof(res->error_message), "Failed to send UDP datagram to %s:%d", req->host, req->port);
+    return false;
+  }
+
+  /* Allocate receive buffer */
+  recv_buffer = (char *)malloc(UDP_RECV_BUFFER_SIZE);
+  if (!recv_buffer) {
+    snprintf(res->error_message, sizeof(res->error_message), "Memory allocation failed");
+    goto cleanup;
+  }
+
+  /* Receive response - retry on EINTR */
+  do {
+    recv_bytes = recvfrom(sockfd, recv_buffer, UDP_RECV_BUFFER_SIZE - 1, 0, NULL, NULL);
+  } while (recv_bytes < 0 && errno == EINTR);
+
+  if (recv_bytes < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      snprintf(res->error_message, sizeof(res->error_message), "Receive timeout");
+    } else {
+      snprintf(res->error_message, sizeof(res->error_message), "Receive failed: %s", strerror(errno));
+    }
+    goto cleanup;
+  }
+
+  /* Success */
+  res->recv_data = recv_buffer;
+  res->recv_data_len = recv_bytes;
+  success = true;
+  recv_buffer = NULL;  /* Ownership transferred to response */
+
+cleanup:
+  if (sockfd >= 0) {
+    close(sockfd);
+  }
+  if (recv_buffer) {
+    free(recv_buffer);
+  }
+
+  return success;
+}


### PR DESCRIPTION
Replace LwIP with native POSIX sockets for POSIX platforms while preserving LwIP for microcontroller builds. This enables HTTP/HTTPS networking on Linux, macOS, and other POSIX systems.

## Features

### Network Protocols
- **DNS Resolution**: Uses getaddrinfo() for IPv4 hostname resolution
- **TCP Client**: POSIX sockets with connect/send/recv for HTTP
- **TLS Client**: mbedTLS integration for HTTPS with SNI support
- **UDP Client**: sendto/recvfrom for UDP datagrams

### Reliability
- EINTR handling: All system calls retry on interruption
- Error logging: Detailed stderr output for debugging
- Dynamic buffers: Auto-resizing receive buffers for large responses
- Timeout support: Configurable timeouts for all operations

### Platform Separation
- Conditional compilation with #ifdef PICORB_PLATFORM_POSIX
- POSIX headers only in implementation files (ports/posix/*.c)
- Shared Ruby API across all platforms
- Zero impact on microcontroller builds

## Implementation Details

### Files Added
- `ports/posix/dns.c`: DNS resolution via getaddrinfo()
- `ports/posix/tcp_client.c`: TCP client with EINTR handling
- `ports/posix/tls_client.c`: TLS client using mbedTLS
- `ports/posix/udp_client.c`: UDP client implementation
- `ports/posix/net.c`: Platform utilities and Ruby bindings
- `build_config/posix-net-test.rb`: Test configuration

### Files Modified
- `include/net.h`: Platform-conditional headers
- `mrbgem.rake`: Conditional build (POSIX vs LwIP)
- `picoruby-mbedtls/include/mbedtls_config.h`: Enable MBEDTLS_NET_C

### Build System
- POSIX: Compiles ports/posix/*.c with native sockets
- Microcontroller: Compiles src/*.c with LwIP (unchanged)
- mrubyc compatibility: Custom init wrappers for gem system

## Technical Highlights

### TLS Implementation
- Full mbedTLS SSL context with entropy/RNG
- TLS 1.2 with configurable cipher suites
- SNI (Server Name Indication) support
- Graceful shutdown with close_notify
- Currently uses VERIFY_NONE (can enable cert validation)

### Error Handling
- AI_ADDRCONFIG removed (compatibility fix)
- EINTR retry loops on all blocking calls
- errno tracking across connection attempts
- Descriptive error messages with system details

### Memory Management
- Dynamic buffer allocation with realloc
- Proper cleanup on error paths
- Memory ownership transfer to response structs

## Usage

```ruby
require 'net'

# DNS
ip = Net::DNS.resolve('example.com', true)

# HTTP
client = Net::HTTPClient.new('example.com', 80)
response = client.get('/')

# HTTPS
client = Net::HTTPSClient.new('google.com', 443)
response = client.get('/')
```

## Testing

Build and test:
```bash
rake MRUBY_CONFIG=posix-net-test
bin/picoruby -e "require 'net'; p Net::HTTPSClient.new('google.com').get('/')"
```

## Future Enhancements

Optional improvements for production:
- Certificate verification (add CA bundle, enable VERIFY_REQUIRED)
- IPv6 support (change AF_INET to AF_UNSPEC)
- DTLS support (secure UDP)
- Connection pooling