### PR TITLE
Set ESP-IDF WiFi component log level to ESP_LOG_WARN in ESP32_WIFI_init().

### DIFF
--- a/mrbgems/picoruby-esp32/ports/esp32.c
+++ b/mrbgems/picoruby-esp32/ports/esp32.c
@@ -36,6 +36,17 @@ wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, voi
   }
 }
 
+static void
+ESP32_WIFI_log_level_set(esp_log_level_t level)
+{
+  esp_log_level_set("wifi", level);
+  esp_log_level_set("wifi_init", level);
+  esp_log_level_set("phy_init", level);
+  esp_log_level_set("pp", level);
+  esp_log_level_set("net80211", level);
+  esp_log_level_set("esp_netif_handlers", level);
+}
+
 int
 ESP32_WIFI_init()
 {
@@ -43,6 +54,8 @@ ESP32_WIFI_init()
     ESP_LOGI(TAG, "WiFi already initialized");
     return 0;
   }
+
+  ESP32_WIFI_log_level_set(ESP_LOG_WARN)
 
   esp_err_t ret = esp_netif_init();
   if (ret != ESP_OK) {


### PR DESCRIPTION
### Description
This pull request updates the WiFi class in picoruby-esp32 by setting the log level of ESP-IDF WiFi-related components to `ESP_LOG_WARN` inside `ESP32_WIFI_init()`.  
The default log level produces a large amount of output during Wi-Fi connection procedures, which can make debugging or monitoring difficult on resource-constrained devices.

### Summary of changes
- Updated `ESP32_WIFI_init()` to configure ESP-IDF WiFi components to use `ESP_LOG_WARN`.
- Reduced verbosity of Wi-Fi connection logs to improve readability and runtime usability.

### Notes
This change suppresses excessive Wi-Fi logs while preserving warnings and error messages important for debugging.
