### PR TITLE
Get rid of hal code in mrubyc

### DIFF
--- a/mrbgems/picoruby-machine/include/hal.h
+++ b/mrbgems/picoruby-machine/include/hal.h
@@ -26,7 +26,10 @@ void machine_hal_init(void);
 #define hal_init() machine_hal_init()
 #endif
 
-void hal_idle_cpu(void);
+#ifndef MRBC_SCHEDULER_EXIT
+#define MRBC_SCHEDULER_EXIT 1
+#endif
+
 #endif
 
 int hal_write(int fd, const void *buf, int nbytes);
@@ -39,6 +42,7 @@ int hal_write(int fd, const void *buf, int nbytes);
   void mrb_task_disable_irq(void);
 #endif
 
+void hal_idle_cpu(void);
 void hal_abort(const char *s);
 int hal_flush(int fd);
 int hal_read_available(void);

--- a/mrbgems/picoruby-mrubyc/mrbgem.rake
+++ b/mrbgems/picoruby-mrubyc/mrbgem.rake
@@ -26,16 +26,6 @@ MRuby::Gem::Specification.new('picoruby-mrubyc') do |spec|
     end
   end
 
-  if cc.build.posix?
-    cc.include_paths.unshift "#{mrubyc_dir}/hal/posix"
-    hal_src = "#{mrubyc_dir}/hal/posix/hal.c"
-    obj = objfile(hal_src.pathmap("#{build_dir}/src/%n"))
-    build.libmruby_objs << obj
-    file obj => hal_src do |f|
-      cc.run f.name, f.prerequisites.first
-    end
-  end
-
   next if %w(clean deep_clean).include?(Rake.application.top_level_tasks.first)
 
 end

--- a/mrbgems/picoruby-picorubyvm/src/mruby/picorubyvm.c
+++ b/mrbgems/picoruby-picorubyvm/src/mruby/picorubyvm.c
@@ -5,7 +5,12 @@
 static mrb_value
 mrb_picorubyvm_s_memory_statistics(mrb_state *mrb, mrb_value klass)
 {
+#if defined(PICORUBY_DEBUG)
   return mrb_alloc_statistics(mrb);
+#else
+  mrb_notimplement(mrb);
+  return mrb_nil_value();
+#endif
 }
 
 static mrb_value


### PR DESCRIPTION
- Remove dependency of POSIX's hal in mruby/c
- Some other adjustment regarding PICORUBY_DEBUG