### PR TITLE
Porting picoruby-socket(TCPSocket and UDPSocket) for ESP32.

### DIFF
--- a/build_config/riscv-esp.rb
+++ b/build_config/riscv-esp.rb
@@ -41,5 +41,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: 'picoruby-esp32'
   conf.gem core: 'picoruby-rmt'
   conf.gem core: 'picoruby-mbedtls'
+  conf.gem core: 'picoruby-socket'
   conf.gem core: 'picoruby-adafruit_sk6812'
 end

--- a/build_config/xtensa-esp.rb
+++ b/build_config/xtensa-esp.rb
@@ -42,5 +42,6 @@ MRuby::CrossBuild.new("esp32") do |conf|
   conf.gem core: 'picoruby-esp32'
   conf.gem core: 'picoruby-rmt'
   conf.gem core: 'picoruby-mbedtls'
+  conf.gem core: 'picoruby-socket'
   conf.gem core: 'picoruby-adafruit_sk6812'
 end

--- a/mrbgems/picoruby-socket/mrbgem.rake
+++ b/mrbgems/picoruby-socket/mrbgem.rake
@@ -16,14 +16,14 @@ MRuby::Gem::Specification.new('picoruby-socket') do |spec|
   spec.cc.include_paths << "#{dir}/include"
 
   # Add mbedtls include path for SSL support (non-POSIX only)
-  unless build.posix?
+  unless build.posix? || build.name == "esp32"
     mbedtls_dir = "#{MRUBY_ROOT}/mrbgems/picoruby-mbedtls/lib/mbedtls"
     if File.directory?(mbedtls_dir)
       spec.cc.include_paths << "#{mbedtls_dir}/include"
     end
   end
 
-  unless build.posix?
+  unless build.posix? || build.name == "esp32"
     # LwIP configuration
     LWIP_VERSION = "STABLE-2_2_1_RELEASE"
     LWIP_REPO = "https://github.com/lwip-tcpip/lwip"

--- a/mrbgems/picoruby-socket/ports/esp32/net_helpers.c
+++ b/mrbgems/picoruby-socket/ports/esp32/net_helpers.c
@@ -1,0 +1,26 @@
+#include "../../include/socket.h"
+
+void
+Net_sleep_ms(int ms)
+{
+  /* No operation implementation */
+}
+
+void
+lwip_begin(void)
+{
+  /* No operation implementation */
+}
+
+void
+lwip_end(void)
+{
+  /* No operation implementation */
+}
+
+int
+Net_get_ip(const char *name, void *ip)
+{
+  /* No operation implementation */
+  return 0;
+}

