### PR TITLE
Generate machine_id when `Machine.unique_id` is nil for macOS

### DIFF
--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -123,7 +123,8 @@ class Shell
         self.ensure_system_file(path, exe[:code], exe[:crc])
       end
       path = "#{root}/etc/machine-id"
-      self.ensure_system_file(path, Machine.unique_id, nil)
+      machine_id = Machine.unique_id || self.generate_machine_id
+      self.ensure_system_file(path, machine_id, nil)
     end
     Dir.chdir ENV['HOME'] || ENV_DEFAULT_HOME
 
@@ -166,6 +167,18 @@ class Shell
       end
     rescue
     end
+  end
+
+  def self.generate_machine_id
+    x = Time.now.to_i & 0xffffffff
+    bytes = ""
+    16.times do
+      x ^= (x << 13) & 0xffffffff
+      x ^= (x >> 7)
+      x ^= (x << 17) & 0xffffffff
+      bytes << sprintf("%02x", x & 0xff)
+    end
+    bytes
   end
 
   def self.bootstrap(file)

--- a/mrbgems/picoruby-shell/sig/shell.rbs
+++ b/mrbgems/picoruby-shell/sig/shell.rbs
@@ -34,6 +34,7 @@ class Shell
   def self.setup_root_volume: (Symbol drive, ?label: String) -> void
   def self.ensure_system_file: (String path, String code, ?(Integer | nil) crc) -> void
   def self.setup_system_files: (?(String | nil) root, ?force: bool) -> void
+  def self.generate_machine_id: -> String
   def self.bootstrap: (String file) -> bool
   def self.simple_question: (String question) { (String answer) -> boolish } -> void
   def self.find_executable: (String name) -> String?


### PR DESCRIPTION
macOS doesn't have machine id, so generate it.

Resolved error is below:

```console
❯ bin/r2p2
Created root directory: /Users/makicamel/github.com/makicamel/picoruby/.r2p2
Creating directory: bin
Creating directory: home
Creating directory: etc
Creating directory: etc/init.d
Creating directory: etc/network
Creating directory: var
Creating directory: var/log
Creating directory: lib

# ... snip ...

Failed to open /etc/machine-id: No such file or directory
Writing : /Users/makicamel/github.com/makicamel/picoruby/.r2p2/etc/machine-id
undefined local variable or method 'length' for NilClass
```