### PR TITLE
Add README.md copying to runtime_gems task

### DIFF
--- a/runtime_gems/picoruby-adafruit_pcf8523/README.md
+++ b/runtime_gems/picoruby-adafruit_pcf8523/README.md
@@ -1,0 +1,35 @@
+# picoruby-adafruit_pcf8523
+
+PCF8523 Real-Time Clock (RTC) library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'pcf8523'
+
+i2c = I2C.new(unit: :RP2040_I2C0, sda_pin: 4, scl_pin: 5)
+rtc = PCF8523.new(i2c: i2c)
+
+# Set current time
+rtc.current_time = Time.local(2024, 1, 15, 10, 30, 0)
+
+# Read current time
+time = rtc.current_time
+puts "#{time.year}/#{time.mon}/#{time.mday} #{time.hour}:#{time.min}:#{time.sec}"
+```
+
+## API
+
+### Methods
+
+- `PCF8523.new(i2c:)` - Initialize RTC with I2C instance
+- `current_time=(time)` - Set RTC time using Time object
+- `current_time()` - Read current time from RTC, returns Time object
+- `set_power_management(pow = 0b001)` - Configure power management mode
+
+## Notes
+
+- I2C address is 0x68 (fixed)
+- Supported year range: 2000-2099
+- Battery backup support with configurable power management
+- Default power mode enables battery switch-over in direct switching mode

--- a/runtime_gems/picoruby-aht25/README.md
+++ b/runtime_gems/picoruby-aht25/README.md
@@ -1,0 +1,31 @@
+# picoruby-aht25
+
+AHT25 temperature and humidity sensor library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'aht25'
+
+i2c = I2C.new(unit: :RP2040_I2C0, sda_pin: 4, scl_pin: 5)
+sensor = AHT25.new(i2c: i2c)
+
+data = sensor.read
+puts "Temperature: #{data[:temperature]}°C"
+puts "Humidity: #{data[:humidity]}%"
+```
+
+## API
+
+### Methods
+
+- `AHT25.new(i2c:)` - Initialize sensor with I2C instance
+- `read()` - Read sensor data, returns hash with `:temperature` and `:humidity` keys
+- `check()` - Check sensor status, returns true if ready
+- `reset()` - Reset sensor
+
+## Notes
+
+- I2C address is 0x38 (fixed)
+- Temperature range: -40°C to 85°C
+- Humidity range: 0% to 100%RH

--- a/runtime_gems/picoruby-akizukidenshi_aqm0802a/README.md
+++ b/runtime_gems/picoruby-akizukidenshi_aqm0802a/README.md
@@ -1,0 +1,35 @@
+# picoruby-akizukidenshi_aqm0802a
+
+AQM0802A 8x2 character LCD display library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'aqm0802a'
+
+i2c = I2C.new(unit: :RP2040_I2C0, sda_pin: 14, scl_pin: 15)
+lcd = AQM0802A.new(i2c: i2c)
+
+lcd.print "Hello!"
+lcd.break_line
+lcd.print "PicoRuby"
+```
+
+## API
+
+### Methods
+
+- `AQM0802A.new(i2c:, init: true)` - Initialize LCD with I2C instance
+- `print(text)` - Print text to LCD
+- `putc(char)` - Print single character
+- `break_line()` - Move to second line
+- `clear()` - Clear display
+- `home()` - Move cursor to home position
+- `reset()` - Reset and initialize LCD
+- `write_instruction(inst)` - Write instruction byte to LCD
+
+## Notes
+
+- I2C address is 0x3E (fixed)
+- Display size: 8 characters × 2 lines
+- Supports both AQM0802A-RN-GBW (no backlight) and AQM0802A-FLW-GBW (with backlight)

--- a/runtime_gems/picoruby-dip_switch/README.md
+++ b/runtime_gems/picoruby-dip_switch/README.md
@@ -1,0 +1,34 @@
+# picoruby-dip_switch
+
+DIP switch reader library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'dip_switch'
+
+# Positive logic (with control pin)
+c_pin = GPIO.new(0, GPIO::OUT)
+dip = DipSwitch.new(c_pin, [1, 2, 3, 4])
+value = dip.read  # Returns 0..15 (4-bit value)
+
+# Negative logic (without control pin)
+dip = DipSwitch.new(nil, [1, 2, 3, 4])
+value = dip.read  # Returns 0..15 (4-bit value)
+```
+
+## API
+
+### Methods
+
+- `DipSwitch.new(control_pin, pin_numbers)` - Initialize DIP switch reader
+  - `control_pin`: GPIO instance for control (use `nil` for negative logic)
+  - `pin_numbers`: Array of GPIO pin numbers for switch positions
+- `read()` - Read DIP switch value as Integer
+
+## Notes
+
+- **Positive logic**: Uses pull-down resistors, requires control pin
+- **Negative logic**: Uses pull-up resistors, no control pin needed
+- Return value represents the binary state of all switches
+- Example: 4 switches can return values 0-15

