### PR TITLE
Add picoruby-esp32 mrbgem which has WiFi class.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -16,6 +16,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "MRBC_USE_FLOAT=2"
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "USE_FAT_FLASH_DISK"
+  conf.cc.defines << "ESP32_PLATFORM"
   conf.cc.defines << "NDEBUG"
 
   conf.picoruby(alloc_libc: false)
@@ -37,6 +38,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: 'picoruby-pwm'
 
   # others
+  conf.gem core: 'picoruby-esp32'
   conf.gem core: 'picoruby-rmt'
   conf.gem core: 'picoruby-mbedtls'
   conf.gem core: 'picoruby-adafruit_sk6812'

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -17,6 +17,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.cc.defines << "MRBC_USE_FLOAT=2"
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "USE_FAT_FLASH_DISK"
+  conf.cc.defines << "ESP32_PLATFORM"
   conf.cc.defines << "NDEBUG"
 
   conf.picoruby(alloc_libc: false)
@@ -38,6 +39,7 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: 'picoruby-pwm'
 
   # others
+  conf.gem core: 'picoruby-esp32'
   conf.gem core: 'picoruby-rmt'
   conf.gem core: 'picoruby-mbedtls'
   conf.gem core: 'picoruby-adafruit_sk6812'

--- a/mrbgems/picoruby-esp32/include/esp32.h
+++ b/mrbgems/picoruby-esp32/include/esp32.h
@@ -1,0 +1,18 @@
+#ifndef ESP32_DEFINED_H_
+#define ESP32_DEFINED_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ESP32_WIFI_init();
+int ESP32_WIFI_initialized();
+int ESP32_WIFI_connect_timeout(const char* ssid, const char* password, int auth, int timeout_ms);
+int ESP32_WIFI_disconnect();
+int ESP32_WIFI_tcpip_link_status();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP32_DEFINED_H_ */

--- a/mrbgems/picoruby-esp32/mrbgem.rake
+++ b/mrbgems/picoruby-esp32/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('picoruby-esp32') do |spec|
+  spec.license = 'MIT'
+  spec.authors = ['Yuhei Okazaki']
+  spec.summary = 'ESP32 class'
+end

--- a/mrbgems/picoruby-esp32/mrblib/esp32.rb
+++ b/mrbgems/picoruby-esp32/mrblib/esp32.rb
@@ -1,0 +1,34 @@
+class ESP32
+  class WiFi
+    LINK_DOWN  = 0
+    LINK_NOIP  = 2
+    LINK_UP    = 3
+    LINK_NONET = 5
+
+    def self.tcpip_link_status_name
+      case tcpip_link_status
+      when LINK_DOWN
+        "LINK_DOWN"
+      when LINK_NOIP
+        "LINK_NOIP"
+      when LINK_UP
+        "LINK_UP"
+      when LINK_NONET
+        "LINK_NONET"
+      else
+        "UNKNOWN_STATUS"
+      end
+    end
+  end
+
+  class Auth
+    OPEN           = 0
+    WPA_TKIP_PSK   = 2
+    WPA2_AES_PSK   = 3
+    WPA2_MIXED_PSK = 4
+  end
+
+  # Exception raised when WiFi connection times out
+  class ConnectTimeout < RuntimeError
+  end
+end

