### PR TITLE
Fix `Shell#_cd` with relative path breakes `ENV['PWD']`

### DIFF
--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -743,8 +743,8 @@ class Shell
       return false
     end
     ENV['OLDPWD'] = Dir.pwd
-    ENV['PWD'] = dir
     Dir.chdir(dir)
+    ENV['PWD'] = Dir.pwd
   end
 
   def _exit(*args)


### PR DESCRIPTION
This PR fixes `Shell#_cd` with relative path breakes `ENV['PWD']`.

Before:
```
$> pwd
/home
$> ls
test
$> cd test
$> export
# ...snip...
PWD="/test/test"
# ...snip...
$> pwd
/test/test
$>
```

After:
```
$> pwd
/home
$> ls
test
$> cd test
$> export
# ...snip...
PWD="/home/test"
# ...snip...
$> pwd
/home/test
$>
```

`VFS.chdir` sets `ENV['PWD']` so we don't need to set here for `VFS`, but may need for POSIX.