### PR TITLE
Fix typo "augh" to "auth" in cyw43.rbs

### DIFF
--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -15,7 +15,7 @@ class CYW43
 
   def self.init: (?String country, ?force: bool) -> bool
   def self.initialized?: () -> bool
-  def self.connect_timeout: (String ssid, String password, Integer augh, ?Integer timeout) -> bool
+  def self.connect_timeout: (String ssid, String password, Integer auth, ?Integer timeout) -> bool
   def self.disconnect: () -> bool
   def self.enable_sta_mode: () -> bool
   def self.disable_sta_mode: () -> bool


### PR DESCRIPTION
### Description

This pull request fixes a typographical error in the `cyw43.rbs` signature file.  
The method parameter was incorrectly written as `augh` and has been corrected to `auth`.

### Summary of changes

- Corrected the typo `augh` → `auth` in `mrbgems/picoruby-cyw43/sig/cyw43.rbs`.
