### PR TITLE
Enabled `picoruby-rmt` to run on MicroRuby.

### DIFF
--- a/mrbgems/picoruby-rmt/src/mruby/rmt.c
+++ b/mrbgems/picoruby-rmt/src/mruby/rmt.c
@@ -1,0 +1,52 @@
+#include <mruby.h>
+#include <mruby/presym.h>
+#include <mruby/variable.h>
+#include <mruby/array.h>
+
+static mrb_value
+mrb_rmt__init(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pin, t0h_ns, t0l_ns, t1h_ns, t1l_ns, reset_ns;
+  mrb_get_args(mrb, "iiiiii", &pin, &t0h_ns, &t0l_ns, &t1h_ns, &t1l_ns, &reset_ns);
+
+  RMT_symbol_dulation_t rmt_symbol_dulation = {
+    .t0h_ns = t0h_ns,
+    .t0l_ns = t0l_ns,
+    .t1h_ns = t1h_ns,
+    .t1l_ns = t1l_ns,
+    .reset_ns = reset_ns
+  };
+
+  int ret = RMT_init((uint32_t)pin, &rmt_symbol_dulation);
+  return mrb_fixnum_value(ret);
+}
+
+static mrb_value
+mrb_rmt__write(mrb_state *mrb, mrb_value self)
+{
+  mrb_value value_ary;
+  mrb_get_args(mrb, "A", &value_ary);
+  int len = RARRAY_LEN(value_ary);
+  uint8_t txdata[len];
+
+  for (int i = 0 ; i < len ; i++) {
+    txdata[i] = mrb_integer(mrb_ary_ref(mrb, value_ary, i));
+  }
+
+  int ret = RMT_write(txdata, len);
+  return mrb_fixnum_value(ret);
+}
+
+void
+mrb_picoruby_rmt_gem_init(mrb_state* mrb)
+{
+  struct RClass *class_RMT = mrb_define_class_id(mrb, MRB_SYM(RMT), mrb->object_class);
+
+  mrb_define_method_id(mrb, class_RMT, MRB_SYM(_init), mrb_rmt__init, MRB_ARGS_REQ(6));
+  mrb_define_method_id(mrb, class_RMT, MRB_SYM(_write), mrb_rmt__write, MRB_ARGS_REQ(1));
+}
+
+void
+mrb_picoruby_rmt_gem_final(mrb_state* mrb)
+{
+}

--- a/mrbgems/picoruby-rmt/src/mrubyc/rmt.c
+++ b/mrbgems/picoruby-rmt/src/mrubyc/rmt.c
@@ -1,0 +1,39 @@
+#include <mrubyc.h>
+
+static void
+c_rmt__init(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  RMT_symbol_dulation_t rmt_symbol_dulation = {
+    .t0h_ns = GET_INT_ARG(2),
+    .t0l_ns = GET_INT_ARG(3),
+    .t1h_ns = GET_INT_ARG(4),
+    .t1l_ns = GET_INT_ARG(5),
+    .reset_ns = GET_INT_ARG(6)
+  };
+
+  int ret = RMT_init((uint32_t)GET_INT_ARG(1), &rmt_symbol_dulation);
+  SET_INT_RETURN(ret);
+}
+
+static void
+c_rmt__write(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_array value_ary = *(GET_ARY_ARG(1).array);
+  int len = value_ary.n_stored;
+  uint8_t txdata[len];
+
+  for (int i = 0 ; i < len ; i++) {
+    txdata[i] = mrbc_integer(value_ary.data[i]);
+  }
+
+  int ret = RMT_write(txdata, len);
+  SET_INT_RETURN(ret);
+}
+
+void
+mrbc_rmt_init(mrbc_vm *vm)
+{
+  mrbc_class *mrbc_class_RMT = mrbc_define_class(vm, "RMT", mrbc_class_object);
+  mrbc_define_method(vm, mrbc_class_RMT, "_init", c_rmt__init);
+  mrbc_define_method(vm, mrbc_class_RMT, "_write", c_rmt__write);
+}

--- a/mrbgems/picoruby-rmt/src/rmt.c
+++ b/mrbgems/picoruby-rmt/src/rmt.c
@@ -1,41 +1,11 @@
-#include <mrubyc.h>
-
 #include "rmt.h"
 
-static void
-c_rmt__init(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  RMT_symbol_dulation_t rmt_symbol_dulation = {
-    .t0h_ns = GET_INT_ARG(2),
-    .t0l_ns = GET_INT_ARG(3),
-    .t1h_ns = GET_INT_ARG(4),
-    .t1l_ns = GET_INT_ARG(5),
-    .reset_ns = GET_INT_ARG(6)
-  };
+#if defined(PICORB_VM_MRUBY)
 
-  int ret = RMT_init((uint32_t)GET_INT_ARG(1), &rmt_symbol_dulation);
-  SET_INT_RETURN(ret);
-}
+#include "mruby/rmt.c"
 
-static void
-c_rmt__write(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  mrbc_array value_ary = *(GET_ARY_ARG(1).array);
-  int len = value_ary.n_stored;
-  uint8_t txdata[len];
+#elif defined(PICORB_VM_MRUBYC)
 
-  for (int i = 0 ; i < len ; i++) {
-    txdata[i] = mrbc_integer(value_ary.data[i]);
-  }
+#include "mrubyc/rmt.c"
 
-  int ret = RMT_write(txdata, len);
-  SET_INT_RETURN(ret);
-}
-
-void
-mrbc_rmt_init(mrbc_vm *vm)
-{
-  mrbc_class *mrbc_class_RMT = mrbc_define_class(vm, "RMT", mrbc_class_object);
-  mrbc_define_method(vm, mrbc_class_RMT, "_init", c_rmt__init);
-  mrbc_define_method(vm, mrbc_class_RMT, "_write", c_rmt__write);
-}
+#endif


### PR DESCRIPTION
## Overview

Enabled `picoruby-rmt` to run on MicroRuby.

## What Was Done

Added support for switching source code depending on the VM by creating `mruby` and `mrubyc` directories under `mrbgems/picoruby-rmt/src`.