--- a/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
@@ -1,0 +1,122 @@
+#include "../../include/socket.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+struct picorb_ssl_context {
+  int dummy;
+};
+
+struct picorb_ssl_socket {
+  int dummy;
+};
+
+picorb_ssl_context_t*
+SSLContext_create(void)
+{
+  /* No operation implementation */
+  return NULL;
+}
+
+bool
+SSLContext_set_ca_file(picorb_ssl_context_t *ctx, const char *ca_file)
+{
+  /* No operation implementation */
+  return false;
+}
+
+bool
+SSLContext_set_ca_cert(picorb_ssl_context_t *ctx, const void *addr, size_t size)
+{
+  /* No operation implementation */
+  return false;
+}
+
+bool
+SSLContext_set_verify_mode(picorb_ssl_context_t *ctx, int mode)
+{
+  /* No operation implementation */
+  return false;
+}
+
+int
+SSLContext_get_verify_mode(picorb_ssl_context_t *ctx)
+{
+  /* No operation implementation */
+  return -1;
+}
+
+void
+SSLContext_free(picorb_ssl_context_t *ctx)
+{
+  /* No operation implementation */
+}
+
+picorb_ssl_socket_t*
+SSLSocket_create(picorb_ssl_context_t *ssl_ctx)
+{
+  /* No operation implementation */
+  return NULL;
+}
+
+bool
+SSLSocket_set_hostname(picorb_ssl_socket_t *ssl_sock, const char *hostname)
+{
+  /* No operation implementation */
+  return false;
+}
+
+bool
+SSLSocket_set_port(picorb_ssl_socket_t *ssl_sock, int port)
+{
+  /* No operation implementation */
+  return false;
+}
+
+bool
+SSLSocket_connect(picorb_ssl_socket_t *ssl_sock)
+{
+  /* No operation implementation */
+  return false;
+}
+
+ssize_t
+SSLSocket_send(picorb_ssl_socket_t *ssl_sock, const void *data, size_t len)
+{
+  /* No operation implementation */
+  return -1;
+}
+
+ssize_t
+SSLSocket_recv(picorb_ssl_socket_t *ssl_sock, void *buf, size_t len)
+{
+  /* No operation implementation */
+  return -1;
+}
+
+bool
+SSLSocket_close(picorb_ssl_socket_t *ssl_sock)
+{
+  /* No operation implementation */
+  return false;
+}
+
+bool
+SSLSocket_closed(picorb_ssl_socket_t *ssl_sock)
+{
+  /* No operation implementation */
+  return true;
+}
+
+const char*
+SSLSocket_remote_host(picorb_ssl_socket_t *ssl_sock)
+{
+  /* No operation implementation */
+  return NULL;
+}
+
+int
+SSLSocket_remote_port(picorb_ssl_socket_t *ssl_sock)
+{
+  /* No operation implementation */
+  return -1;
+}

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
@@ -1,0 +1,41 @@
+#include "../../include/socket.h"
+#include <stdbool.h>
+
+struct picorb_tcp_server {
+  int dummy;
+};
+
+picorb_tcp_server_t*
+TCPServer_create(int port, int backlog)
+{
+  /* No operation implementation */
+  return 0;
+}
+
+picorb_socket_t*
+TCPServer_accept_nonblock(picorb_tcp_server_t *server)
+{
+  /* No operation implementation */
+  return 0;
+}
+
+bool
+TCPServer_close(picorb_tcp_server_t *server)
+{
+  /* No operation implementation */
+  return false;
+}
+
+int
+TCPServer_port(picorb_tcp_server_t *server)
+{
+  /* No operation implementation */
+  return -1;
+}
+
+bool
+TCPServer_listening(picorb_tcp_server_t *server)
+{
+  /* No operation implementation */
+  return false;
+}

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
@@ -1,0 +1,146 @@
+#define PICORB_PLATFORM_POSIX 1
+
+#include "../../include/socket.h"
+
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
+
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+
+/* Prevent name collision with embedded Ruby bytecode */
+#ifdef socket
+#undef socket
+#endif
+
+bool
+TCPSocket_create(picorb_socket_t *sock)
+{
+  if (!sock) return false;
+
+  memset(sock, 0, sizeof(picorb_socket_t));
+
+  sock->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (sock->fd < 0) {
+    return false;
+  }
+
+  sock->family = AF_INET;
+  sock->socktype = SOCK_STREAM;
+  sock->protocol = IPPROTO_TCP;
+  sock->connected = false;
+  sock->closed = false;
+
+  return true;
+}
+
+bool
+TCPSocket_connect(picorb_socket_t *sock, const char *host, int port)
+{
+  if (!sock || !host || port <= 0 || port > 65535) {
+    return false;
+  }
+
+  if (sock->family != AF_INET || sock->fd < 0) {
+    if (!TCPSocket_create(sock)) {
+      return false;
+    }
+  }
+
+  struct hostent *he = gethostbyname(host);
+  if (!he) {
+    close(sock->fd);
+    sock->fd = -1;
+    return false;
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  memcpy(&addr.sin_addr, he->h_addr_list[0], he->h_length);
+
+  if (connect(sock->fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    close(sock->fd);
+    sock->fd = -1;
+    return false;
+  }
+
+  strncpy(sock->remote_host, host, sizeof(sock->remote_host) - 1);
+  sock->remote_host[sizeof(sock->remote_host) - 1] = '\0';
+  sock->remote_port = port;
+  sock->connected = true;
+
+  return true;
+}
+
+ssize_t
+TCPSocket_send(picorb_socket_t *sock, const void *data, size_t len)
+{
+  if (!sock || !data || sock->fd < 0 || sock->closed) {
+    return -1;
+  }
+
+  ssize_t sent = send(sock->fd, data, len, 0);
+  if (sent < 0) {
+    return -1;
+  }
+
+  return sent;
+}
+
+ssize_t
+TCPSocket_recv(picorb_socket_t *sock, void *buf, size_t len)
+{
+  if (!sock || !buf || sock->fd < 0 || sock->closed) {
+    return -1;
+  }
+
+  ssize_t received = recv(sock->fd, buf, len, 0);
+  if (received < 0) {
+    return -1;
+  }
+
+  if (received == 0) {
+    sock->connected = false;
+  }
+
+  return received;
+}
+
+bool
+TCPSocket_close(picorb_socket_t *sock)
+{
+  if (!sock || sock->fd < 0) {
+    return false;
+  }
+
+  close(sock->fd);
+  sock->fd = -1;
+  sock->connected = false;
+  sock->closed = true;
+
+  return true;
+}
+
+const char*
+TCPSocket_remote_host(picorb_socket_t *sock)
+{
+  if (!sock) return NULL;
+  return sock->remote_host;
+}
+
+int
+TCPSocket_remote_port(picorb_socket_t *sock)
+{
+  if (!sock) return -1;
+  return sock->remote_port;
+}
+
+bool
+TCPSocket_closed(picorb_socket_t *sock)
+{
+  if (!sock) return true;
+  return sock->closed || sock->fd < 0;
+}

--- a/mrbgems/picoruby-socket/ports/esp32/udp_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/udp_socket.c
@@ -1,0 +1,209 @@
+#define PICORB_PLATFORM_POSIX 1
+
+#include "../../include/socket.h"
+
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
+
+#include <string.h>
+#include <errno.h>
+
+/* Prevent name collision with embedded Ruby bytecode */
+#ifdef socket
+#undef socket
+#endif
+
+bool
+UDPSocket_create(picorb_socket_t *sock)
+{
+  if (!sock) return false;
+
+  memset(sock, 0, sizeof(picorb_socket_t));
+  sock->fd = -1;
+  sock->family = AF_INET;
+  sock->socktype = SOCK_DGRAM;
+  sock->protocol = IPPROTO_UDP;
+  sock->connected = false;
+  sock->closed = false;
+  sock->remote_port = 0;
+
+  sock->fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (sock->fd < 0) {
+    return false;
+  }
+
+  int flags = fcntl(sock->fd, F_GETFL, 0);
+  if (flags >= 0) {
+    fcntl(sock->fd, F_SETFL, flags | O_NONBLOCK);
+  }
+
+  return true;
+}
+
+bool
+UDPSocket_bind(picorb_socket_t *sock, const char *host, int port)
+{
+  if (!sock || sock->fd < 0) return false;
+
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  char port_str[6];
+  snprintf(port_str, sizeof(port_str), "%d", port);
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+  hints.ai_flags = AI_PASSIVE;
+
+  const char *bind_host = (host && *host) ? host : "0.0.0.0";
+
+  int err = getaddrinfo(bind_host, port_str, &hints, &res);
+  if (err != 0 || !res) {
+    return false;
+  }
+
+  if (bind(sock->fd, res->ai_addr, res->ai_addrlen) < 0) {
+    freeaddrinfo(res);
+    return false;
+  }
+
+  freeaddrinfo(res);
+
+  return true;
+}
+
+bool
+UDPSocket_connect(picorb_socket_t *sock, const char *host, int port)
+{
+  if (!sock || sock->fd < 0 || !host) return false;
+
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  char port_str[6];
+  snprintf(port_str, sizeof(port_str), "%d", port);
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+
+  int err = getaddrinfo(host, port_str, &hints, &res);
+  if (err != 0 || !res) {
+    return false;
+  }
+
+  if (connect(sock->fd, res->ai_addr, res->ai_addrlen) < 0) {
+    freeaddrinfo(res);
+    return false;
+  }
+
+  freeaddrinfo(res);
+
+  sock->connected = true;
+  strncpy(sock->remote_host, host, sizeof(sock->remote_host) - 1);
+  sock->remote_host[sizeof(sock->remote_host) - 1] = '\0';
+  sock->remote_port = port;
+
+  return true;
+}
+
+ssize_t
+UDPSocket_send(picorb_socket_t *sock, const void *data, size_t len)
+{
+  if (!sock || sock->fd < 0 || !data || !sock->connected) {
+    return -1;
+  }
+
+  ssize_t sent = send(sock->fd, data, len, 0);
+  if (sent < 0) {
+    return -1;
+  }
+
+  return sent;
+}
+
+ssize_t
+UDPSocket_sendto(picorb_socket_t *sock, const void *data, size_t len,
+                  const char *host, int port)
+{
+  if (!sock || sock->fd < 0 || !data || !host) {
+    return -1;
+  }
+
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  char port_str[6];
+  snprintf(port_str, sizeof(port_str), "%d", port);
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_DGRAM;
+
+  int err = getaddrinfo(host, port_str, &hints, &res);
+  if (err != 0 || !res) {
+    return -1;
+  }
+
+  ssize_t sent = sendto(sock->fd, data, len, 0, res->ai_addr, res->ai_addrlen);
+
+  freeaddrinfo(res);
+
+  if (sent < 0) {
+    return -1;
+  }
+
+  return sent;
+}
+
+ssize_t
+UDPSocket_recvfrom(picorb_socket_t *sock, void *buf, size_t len,
+                    char *host, size_t host_len, int *port)
+{
+  if (!sock || sock->fd < 0 || !buf) {
+    return -1;
+  }
+
+  struct sockaddr_in addr;
+  socklen_t addr_len = sizeof(addr);
+  memset(&addr, 0, sizeof(addr));
+
+  ssize_t received = recvfrom(sock->fd, buf, len, 0,
+                               (struct sockaddr *)&addr, &addr_len);
+  if (received < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0;
+    }
+    return -1;
+  }
+
+  if (host && host_len > 0) {
+    inet_ntop(AF_INET, &addr.sin_addr, host, host_len);
+  }
+  if (port) {
+    *port = ntohs(addr.sin_port);
+  }
+
+  return received;
+}
+
+bool
+UDPSocket_close(picorb_socket_t *sock)
+{
+  if (!sock || sock->fd < 0) return false;
+
+  if (close(sock->fd) < 0) {
+    return false;
+  }
+
+  sock->fd = -1;
+  sock->closed = true;
+  sock->connected = false;
+
+  return true;
+}
+
+bool
+UDPSocket_closed(picorb_socket_t *sock)
+{
+  if (!sock) return true;
+  return sock->closed || sock->fd < 0;
+}

--- a/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
+++ b/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
@@ -51,7 +51,7 @@
  * - some unhandled/untested things might be caught by LWIP_ASSERTs...
  */
 
-#if !defined(PICORB_PLATFORM_POSIX)
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(ESP32_PLATFORM)
 
 #include "lwip/opt.h"
 #include "lwip/sys.h"
@@ -1366,4 +1366,4 @@ const struct altcp_functions altcp_mbedtls_functions = {
 #endif /* LWIP_ALTCP_TLS && LWIP_ALTCP_TLS_MBEDTLS */
 #endif /* LWIP_ALTCP */
 
-#endif /* !PICORB_PLATFORM_POSIX */
+#endif /* !PICORB_PLATFORM_POSIX && !ESP32_PLATFORM */


### PR DESCRIPTION
## Summary

This Pull Request ports the `picoruby-socket` mrbgem to **ESP32**, enabling socket networking features on **R2P2-ESP32**.

## Available Classes

- `TCPSocket`
- `UDPSocket`

## Not Implemented Yet

- `SSLSocket`
- `TCPServer`

## Implementation Details

- This port uses **lwIP** provided by **ESP-IDF**.
- The implementation is based on the **POSIX-oriented** version of `picoruby-socket`,