--- a/mrbgems/picoruby-esp32/ports/esp32.c
+++ b/mrbgems/picoruby-esp32/ports/esp32.c
@@ -1,0 +1,178 @@
+#include <string.h>
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_netif.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+static const char *TAG = "ESP32_WIFI";
+
+static bool wifi_initialized = false;
+static bool wifi_connected = false;
+static EventGroupHandle_t wifi_event_group = NULL;
+
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT      BIT1
+
+static void
+wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data)
+{
+  if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+    ESP_LOGI(TAG, "WiFi started");
+  } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    ESP_LOGI(TAG, "WiFi disconnected");
+    wifi_connected = false;
+    if (wifi_event_group) {
+      xEventGroupSetBits(wifi_event_group, WIFI_FAIL_BIT);
+    }
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+    ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
+    ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+    wifi_connected = true;
+    if (wifi_event_group) {
+      xEventGroupSetBits(wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+  }
+}
+
+int
+ESP32_WIFI_init()
+{
+  if (wifi_initialized) {
+    ESP_LOGI(TAG, "WiFi already initialized");
+    return 0;
+  }
+
+  esp_err_t ret = esp_netif_init();
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_netif_init failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_event_loop_create_default();
+  if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "esp_event_loop_create_default failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  esp_netif_create_default_wifi_sta();
+
+  wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+  ret = esp_wifi_init(&cfg);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_init failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register WiFi event handler: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register IP event handler: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_wifi_set_mode(WIFI_MODE_STA);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_set_mode failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  wifi_initialized = true;
+  ESP_LOGI(TAG, "WiFi initialized successfully");
+  return 0;
+}
+
+int
+ESP32_WIFI_initialized()
+{
+  return wifi_initialized ? 1 : 0;
+}
+
+int
+ESP32_WIFI_connect_timeout(const char* ssid, const char* password, int auth, int timeout_ms)
+{
+  if (wifi_event_group == NULL) {
+    wifi_event_group = xEventGroupCreate();
+  }
+  xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+
+  wifi_config_t wifi_config = {0};
+  strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
+  strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+  wifi_config.sta.threshold.authmode = auth;
+
+  esp_err_t ret = esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_set_config failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_wifi_start();
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_start failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  ret = esp_wifi_connect();
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "esp_wifi_connect failed: %s", esp_err_to_name(ret));
+    return -1;
+  }
+
+  // Wait for connection (with timeout)
+  EventBits_t bits = xEventGroupWaitBits(wifi_event_group,
+                                         WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                         pdFALSE,
+                                         pdFALSE,
+                                         pdMS_TO_TICKS(timeout_ms));
+
+  if (bits & WIFI_CONNECTED_BIT) {
+    ESP_LOGI(TAG, "Connected to AP SSID:%s", ssid);
+    return 0; // Success
+  } else if (bits & WIFI_FAIL_BIT) {
+    ESP_LOGE(TAG, "Failed to connect to SSID:%s", ssid);
+    return -1; // Failure
+  } else {
+    ESP_LOGE(TAG, "Connection timeout for SSID:%s", ssid);
+    return -2; // Timeout
+  }
+}
+
+int
+ESP32_WIFI_disconnect()
+{
+  esp_wifi_disconnect();
+  esp_wifi_stop();
+  wifi_connected = false;
+  ESP_LOGI(TAG, "WiFi disconnected");
+  return 0;
+}
+
+int
+ESP32_WIFI_tcpip_link_status()
+{
+  if (!wifi_initialized) {
+    return 5; // LINK_NONET
+  }
+
+  if (wifi_connected) {
+    return 3; // LINK_UP
+  }
+
+  wifi_ap_record_t ap_info;
+  esp_err_t ret = esp_wifi_sta_get_ap_info(&ap_info);
+
+  if (ret == ESP_OK) {
+    // Connected to AP, but no IP address yet
+    return 2; // LINK_NOIP
+  } else {
+    // Not connected to an AP
+    return 0; // LINK_DOWN
+  }
+}

--- a/mrbgems/picoruby-esp32/sig/esp32.rbs
+++ b/mrbgems/picoruby-esp32/sig/esp32.rbs
@@ -1,0 +1,29 @@
+# @sidebar hardware_device
+class ESP32
+
+  # @sidebar error
+  class ConnectTimeout < RuntimeError
+  end
+
+  class WiFi
+    LINK_DOWN:    Integer
+    LINK_NOIP:    Integer
+    LINK_UP:      Integer
+    LINK_NONET:   Integer
+
+    def self.init: () -> bool
+    def self.initialized?: () -> bool
+    def self.connect_timeout: (String ssid, String password, Integer augh, ?Integer timeout) -> bool
+    def self.disconnect: () -> bool
+    def self.tcpip_link_status: () -> Integer
+    def self.tcpip_link_status_name: () -> String
+  end
+
+  # @sidebar hardware_device
+  class Auth
+    OPEN: Integer
+    WPA_TKIP_PSK: Integer
+    WPA2_AES_PSK: Integer
+    WPA2_MIXED_PSK: Integer
+  end
+end

--- a/mrbgems/picoruby-esp32/src/esp32.c
+++ b/mrbgems/picoruby-esp32/src/esp32.c
@@ -1,0 +1,9 @@
+#if defined(PICORB_VM_MRUBY)
+
+#error "Not supported in mruby"
+
+#elif defined(PICORB_VM_MRUBYC)
+
+#include "mrubyc/esp32.c"
+
+#endif

