### PR TITLE
Add `unpack` method and format pattern `n` to picoruby-pack

### DIFF
--- a/mrbgems/picoruby-pack/README.md
+++ b/mrbgems/picoruby-pack/README.md
@@ -8,7 +8,7 @@ Array and String pack/unpack methods for PicoRuby.
 require 'pack'
 
 # Pack array into binary string
-data = [1, 2, 3, 4].pack("C*")  # Pack as unsigned chars
+data = [1, 2, 3, 4].pack("CCCC")  # Pack as unsigned chars
 
 # Pack with different formats
 value = [0x12345678].pack("N")  # Network byte order (big-endian) 32-bit
@@ -17,6 +17,14 @@ bytes = [255, 128, 64].pack("CCC")  # Three unsigned 8-bit integers
 # String.pack (class method)
 packed = String.pack("C*", 72, 101, 108, 108, 111)
 puts packed  # => "Hello"
+
+# Unpack binary string into an array
+unpacked_data = "Hello".unpack("CCCCC")
+p unpacked_data  # => [72, 101, 108, 108, 111]
+
+# Unpack with different formats
+value = "\x12\x34\x56\x78".unpack("N")
+p value # => [305419896]
 ```
 
 ## Common Format Specifiers
@@ -39,6 +47,8 @@ puts packed  # => "Hello"
 
 - `Array#pack(format)` - Pack array elements into binary string
 - `String.pack(format, *args)` - Pack arguments into binary string
+- `String#unpack(format)` - Unpack binary string into an array of values
+- `Array.unpack(format, *args)` - Unpack arguments into an array of values
 
 ## Notes
 

--- a/mrbgems/picoruby-pack/mrblib/pack.rb
+++ b/mrbgems/picoruby-pack/mrblib/pack.rb
@@ -16,6 +16,9 @@ class String
         result << ((arg >> 16) & 0xFF).chr
         result << ((arg >> 8) & 0xFF).chr
         result << (arg & 0xFF).chr
+      when 'n'
+        result << ((arg >> 8) & 0xFF).chr
+        result << (arg & 0xFF).chr
       else
         raise ArgumentError, "Unsupported format character: #{f}"
       end
@@ -26,12 +29,57 @@ class String
 
     result
   end
+
+  def unpack(format)
+    Array.unpack(format, self)
+  end
 end
 
 class Array
+  def self.unpack(format, packed_string)
+    result = []
+    str_index = 0
+    format_index = 0
+    while format_index < format.size
+      f = format[format_index]
+      case f
+      when 'C'
+        s = packed_string[str_index, 1]
+        if s.is_a? String
+          result << s.ord
+          str_index += 1
+        else
+          raise ArgumentError, "not enough data for format 'C'"
+        end
+      when 'N'
+        s = packed_string[str_index, 4] || ''
+        s1, s2, s3, s4 = s[0], s[1], s[2], s[3]
+        if s1.is_a?(String) && s2.is_a?(String) && s3.is_a?(String) && s4.is_a?(String) 
+          val = (s1.ord << 24) | (s2.ord << 16) | (s3.ord << 8) | (s4.ord)
+          result << val
+          str_index += 4
+        else
+          raise ArgumentError, "not enough data for format 'N'"
+        end
+      when 'n'
+        s = packed_string[str_index, 2] || ''
+        s1, s2 = s[0], s[1]
+        if s1.is_a?(String) && s2.is_a?(String)
+          val = (s1.ord << 8) | (s2.ord)
+          result << val
+          str_index += 2
+        else
+          raise ArgumentError, "not enough data for format 'n'"
+        end
+      else
+        raise ArgumentError, "Unsupported format character: #{f}"
+      end
+      format_index += 1
+    end
+    result
+  end
+
   def pack(format)
     String.pack(format, *self)
   end
 end
-
-

--- a/mrbgems/picoruby-pack/sig/pack.rbs
+++ b/mrbgems/picoruby-pack/sig/pack.rbs
@@ -2,10 +2,12 @@
 # @added_by picoruby-pack
 class String
   def self.pack: (String format, *untyped args) -> String
+  def unpack: (String format) -> Array[untyped]
 end
 
 # @sidebar builtin
 # @added_by picoruby-pack
 class Array[unchecked out Elem] < Object
+  def self.unpack: (String format, String packed_string) -> Array[untyped]
   def pack: (String format) -> String
 end

--- a/mrbgems/picoruby-pack/test/pack_test.rb
+++ b/mrbgems/picoruby-pack/test/pack_test.rb
@@ -1,0 +1,25 @@
+class PackTest < Picotest::Test
+  def test_pack_C
+    assert_equal "A", [65].pack("C")
+  end
+
+  def test_pack_N
+    assert_equal "\x00\x00\x00\x01", [1].pack("N")
+  end
+
+  def test_pack_n
+    assert_equal "\x00\x01", [1].pack("n")
+  end
+
+  def test_unpack_C
+    assert_equal [65], "A".unpack("C")
+  end
+
+  def test_unpack_N
+    assert_equal [1], "\x00\x00\x00\x01".unpack("N")
+  end
+
+  def test_unpack_n
+    assert_equal [1], "\x00\x01".unpack("n")
+  end
+end


### PR DESCRIPTION
Previously, **picoruby-pack** only implemented the `pack` method, and the supported format patterns were limited to `C` and `N`.

This Pull Request extends the functionality with the following two additions:

1. Implementation of the `unpack` method  
2. Addition of the format pattern `n`

In addition to the implementation changes, this Pull Request also includes:

- New and updated tests covering the `unpack` method and the `n` format pattern  
- Updates to the README to document the newly added functionality