--- a/runtime_gems/picoruby-hcsr04/README.md
+++ b/runtime_gems/picoruby-hcsr04/README.md
@@ -1,0 +1,26 @@
+# picoruby-hcsr04
+
+HC-SR04 ultrasonic distance sensor library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'hcsr04'
+
+sensor = HCSR04.new(trig: 26, echo: 27)
+distance = sensor.distance_cm
+puts "Distance: #{distance} cm"
+```
+
+## API
+
+### Methods
+
+- `HCSR04.new(trig:, echo:)` - Initialize sensor with trigger and echo pins
+- `distance_cm()` - Read distance in centimeters
+
+## Notes
+
+- Do not call `distance_cm` too frequently (minimum 200ms interval recommended)
+- Maximum detection range is approximately 400cm
+- Returns distance based on ultrasonic pulse reflection time

--- a/runtime_gems/picoruby-mcp3424/README.md
+++ b/runtime_gems/picoruby-mcp3424/README.md
@@ -1,0 +1,46 @@
+# picoruby-mcp3424
+
+MCP3424 18-bit ADC (Analog-to-Digital Converter) library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'mcp3424'
+
+i2c = I2C.new(unit: :RP2040_I2C0, sda_pin: 4, scl_pin: 5)
+adc = MCP3424.new(i2c: i2c, address_selector: 0)
+
+# Configure resolution and gain
+adc.bit_resolution = 16  # 12, 14, 16, or 18 bits
+adc.pga_gain = 1         # 1, 2, 4, or 8
+
+# One-shot reading
+value = adc.one_shot_read(1)  # Read channel 1
+puts "ADC value: #{value}"
+
+# Continuous conversion
+adc.start_continuous_conversion(1)
+loop do
+  value = adc.read
+  puts "ADC: #{value}" if value
+  sleep 0.1
+end
+```
+
+## API
+
+### Methods
+
+- `MCP3424.new(i2c:, address_selector:)` - Initialize ADC (address_selector: 0-3)
+- `bit_resolution=(bits)` - Set resolution (12, 14, 16, or 18 bits)
+- `pga_gain=(gain)` - Set programmable gain amplifier (1, 2, 4, or 8)
+- `one_shot_read(channel, timeout_ms = nil)` - Read one sample from channel (1-4)
+- `start_continuous_conversion(channel)` - Start continuous conversion on channel
+- `read(timeout_ms = nil)` - Read current ADC value
+- `set_address(address_selector)` - Change I2C address
+
+## Notes
+
+- Base I2C address: 0x68 (configurable with address_selector 0-3)
+- 4 differential input channels
+- Higher resolution = longer conversion time