--- a/mrbgems/picoruby-esp32/src/mrubyc/esp32.c
+++ b/mrbgems/picoruby-esp32/src/mrubyc/esp32.c
@@ -1,0 +1,81 @@
+#include <mrubyc.h>
+#include <string.h>
+#include "esp32.h"
+
+static mrbc_class *ConnectTimeout;
+
+static void
+c_esp32_wifi_init(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (ESP32_WIFI_init() == 0) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_esp32_wifi_initialized(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (ESP32_WIFI_initialized()) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_esp32_wifi_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc < 2) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+
+  const char *ssid = (const char *)GET_STRING_ARG(1);
+  const char *password = (const char *)GET_STRING_ARG(2);
+  int auth = GET_INT_ARG(3);
+  int timeout_ms = 30000; // default 30 seconds
+  if (argc > 3) {
+    timeout_ms = GET_INT_ARG(4);
+  }
+
+  int result = ESP32_WIFI_connect_timeout(ssid, password, auth, timeout_ms);
+
+  if (result == 0) {
+    SET_TRUE_RETURN();
+  } else if (result == -1) {
+    SET_FALSE_RETURN();
+  } else {
+    mrbc_raise(vm, ConnectTimeout, "WiFi connection timeout");
+  }
+}
+
+static void
+c_esp32_wifi_disconnect(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  ESP32_WIFI_disconnect();
+  SET_TRUE_RETURN();
+}
+
+static void
+c_esp32_wifi_tcpip_link_status(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  int status = ESP32_WIFI_tcpip_link_status();
+  SET_INT_RETURN(status);
+}
+
+void
+mrbc_esp32_init(mrbc_vm *vm)
+{
+  mrbc_class *class_ESP32 = mrbc_define_class(vm, "ESP32", mrbc_class_object);
+  
+  ConnectTimeout = mrbc_define_class_under(vm, class_ESP32, "ConnectTimeout", MRBC_CLASS(RuntimeError));
+
+  mrbc_class *class_WiFi = mrbc_define_class_under(vm, class_ESP32, "WiFi", mrbc_class_object);
+  mrbc_define_method(vm, class_WiFi, "init", c_esp32_wifi_init);
+  mrbc_define_method(vm, class_WiFi, "initialized?", c_esp32_wifi_initialized);
+  mrbc_define_method(vm, class_WiFi, "connect_timeout", c_esp32_wifi_connect_timeout);
+  mrbc_define_method(vm, class_WiFi, "disconnect", c_esp32_wifi_disconnect);
+  mrbc_define_method(vm, class_WiFi, "tcpip_link_status", c_esp32_wifi_tcpip_link_status);
+}

--- a/mrbgems/picoruby-machine/include/hal.h
+++ b/mrbgems/picoruby-machine/include/hal.h
@@ -9,9 +9,23 @@ extern "C" {
 #include "mruby.h"
 void mrb_tick(mrb_state *mrb);
 void hal_init(mrb_state *mrb);
+
+/* Avoid conflict with hal_init() from libpp used in ESP-IDF. */
+#ifdef ESP32_PLATFORM
+void machine_hal_init(mrb_state *mrb);
+#define hal_init(mrb) machine_hal_init(mrb)
+#endif
+
 #elif defined(PICORB_VM_MRUBYC)
 void mrbc_tick();
 void hal_init(void);
+
+/* Avoid conflict with hal_init() from libpp used in ESP-IDF. */
+#ifdef ESP32_PLATFORM
+void machine_hal_init(void);
+#define hal_init() machine_hal_init()
+#endif
+
 void hal_idle_cpu(void);
 #endif
 

--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -40,9 +40,9 @@ alarm_handler(void *arg)
 
 void
 #if defined(PICORB_VM_MRUBY)
-hal_init(mrb_state *mrb)
+machine_hal_init(mrb_state *mrb)
 #elif defined(PICORB_VM_MRUBYC)
-hal_init(void)
+machine_hal_init(void)
 #endif
 {
 #if defined(PICORB_VM_MRUBY)

--- a/mrbgems/picoruby-mbedtls/mrbgem.rake
+++ b/mrbgems/picoruby-mbedtls/mrbgem.rake
@@ -72,10 +72,13 @@ MRuby::Gem::Specification.new('picoruby-mbedtls') do |spec|
   spec.cc.defines << "MBEDTLS_CONFIG_FILE='\"#{dir}/include/mbedtls_config.h\"'"
   spec.cc.include_paths << "#{mbedtls_dir}/include"
   spec.cc.include_paths << "#{dir}/include"
-  spec.objs += Dir.glob("#{mbedtls_dir}/library/*.{c,cpp,m,asm,S}").map do |f|
-    f.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
+
+  # For ESP32, use Mbed TLS provided by ESP-IDF
+  unless build.name == "esp32"
+    spec.objs += Dir.glob("#{mbedtls_dir}/library/*.{c,cpp,m,asm,S}").map do |f|
+      f.relative_path_from(dir).pathmap("#{build_dir}/%X.o")
+    end
   end
 
   spec.posix
 end
-


### PR DESCRIPTION
### Description

This pull request adds a new `picoruby-esp32` mrbgem that provides ESP32-specific functionality for PicoRuby.  
As part of this mrbgem, a `WiFi` class has been introduced to expose basic wireless networking features available on the ESP32 platform.

### Summary of changes

- Added a new `picoruby-esp32` mrbgem for ESP32-specific capabilities.
- Implemented the `WiFi` class to support essential wireless operations on ESP32.
- Integrated the new mrbgem into the build system and platform configurations.

### Notes

- The `hal_init()` function in `ports/esp32/machine.c` was rewritten using macros because it conflicted with a function existing in ESP-IDF.
- To determine behavior specific to the ESP32, we added a macro named `ESP32_PLATFORM`.
- We have excluded `picoruby-mbedtls/lib/mbedtls` from the build target. This is to use the mbedtls provided by ESP-IDF.