### PR TITLE
Make picoruby-mbedtls hmac module portable across platforms.

### DIFF
--- a/mrbgems/picoruby-mbedtls/include/hmac.h
+++ b/mrbgems/picoruby-mbedtls/include/hmac.h
@@ -1,0 +1,23 @@
+#ifndef HMAC_DEFINED_H_
+#define HMAC_DEFINED_H_
+
+enum {
+  HMAC_SUCCESS = 0,
+  HMAC_UNSUPPORTED_HASH,
+  HMAC_SETUP_FAILED,
+  HMAC_STARTS_FAILED,
+  HMAC_UPDATE_FAILED,
+  HMAC_RESET_FAILED,
+  HMAC_FINISH_FAILED,
+  HMAC_ALREADY_FINISHED,
+};
+
+int MbedTLS_hmac_instance_size();
+int MbedTLS_hmac_init(void *data, const char *algorithm, const unsigned char *key, int key_len);
+int MbedTLS_hmac_update(void *data, const unsigned char *input, int input_len);
+int MbedTLS_hmac_reset(void *data);
+int MbedTLS_hmac_finish(void *data, unsigned char *output);
+void MbedTLS_hmac_free(void *data);
+int MbedTLS_hmac_check_finished(void *data);
+
+#endif /* HMAC_DEFINED_H_ */

--- a/mrbgems/picoruby-mbedtls/ports/common/hmac.c
+++ b/mrbgems/picoruby-mbedtls/ports/common/hmac.c
@@ -1,0 +1,90 @@
+#include "hmac.h"
+#include "mbedtls/md.h"
+#include <string.h>
+
+typedef struct HmacInstance {
+  mbedtls_md_context_t ctx;
+} hmac_instance_t;
+
+int
+MbedTLS_hmac_instance_size()
+{
+  return sizeof(hmac_instance_t);
+}
+
+int
+MbedTLS_hmac_init(void *data, const char *algorithm, const unsigned char *key, int key_len)
+{
+  if (strcmp(algorithm, "sha256") != 0) {
+    return HMAC_UNSUPPORTED_HASH;
+  }
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  mbedtls_md_init(&instance_data->ctx);
+  const mbedtls_md_info_t *md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  int ret;
+  ret = mbedtls_md_setup(&instance_data->ctx, md_info, 1); // 1 for HMAC
+  if (ret != 0) {
+    return HMAC_SETUP_FAILED;
+  }
+  ret = mbedtls_md_hmac_starts(&instance_data->ctx, key, key_len);
+  if (ret != 0) {
+    return HMAC_STARTS_FAILED;
+  }
+  return HMAC_SUCCESS;
+}
+
+int
+MbedTLS_hmac_check_finished(void *data)
+{
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  if (mbedtls_md_info_from_ctx(&instance_data->ctx) == NULL) { // mbedtls_md_free() makes md_info NULL
+    return HMAC_ALREADY_FINISHED;
+  }
+  return HMAC_SUCCESS;
+}
+
+int
+MbedTLS_hmac_update(void *data, const unsigned char *input, int input_len)
+{
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  if (MbedTLS_hmac_check_finished(data) != HMAC_SUCCESS) {
+    return HMAC_ALREADY_FINISHED;
+  }
+  int ret = mbedtls_md_hmac_update(&instance_data->ctx, input, input_len);
+  if (ret != 0) {
+    return HMAC_UPDATE_FAILED;
+  }
+  return HMAC_SUCCESS;
+}
+
+int
+MbedTLS_hmac_reset(void *data)
+{
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  int ret = mbedtls_md_hmac_reset(&instance_data->ctx);
+  if (ret != 0) {
+    return HMAC_RESET_FAILED;
+  }
+  return HMAC_SUCCESS;
+}
+
+int
+MbedTLS_hmac_finish(void *data, unsigned char *output)
+{
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  if (MbedTLS_hmac_check_finished(data) != HMAC_SUCCESS) {
+    return HMAC_ALREADY_FINISHED;
+  }
+  int ret = mbedtls_md_hmac_finish(&instance_data->ctx, output);
+  if (ret != 0) {
+    return HMAC_FINISH_FAILED;
+  }
+  return HMAC_SUCCESS;
+}
+
+void
+MbedTLS_hmac_free(void *data)
+{
+  hmac_instance_t *instance_data = (hmac_instance_t *)data;
+  mbedtls_md_free(&instance_data->ctx);
+}


### PR DESCRIPTION
### Description
This pull request extracts the HMAC-related code from the picoruby-mbedtls implementation into `ports/common` so that platform-specific versions of mbedtls can be selected per microcontroller.  
By moving mbedtls-dependent logic out of the platform-specific areas, the HMAC module becomes portable across different targets such as RP2040 and ESP32.

### Summary of changes
- Moved HMAC-related mbedtls-dependent code into `ports/common` to support per-platform mbedtls configurations.
- Updated the existing implementation to use the new shared code structure.

### Testing
The updated HMAC implementation is verified by the existing test suite in:  
`mrbgems/picoruby-mbedtls/test/hmac_test.rb`

### Motivation
This refactoring enables greater portability of the picoruby-mbedtls gem and allows different microcontrollers to use their own versions of mbedtls while preserving consistent behavior for HMAC operations.

