### PR TITLE
Use mrbc_define_destructor for MbedTLS::Digest and MbedTLS::PKey::RSA in mruby/c

### DIFF
--- a/mrbgems/picoruby-mbedtls/example/signature.md
+++ b/mrbgems/picoruby-mbedtls/example/signature.md
@@ -49,7 +49,6 @@ if public_key.verify(digest, signature, data)
 else
   p "Not verified"
 end
-digest.free
 ```
 
 ## Create key pair in PicoRuby and MbedTLS

--- a/mrbgems/picoruby-mbedtls/mrblib/digest.rb
+++ b/mrbgems/picoruby-mbedtls/mrblib/digest.rb
@@ -1,4 +1,9 @@
 module MbedTLS
   class Digest
+    def free
+      # No-op for backward compatibility
+      # https://github.com/picoruby/picoruby/pull/302
+      nil
+    end
   end
 end

--- a/mrbgems/picoruby-mbedtls/mrblib/rsa.rb
+++ b/mrbgems/picoruby-mbedtls/mrblib/rsa.rb
@@ -1,0 +1,13 @@
+module MbedTLS
+  module PKey
+    class PKeyBase
+    end
+    class RSA < MbedTLS::PKey::PKeyBase
+      def free
+        # No-op for backward compatibility
+        # https://github.com/picoruby/picoruby/pull/302
+        nil
+      end
+    end
+  end
+end

--- a/mrbgems/picoruby-mbedtls/sig/mbedtls_digest.rbs
+++ b/mrbgems/picoruby-mbedtls/sig/mbedtls_digest.rbs
@@ -6,6 +6,5 @@ module MbedTLS
     def initialize: (algorithm_t algorithm) -> void
     def update: (String input) -> MbedTLS::Digest
     def finish: () -> String
-    def free: () -> self
   end
 end

--- a/mrbgems/picoruby-mbedtls/sig/mbedtls_pkey.rbs
+++ b/mrbgems/picoruby-mbedtls/sig/mbedtls_pkey.rbs
@@ -20,7 +20,6 @@ module MbedTLS
       def public_key: () -> MbedTLS::PKey::PKeyBase
       def public?: () -> bool
       def private?: () -> bool
-      def free: () -> self
     end
   end
 end

--- a/mrbgems/picoruby-mbedtls/src/mruby/digest.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/digest.c
@@ -44,13 +44,6 @@ mrb_mbedtls_digest_initialize(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_mbedtls_digest_free(mrb_state *mrb, mrb_value self)
-{
-  // no-op for compatibility with mruby/c
-  return mrb_nil_value();
-}
-
-static mrb_value
 mrb_mbedtls_digest_update(mrb_state *mrb, mrb_value self)
 {
   mrb_value input;
@@ -90,5 +83,4 @@ gem_mbedtls_digest_init(mrb_state *mrb, struct RClass *module_MbedTLS)
   mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(initialize),  mrb_mbedtls_digest_initialize, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(update),      mrb_mbedtls_digest_update, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(finish),      mrb_mbedtls_digest_finish, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_MbedTLS_Digest, MRB_SYM(free),        mrb_mbedtls_digest_free, MRB_ARGS_NONE());
 }

--- a/mrbgems/picoruby-mbedtls/src/mruby/pkey.c
+++ b/mrbgems/picoruby-mbedtls/src/mruby/pkey.c
@@ -50,13 +50,6 @@ mrb_mbedtls_pkey_rsa_private_p(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-mrb_mbedtls_pkey_rsa_free(mrb_state *mrb, mrb_value self)
-{
-  // For mruby, GC handles freeing. This is for mruby/c compatibility.
-  return mrb_nil_value();
-}
-
-static mrb_value
 mrb_mbedtls_pkey_rsa_s_generate(mrb_state *mrb, mrb_value klass)
 {
   mrb_int bits;
@@ -209,7 +202,6 @@ gem_mbedtls_pkey_init(mrb_state *mrb, struct RClass *module_MbedTLS)
   mrb_define_method_id(mrb, class_MbedTLS_PKey_RSA, MRB_SYM(to_s),        mrb_mbedtls_pkey_rsa_to_pem, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_MbedTLS_PKey_RSA, MRB_SYM_Q(public),    mrb_mbedtls_pkey_rsa_public_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_MbedTLS_PKey_RSA, MRB_SYM_Q(private),   mrb_mbedtls_pkey_rsa_private_p, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_MbedTLS_PKey_RSA, MRB_SYM(free),        mrb_mbedtls_pkey_rsa_free, MRB_ARGS_NONE());
 
   class_MbedTLS_PKey_PKeyError = mrb_define_class_under_id(mrb, module_MbedTLS_PKey, MRB_SYM(PKeyError), E_STANDARD_ERROR);
 }

--- a/mrbgems/picoruby-mbedtls/src/mrubyc/digest.c
+++ b/mrbgems/picoruby-mbedtls/src/mrubyc/digest.c
@@ -2,6 +2,12 @@
 #include "digest.h"
 
 static void
+mrbc_digest_free(mrbc_value *self)
+{
+  MbedTLS_digest_free((unsigned char *)self->instance->data);
+}
+
+static void
 c_mbedtls_digest_new(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   if (argc != 1) {
@@ -32,12 +38,6 @@ c_mbedtls_digest_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
   SET_RETURN(self);
-}
-
-static void
-c_mbedtls_digest_free(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  MbedTLS_digest_free((unsigned char *)v->instance->data);
 }
 
 static void
@@ -85,9 +85,9 @@ void
 gem_mbedtls_digest_init(mrbc_vm *vm, mrbc_class *module_MbedTLS)
 {
   mrbc_class *class_MbedTLS_Digest = mrbc_define_class_under(vm, module_MbedTLS, "Digest", mrbc_class_object);
+  mrbc_define_destructor(class_MbedTLS_Digest, mrbc_digest_free);
 
   mrbc_define_method(vm, class_MbedTLS_Digest, "new", c_mbedtls_digest_new);
   mrbc_define_method(vm, class_MbedTLS_Digest, "update", c_mbedtls_digest_update);
   mrbc_define_method(vm, class_MbedTLS_Digest, "finish", c_mbedtls_digest_finish);
-  mrbc_define_method(vm, class_MbedTLS_Digest, "free", c_mbedtls_digest_free);
 }

--- a/mrbgems/picoruby-mbedtls/src/mrubyc/pkey.c
+++ b/mrbgems/picoruby-mbedtls/src/mrubyc/pkey.c
@@ -37,14 +37,12 @@ c_mbedtls_pkey_rsa_private_q(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
-c_mbedtls_pkey_rsa_free(mrbc_vm *vm, mrbc_value *v, int argc)
+mrbc_pkey_rsa_free(mrbc_value *self)
 {
-  void *pk = v->instance->data;
+  void *pk = self->instance->data;
   if (pk) {
     MbedTLS_pkey_free(pk);
-    // The instance itself is freed by GC
   }
-  SET_NIL_RETURN();
 }
 
 static void
@@ -221,6 +219,8 @@ gem_mbedtls_pkey_init(mrbc_vm *vm, mrbc_class *module_MbedTLS)
   mrbc_define_method(vm, class_MbedTLS_PKey_PKeyBase, "verify", c_mbedtls_pkey_pkeybase_verify);
 
   mrbc_class *class_MbedTLS_PKey_RSA = mrbc_define_class_under(vm, module_MbedTLS_PKey, "RSA", class_MbedTLS_PKey_PKeyBase);
+  mrbc_define_destructor(class_MbedTLS_PKey_RSA, mrbc_pkey_rsa_free);
+
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "new", c_mbedtls_pkey_rsa_new);
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "generate", c_mbedtls_pkey_rsa_generate);
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "public_key", c_mbedtls_pkey_rsa_public_key);
@@ -229,7 +229,6 @@ gem_mbedtls_pkey_init(mrbc_vm *vm, mrbc_class *module_MbedTLS)
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "to_s", c_mbedtls_pkey_rsa_to_pem);
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "public?", c_mbedtls_pkey_rsa_public_q);
   mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "private?", c_mbedtls_pkey_rsa_private_q);
-  mrbc_define_method(vm, class_MbedTLS_PKey_RSA, "free", c_mbedtls_pkey_rsa_free);
 
   class_MbedTLS_PKey_PKeyError = mrbc_define_class_under(vm, module_MbedTLS_PKey, "PKeyError", MRBC_CLASS(StandardError));
 }


### PR DESCRIPTION
Fix #275
This pull request refactors the resource management and API compatibility for the MbedTLS bindings in PicoRuby, focusing on the `Digest` and `RSA` classes. The main goal is to remove the explicit `.free` method from the public API and rely on garbage collection for resource cleanup, while maintaining backward compatibility for existing code that may call `.free`.

**API and Resource Management Refactoring**

* Removed the `.free` method from the public API for both `Digest` and `RSA` classes in Ruby and RBS type signatures, as resource cleanup is now handled by garbage collection. [[1]](diffhunk://#diff-2ff3c16484bc2191c74004a93425900eedbc28541b3d71f69104493e1718a61cL9) [[2]](diffhunk://#diff-59624205c37e21070ba95557170310b99852b046cea4d273b71116e69ca68aaaL23) [[3]](diffhunk://#diff-c6f95f10432e889dee975f32a722fd197be76374c5f9376351703dc124d72075L46-L52) [[4]](diffhunk://#diff-c6f95f10432e889dee975f32a722fd197be76374c5f9376351703dc124d72075L93) [[5]](diffhunk://#diff-5d13a6dec006ce4828f5b1e49a8a47b869e69c519d20ef4a98b6b197d3784febL52-L58) [[6]](diffhunk://#diff-5d13a6dec006ce4828f5b1e49a8a47b869e69c519d20ef4a98b6b197d3784febL212) [[7]](diffhunk://#diff-8d6f0fe6c3670f75f5ab63fdd2100791ee1451d6c7e1f6fadbc070353493df9dL37-L42) [[8]](diffhunk://#diff-8d6f0fe6c3670f75f5ab63fdd2100791ee1451d6c7e1f6fadbc070353493df9dR88-L92) [[9]](diffhunk://#diff-7420c5451b7d593ec0a695a842d054f9d460e14724fa71d8de292b991986c700L40-L47) [[10]](diffhunk://#diff-7420c5451b7d593ec0a695a842d054f9d460e14724fa71d8de292b991986c700R222-R223) [[11]](diffhunk://#diff-7420c5451b7d593ec0a695a842d054f9d460e14724fa71d8de292b991986c700L232)
* Introduced destructor functions (`mrbc_digest_free` and `mrbc_pkey_rsa_free`) for `mrubyc` to ensure proper resource cleanup when objects are garbage collected. [[1]](diffhunk://#diff-8d6f0fe6c3670f75f5ab63fdd2100791ee1451d6c7e1f6fadbc070353493df9dR4-R9) [[2]](diffhunk://#diff-8d6f0fe6c3670f75f5ab63fdd2100791ee1451d6c7e1f6fadbc070353493df9dR88-L92) [[3]](diffhunk://#diff-7420c5451b7d593ec0a695a842d054f9d460e14724fa71d8de292b991986c700L40-L47) [[4]](diffhunk://#diff-7420c5451b7d593ec0a695a842d054f9d460e14724fa71d8de292b991986c700R222-R223)
* Updated Ruby classes (`Digest` and `RSA`) to provide a no-op `.free` method for backward compatibility, preventing errors in code that may still call `.free`. [[1]](diffhunk://#diff-23a46c1dc7b39fd20cfef9b1758395da5fb85df0110ea2f759a5bce6c55ab52aR3-R6) [[2]](diffhunk://#diff-1450bfa79961ee70b9e1e1c52e6996e44c7b0f700dfe5c3a20806bc4b1103535R1-R12)

**Documentation Update**

* Removed the explicit call to `.free` in the signature verification example, reflecting the new resource management approach.