### PR TITLE
Add a semicolon after ESP32_WIFI_log_level_set().

### DIFF
--- a/mrbgems/picoruby-esp32/ports/esp32.c
+++ b/mrbgems/picoruby-esp32/ports/esp32.c
@@ -55,7 +55,7 @@ ESP32_WIFI_init()
     return 0;
   }
 
-  ESP32_WIFI_log_level_set(ESP_LOG_WARN)
+  ESP32_WIFI_log_level_set(ESP_LOG_WARN);
 
   esp_err_t ret = esp_netif_init();
   if (ret != ESP_OK) {


### PR DESCRIPTION
I apologize.

In Pull Request #303, I forgot the semicolon when calling ESP32_WIFI_log_level_set().

Since the build is failing, I will add the semicolon.