--- a/runtime_gems/picoruby-mcp3x0x/README.md
+++ b/runtime_gems/picoruby-mcp3x0x/README.md
@@ -1,0 +1,58 @@
+# picoruby-mcp3x0x
+
+MCP3004/MCP3008/MCP3204/MCP3208 SPI ADC library for PicoRuby.
+
+## Usage
+
+```ruby
+require 'mcp3x0x'
+
+# MCP3008: 8-channel 10-bit ADC
+adc = MCP3008.new(
+  unit: :RP2040_SPI0,
+  sck_pin: 18,
+  cipo_pin: 16,
+  copi_pin: 19,
+  cs_pin: 17
+)
+
+# Single-ended read
+value = adc.read(0)  # Read channel 0 (0-7)
+puts "ADC: #{value}"
+
+# Differential read
+diff = adc.read(0, differential: true)  # CH0(+) - CH1(-)
+```
+
+## Supported Chips
+
+- **MCP3004**: 4-channel, 10-bit ADC
+- **MCP3008**: 8-channel, 10-bit ADC
+- **MCP3204**: 4-channel, 12-bit ADC
+- **MCP3208**: 8-channel, 12-bit ADC
+
+## API
+
+### Methods
+
+- `MCP300x.new(unit:, frequency: 500000, sck_pin:, cipo_pin:, copi_pin:, cs_pin:)` - Initialize ADC
+- `read(channel, differential: false)` - Read ADC value from channel
+
+### Channels
+
+**Single-ended mode** (differential: false):
+- MCP3004/MCP3204: channels 0-3
+- MCP3008/MCP3208: channels 0-7
+
+**Differential mode** (differential: true):
+- Channel 0: CH0(+) - CH1(-)
+- Channel 1: CH0(-) - CH1(+)
+- Channel 2: CH2(+) - CH3(-)
+- Channel 3: CH2(-) - CH3(+)
+- (MCP3008/MCP3208 have additional pairs for CH4-7)
+
+## Notes
+
+- Default SPI frequency: 500kHz
+- MCP3004/MCP3008: 10-bit resolution (0-1023)
+- MCP3204/MCP3208: 12-bit resolution (0-4095)

--- a/runtime_gems/picoruby-quectel_cellular/README.md
+++ b/runtime_gems/picoruby-quectel_cellular/README.md
@@ -1,0 +1,63 @@
+# picoruby-quectel_cellular
+
+Quectel cellular module driver for PicoRuby.
+
+## Overview
+
+This gem provides a Ruby interface for controlling Quectel cellular modem modules.
+It supports UDP and HTTPS communication through AT commands over UART.
+
+## Supported Modules
+
+- EC21 - LTE Cat 1
+- EC20 - LTE Cat 4
+- BG96 - LTE Cat M1/NB1
+
+## Features
+
+- Basic module control and SIM card management
+- UDP client communication
+- HTTPS client with TLS support
+- Soracom Beam UDP integration
+- File upload/download to module storage
+- Command logging for debugging
+
+## Usage
+
+### UDP Communication
+
+```ruby
+require 'quectel_cellular'
+
+uart = UART.new(unit: :RP2040_UART1, txd_pin: 8, rxd_pin: 9, baudrate: 115200)
+client = QuectelCellular::UDPClient.new(uart: uart)
+client.check_sim_status
+client.configure_and_activate_context
+client.send("example.com", 1234, "Hello, World!")
+```
+
+### HTTPS Communication
+
+See [example/ambient.rb](example/ambient.rb) for a complete example of sending sensor data to Ambient IoT service via HTTPS.
+
+### Module Reset (if PERST pin is connected)
+
+```ruby
+client.perst = GPIO.new(21, GPIO::OUT)
+client.reset
+```
+
+## Configuration
+
+Default APN settings are configured for Soracom:
+
+```ruby
+client.apn = "SORACOM.IO"
+client.username = "sora"
+client.password = "sora"
+client.user_agent = "picoruby"
+```
+
+## API Reference
+
+See [sig/quectel_cellular.rbs](sig/quectel_cellular.rbs) for complete API signatures.


### PR DESCRIPTION
## Summary
- Enhanced `rake runtime_gems` task to copy README.md files alongside compiled .mrb files
- Each gem's README.md (if present) is now exported to `runtime_gems/<gem_name>/README.md`

## Changes
Modified `lib/picoruby/runtime_gems.rb`:
- Renamed `mrb_files` variable to `output_files` to reflect that it now includes non-mrb files
- Added logic to check for README.md in each gem's source directory
- If README.md exists, it is registered as a Rake file task with proper dependency tracking

## Motivation
This change makes documentation available alongside the compiled runtime gems, improving usability for users who want to understand how to use each gem without referring back to the source repository.