### PR TITLE
Add picoruby-mqtt

### DIFF
--- a/mrbgems/picoruby-mqtt/README.md
+++ b/mrbgems/picoruby-mqtt/README.md
@@ -1,0 +1,178 @@
+# picoruby-mqtt
+
+MQTT client for PicoRuby.
+
+This is a pure Ruby implementation of MQTT 3.1.1 client for PicoRuby, designed for IoT devices.
+
+## Features
+
+- MQTT 3.1.1 protocol support
+- QoS 0 (At most once delivery)
+- CONNECT, PUBLISH, SUBSCRIBE, UNSUBSCRIBE, PING, DISCONNECT
+- Keep-alive with automatic PING
+- Clean session support
+- Retained messages
+- Uses TCPSocket from picoruby-socket-class
+
+## Installation
+
+Add to your `build_config.rb`:
+
+```ruby
+conf.gem :core => 'picoruby-mqtt'
+```
+
+## Usage
+
+### Connect and Publish
+
+```ruby
+require 'mqtt'
+
+# Connect to MQTT broker
+client = MQTT::Client.new("test.mosquitto.org", 1883)
+client.connect(client_id: "picoruby-device")
+
+# Publish a message
+client.publish("sensors/temperature", "25.5")
+
+# Disconnect
+client.disconnect
+```
+
+### Subscribe to Topics
+
+```ruby
+require 'mqtt'
+
+client = MQTT::Client.new("test.mosquitto.org", 1883)
+client.connect(client_id: "picoruby-subscriber")
+
+# Subscribe to a topic
+client.subscribe("sensors/#")
+
+# Receive messages
+5.times do
+  topic, message = client.receive
+  puts "#{topic}: #{message}"
+end
+
+client.disconnect
+```
+
+### With Block
+
+```ruby
+require 'mqtt'
+
+MQTT::Client.connect("test.mosquitto.org", 1883, client_id: "picoruby") do |client|
+  client.publish("hello/world", "Hello from PicoRuby!")
+end
+```
+
+### Keep-Alive
+
+```ruby
+client = MQTT::Client.new("test.mosquitto.org", 1883)
+client.connect(
+  client_id: "picoruby-device",
+  keep_alive: 60  # Send PING every 60 seconds
+)
+
+# Client will automatically send PING requests
+# to keep the connection alive
+```
+
+### Retained Messages
+
+```ruby
+client = MQTT::Client.new("test.mosquitto.org", 1883)
+client.connect(client_id: "picoruby")
+
+# Publish a retained message
+client.publish("device/status", "online", retain: true)
+
+client.disconnect
+```
+
+## API Reference
+
+### MQTT::Client
+
+#### Class Methods
+
+- `MQTT::Client.new(host, port = 1883)` - Create new MQTT client
+- `MQTT::Client.connect(host, port = 1883, **options) { |client| ... }` - Connect with block
+
+#### Instance Methods
+
+- `connect(**options)` - Connect to broker
+  - `client_id:` - Client identifier (default: random)
+  - `keep_alive:` - Keep-alive interval in seconds (default: 60)
+  - `clean_session:` - Clean session flag (default: true)
+  - `username:` - Username for authentication
+  - `password:` - Password for authentication
+
+- `publish(topic, payload, retain: false, qos: 0)` - Publish message
+  - `topic` - Topic name
+  - `payload` - Message payload (string)
+  - `retain` - Retain flag (default: false)
+  - `qos` - Quality of Service (0 only, default: 0)
+
+- `subscribe(*topics, qos: 0)` - Subscribe to topics
+  - `topics` - One or more topic filters
+  - `qos` - Quality of Service (0 only, default: 0)
+
+- `unsubscribe(*topics)` - Unsubscribe from topics
+
+- `receive(timeout: nil)` - Receive next message
+  - Returns `[topic, payload]` or `nil` on timeout
+
+- `ping` - Send PING request
+
+- `disconnect` - Disconnect from broker
+
+- `connected?` - Check connection status
+
+## Supported Features
+
+- ✅ CONNECT / CONNACK
+- ✅ PUBLISH (QoS 0)
+- ✅ SUBSCRIBE / SUBACK
+- ✅ UNSUBSCRIBE / UNSUBACK
+- ✅ PINGREQ / PINGRESP
+- ✅ DISCONNECT
+- ✅ Keep-alive
+- ✅ Retained messages
+- ✅ Clean session
+- ✅ Username/password authentication
+- ⚠️ QoS 1/2 not supported
+- ⚠️ Will message not supported
+
+## Example: IoT Sensor
+
+```ruby
+require 'mqtt'
+
+def read_temperature
+  # Read from sensor
+  22.5 + rand * 3
+end
+
+client = MQTT::Client.new("mqtt.example.com", 1883)
+client.connect(
+  client_id: "sensor-001",
+  keep_alive: 30
+)
+
+# Publish sensor data every 5 seconds
+loop do
+  temp = read_temperature
+  client.publish("sensors/temperature", temp.to_s)
+  sleep 5
+end
+```
+
+## License
+
+MIT

--- a/mrbgems/picoruby-mqtt/mrbgem.rake
+++ b/mrbgems/picoruby-mqtt/mrbgem.rake
@@ -1,0 +1,13 @@
+MRuby::Gem::Specification.new('picoruby-mqtt') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'HASUMI Hitoshi'
+  spec.summary = 'MQTT client for PicoRuby'
+
+  spec.add_dependency 'picoruby-socket'
+
+  if build.vm_mruby?
+    spec.add_dependency 'mruby-pack', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-pack"
+  elsif build.vm_mrubyc?
+    spec.add_dependency 'picoruby-pack'
+  end
+end

--- a/mrbgems/picoruby-mqtt/mrblib/mqtt.rb
+++ b/mrbgems/picoruby-mqtt/mrblib/mqtt.rb
@@ -1,0 +1,456 @@
+#
+# MQTT library for PicoRuby
+# This is a pure Ruby implementation of MQTT 3.1.1 client.
+# Designed for IoT devices and constrained environments.
+#
+# Author: Hitoshi HASUMI
+# License: MIT
+#
+
+require 'socket'
+require 'pack'
+
+module MQTT
+  class MQTTError < StandardError; end
+  class ConnectionError < MQTTError; end
+  class ProtocolError < MQTTError; end
+
+  # MQTT Control Packet Types
+  CONNECT     = 1
+  CONNACK     = 2
+  PUBLISH     = 3
+  PUBACK      = 4
+  PUBREC      = 5
+  PUBREL      = 6
+  PUBCOMP     = 7
+  SUBSCRIBE   = 8
+  SUBACK      = 9
+  UNSUBSCRIBE = 10
+  UNSUBACK    = 11
+  PINGREQ     = 12
+  PINGRESP    = 13
+  DISCONNECT  = 14
+
+  # Connection return codes
+  CONNACK_ACCEPTED              = 0x00
+  CONNACK_REFUSED_PROTOCOL      = 0x01
+  CONNACK_REFUSED_IDENTIFIER    = 0x02
+  CONNACK_REFUSED_SERVER        = 0x03
+  CONNACK_REFUSED_CREDENTIALS   = 0x04
+  CONNACK_REFUSED_AUTHORIZED    = 0x05
+
+  class Client
+    attr_reader :host, :port
+    attr_accessor :client_id, :keep_alive, :clean_session
+    attr_accessor :username, :password
+
+    def initialize(host, port = 1883)
+      @host = host
+      @port = port
+      @client_id = nil
+      @keep_alive = 60
+      @clean_session = true
+      @username = nil
+      @password = nil
+      @socket = nil
+      @packet_id = 0
+      @last_ping = nil
+    end
+
+    def self.connect(host, port = 1883, **options, &block)
+      client = new(host, port)
+      client.connect(**options)
+      if block
+        begin
+          block.call(client)
+        ensure
+          client.disconnect
+        end
+      else
+        client
+      end
+    end
+
+    def connect(**options)
+      @client_id = options[:client_id] || "picoruby_#{Time.now.to_i}"
+      @keep_alive = options[:keep_alive] || 60
+      @clean_session = options[:clean_session] || true
+      @username = options[:username]
+      @password = options[:password]
+
+      # Open TCP connection
+      @socket = TCPSocket.new(@host, @port)
+
+      # Send CONNECT packet
+      send_connect
+
+      # Receive CONNACK
+      receive_connack
+
+      @last_ping = Time.now
+      true
+    end
+
+    def connected?
+      @socket.nil? ? false : !(@socket.closed?)
+    end
+
+    def publish(topic, payload, retain: false, qos: 0)
+      raise MQTTError.new("Not connected") unless connected?
+      raise MQTTError.new("QoS must be 0") if qos != 0
+
+      send_publish(topic, payload, retain: retain, qos: qos)
+    end
+
+    def subscribe(*topics, qos: 0)
+      raise MQTTError.new("Not connected") unless connected?
+      raise MQTTError.new("QoS must be 0") if qos != 0
+
+      send_subscribe(topics, qos)
+      receive_suback
+    end
+
+    def unsubscribe(*topics)
+      raise MQTTError.new("Not connected") unless connected?
+
+      send_unsubscribe(topics)
+      receive_unsuback
+    end
+
+    def receive(timeout: nil)
+      raise MQTTError.new("Not connected") unless connected?
+
+      # Check if we need to send PING
+      check_keepalive
+
+      # Wait for PUBLISH packet
+      deadline = timeout ? Time.now.to_f + timeout : nil
+
+      loop do
+        if deadline && Time.now.to_f > deadline
+          return nil
+        end
+
+        # Non-blocking receive with short timeout
+        packet_type, flags, data = receive_packet
+
+        case packet_type
+        when PUBLISH
+          # Parse PUBLISH packet
+          topic, payload = parse_publish(flags, data)
+          return [topic, payload]
+        when PINGRESP
+          # Update last ping time
+          @last_ping = Time.now
+        else
+          # Unexpected packet, ignore
+        end
+
+        # Check keepalive even while waiting
+        check_keepalive
+      end
+
+      nil # never reached
+    end
+
+    def ping
+      raise MQTTError.new("Not connected") unless connected?
+
+      send_ping
+      @last_ping = Time.now
+
+      # Wait for PINGRESP
+      packet_type, flags, data = receive_packet
+      if packet_type != PINGRESP
+        raise ProtocolError.new("Expected PINGRESP, got #{packet_type}")
+      end
+
+      true
+    end
+
+    def disconnect
+      return unless connected?
+
+      send_disconnect
+      @socket.close
+      @socket = nil
+    end
+
+    private
+
+    def next_packet_id
+      @packet_id = (@packet_id + 1) & 0xFFFF
+      @packet_id = 1 if @packet_id == 0
+      @packet_id
+    end
+
+    def check_keepalive
+      return unless @keep_alive > 0
+
+      elapsed = Time.now.to_f - @last_ping.to_f
+      if elapsed >= @keep_alive * 0.8
+        ping
+      end
+    end
+
+    # Encode variable length integer
+    def encode_length(length)
+      result = ""
+      loop do
+        byte = length % 128
+        length = length / 128
+        if length > 0
+          byte |= 0x80
+        end
+        result += [byte].pack("C")
+        break if length == 0
+      end
+      result
+    end
+
+    # Decode variable length integer
+    def decode_length(data, offset = 0)
+      multiplier = 1
+      value = 0
+      loop do
+        sliced_data = data[offset]
+        break unless sliced_data.is_a?(String)
+
+        byte = sliced_data.ord
+        offset += 1
+        value += (byte & 0x7F) * multiplier
+        break if (byte & 0x80) == 0
+        multiplier *= 128
+        raise ProtocolError.new("Invalid remaining length") if multiplier > 128*128*128
+      end
+      [value, offset]
+    end
+
+    # Encode string with length prefix
+    def encode_string(str)
+      [str.length].pack("n") + str
+    end
+
+    def send_connect
+      # Variable header
+      protocol_name = encode_string("MQTT")
+      protocol_level = [4].pack("C")  # MQTT 3.1.1
+
+      # Connect flags
+      flags = 0
+      flags |= 0x02 if @clean_session  # Clean session
+      if @username
+        flags |= 0x80  # Username flag
+        flags |= 0x40 if @password  # Password flag
+      end
+
+      connect_flags = [flags].pack("C")
+      keep_alive = [@keep_alive].pack("n")
+
+      variable_header = protocol_name + protocol_level + connect_flags + keep_alive
+
+      # Payload
+      payload = encode_string(@client_id)
+      payload += encode_string(@username) if @username
+      payload += encode_string(@password || "") if @password
+
+      # Fixed header
+      packet_type = (CONNECT << 4)
+      remaining_length = variable_header.length + payload.length
+
+      packet = [packet_type].pack("C") + encode_length(remaining_length) + variable_header + payload
+
+      @socket.write(packet)
+    end
+
+    def receive_connack
+      packet_type, flags, data = receive_packet
+
+      if packet_type != CONNACK
+        raise ProtocolError.new("Expected CONNACK, got #{packet_type}")
+      end
+
+      if data.length < 2
+        raise ProtocolError.new("Invalid CONNACK packet")
+      end
+
+      return_code_data = data[1]
+      return_code = return_code_data.is_a?(String) ? return_code_data.ord : -1
+
+      if return_code != CONNACK_ACCEPTED
+        error_messages = {
+          CONNACK_REFUSED_PROTOCOL => "Unacceptable protocol version",
+          CONNACK_REFUSED_IDENTIFIER => "Identifier rejected",
+          CONNACK_REFUSED_SERVER => "Server unavailable",
+          CONNACK_REFUSED_CREDENTIALS => "Bad username or password",
+          CONNACK_REFUSED_AUTHORIZED => "Not authorized"
+        }
+        raise ConnectionError.new(error_messages[return_code] || "Connection refused: #{return_code}")
+      end
+
+      true
+    end
+
+    def send_publish(topic, payload, retain: false, qos: 0)
+      # Variable header
+      variable_header = encode_string(topic)
+
+      # No packet identifier for QoS 0
+
+      # Fixed header
+      flags = 0
+      flags |= 0x01 if retain
+      flags |= (qos << 1)
+
+      packet_type = (PUBLISH << 4) | flags
+      remaining_length = variable_header.length + payload.length
+
+      packet = [packet_type].pack("C") + encode_length(remaining_length) + variable_header + payload
+
+      @socket.write(packet)
+    end
+
+    def send_subscribe(topics, qos)
+      # Variable header
+      packet_id = next_packet_id
+      variable_header = [packet_id].pack("n")
+
+      # Payload
+      payload = ""
+      topics.each do |topic|
+        payload += encode_string(topic)
+        payload += [qos].pack("C")
+      end
+
+      # Fixed header
+      packet_type = (SUBSCRIBE << 4) | 0x02  # Reserved flags
+      remaining_length = variable_header.length + payload.length
+
+      packet = [packet_type].pack("C") + encode_length(remaining_length) + variable_header + payload
+
+      @socket.write(packet)
+    end
+
+    def receive_suback
+      packet_type, flags, data = receive_packet
+
+      if packet_type != SUBACK
+        raise ProtocolError.new("Expected SUBACK, got #{packet_type}")
+      end
+
+      # data[0..1] is packet ID
+      # data[2..-1] are return codes for each subscription
+      # For now, we just check that we got SUBACK
+      true
+    end
+
+    def send_unsubscribe(topics)
+      # Variable header
+      packet_id = next_packet_id
+      variable_header = [packet_id].pack("n")
+
+      # Payload
+      payload = ""
+      topics.each do |topic|
+        payload += encode_string(topic)
+      end
+
+      # Fixed header
+      packet_type = (UNSUBSCRIBE << 4) | 0x02  # Reserved flags
+      remaining_length = variable_header.length + payload.length
+
+      packet = [packet_type].pack("C") + encode_length(remaining_length) + variable_header + payload
+
+      @socket.write(packet)
+    end
+
+    def receive_unsuback
+      packet_type, flags, data = receive_packet
+
+      if packet_type != UNSUBACK
+        raise ProtocolError.new("Expected UNSUBACK, got #{packet_type}")
+      end
+
+      true
+    end
+
+    def send_ping
+      packet_type = (PINGREQ << 4)
+      packet = [packet_type, 0].pack("CC")
+
+      @socket.write(packet)
+    end
+
+    def send_disconnect
+      packet_type = (DISCONNECT << 4)
+      packet = [packet_type, 0].pack("CC")
+
+      @socket.write(packet)
+    end
+
+    def receive_packet
+      # Read fixed header
+      byte1 = @socket.read(1)
+      raise ConnectionError.new("Connection closed") if byte1.nil? || byte1.empty?
+
+      packet_type = (byte1[0].ord >> 4) & 0x0F
+      flags = byte1[0].ord & 0x0F
+
+      # Read remaining length
+      remaining_length, offset = read_remaining_length
+
+      # Read data
+      data = ""
+      if remaining_length > 0
+        data = @socket.read(remaining_length)
+        if data.nil? || data.length < remaining_length
+          raise ConnectionError.new("Incomplete packet")
+        end
+      end
+
+      [packet_type, flags, data]
+    end
+
+    def read_remaining_length
+      multiplier = 1
+      value = 0
+      loop do
+        byte_str = @socket.read(1)
+        raise ConnectionError.new("Connection closed") if byte_str.nil? || byte_str.empty?
+
+        byte = byte_str[0].ord
+        value += (byte & 0x7F) * multiplier
+        break if (byte & 0x80) == 0
+        multiplier *= 128
+        raise ProtocolError.new("Invalid remaining length") if multiplier > 128*128*128
+      end
+      [value, 0]
+    end
+
+    def parse_publish(flags, data)
+      offset = 0
+
+      # Topic name
+      topic_data = data[offset, 2] || ''
+      topic_length = topic_data.unpack("n")[0]
+      offset += 2
+      topic = data[offset, topic_length] || ''
+      offset += topic_length
+
+      # QoS level
+      qos = (flags >> 1) & 0x03
+
+      # Packet ID (only for QoS > 0)
+      if qos > 0
+        packet_id_data = data[offset, 2] || ''
+        packet_id = packet_id_data.unpack("n")[0]
+        offset += 2
+      end
+
+      # Payload
+      payload = data[offset..-1] || ''
+
+      [topic, payload]
+    end
+  end
+end

--- a/mrbgems/picoruby-mqtt/sig/mqtt.rbs
+++ b/mrbgems/picoruby-mqtt/sig/mqtt.rbs
@@ -1,0 +1,91 @@
+module MQTT
+  # @sidebar error
+  class MQTTError < StandardError
+  end
+  # @sidebar error
+  class ConnectionError < MQTTError
+  end
+  # @sidebar error
+  class ProtocolError < MQTTError
+  end
+
+  CONNECT: Integer
+  CONNACK: Integer
+  PUBLISH: Integer
+  PUBACK: Integer
+  PUBREC: Integer
+  PUBREL: Integer
+  PUBCOMP: Integer
+  SUBSCRIBE: Integer
+  SUBACK: Integer
+  UNSUBSCRIBE: Integer
+  UNSUBACK: Integer
+  PINGREQ: Integer
+  PINGRESP: Integer
+  DISCONNECT: Integer
+
+  CONNACK_ACCEPTED: Integer
+  CONNACK_REFUSED_PROTOCOL: Integer
+  CONNACK_REFUSED_IDENTIFIER: Integer
+  CONNACK_REFUSED_SERVER: Integer
+  CONNACK_REFUSED_CREDENTIALS: Integer
+  CONNACK_REFUSED_AUTHORIZED: Integer
+
+  class Client
+
+    def initialize: (String, ?Integer) -> void
+
+    def self.connect: (String, ?Integer, ?client_id: String?, ?keep_alive: Integer, ?clean_session: bool, ?username: String?, ?password: String?) { (Client) -> void } -> void
+                    | (String, ?Integer, ?client_id: String?, ?keep_alive: Integer, ?clean_session: bool, ?username: String?, ?password: String?) -> Client
+
+    def connect: (?client_id: String?, ?keep_alive: Integer, ?clean_session: bool, ?username: String?, ?password: String?) -> bool
+
+    def connected?: () -> bool
+
+    def publish: (String, String, ?retain: bool, ?qos: Integer) -> void
+
+    def subscribe: (*String, ?qos: Integer) -> void
+
+    def unsubscribe: (*String) -> void
+
+    def receive: (?timeout: (Integer | Float)?) -> [String, String]?
+
+    def ping: () -> bool
+
+    def disconnect: () -> void
+
+    private def next_packet_id: () -> Integer
+
+    private def check_keepalive: () -> void
+
+    private def encode_length: (Integer) -> String
+
+    private def decode_length: (String, ?Integer) -> [Integer, Integer]
+
+    private def encode_string: (String) -> String
+
+    private def send_connect: () -> void
+
+    private def receive_connack: () -> bool
+
+    private def send_publish: (String, String, retain: bool, qos: Integer) -> void
+
+    private def send_subscribe: (Array[String], Integer) -> void
+
+    private def receive_suback: () -> bool
+
+    private def send_unsubscribe: (Array[String]) -> void
+
+    private def receive_unsuback: () -> bool
+
+    private def send_ping: () -> void
+
+    private def send_disconnect: () -> void
+
+    private def receive_packet: () -> [Integer, Integer, String]
+
+    private def read_remaining_length: () -> [Integer, Integer]
+
+    private def parse_publish: (Integer, String) -> [String, String]
+  end
+end

--- a/mrbgems/picoruby-mqtt/test/mqtt_test.rb
+++ b/mrbgems/picoruby-mqtt/test/mqtt_test.rb
@@ -1,0 +1,48 @@
+class MQTTClientTest < Picotest::Test
+  def test_mqtt_new
+    client = MQTT::Client.new('127.0.0.1', 1883)
+    assert_equal('127.0.0.1', client.host)
+    assert_equal(1883, client.port)
+    assert_false(client.connected?)
+  end
+
+  # Note: The following tests require an external MQTT broker for connectivity.
+  # They are currently commented out because:
+  # 1. They depend on an external MQTT broker.
+  # 2. Integration tests with network services often require threading/async support,
+  #    which is not readily available in the current test environment.
+  # Uncomment and ensure an MQTT broker is running before attempting to run these tests.
+
+  # def test_mqtt_connect_disconnect
+  #   client = MQTT::Client.new('127.0.0.1', 1883)
+  #   client.connect(client_id:  "picoruby-mqtt-test-#{Time.now.to_i}")
+  #   assert_true(client.connected?)
+
+  #   client.disconnect
+  #   assert_false(client.connected?)
+  # end
+
+  # def test_mqtt_publish
+  #   client = MQTT::Client.new('127.0.0.1', 1883)
+  #   client_id = "picoruby-mqtt-test-#{Time.now.to_i}"
+  #   client.connect(client_id:  client_id)
+
+  #   topic = "picoruby-test/topic-#{client_id}"
+  #   message = "Hello from PicoRuby MQTT test!"
+  #   client.publish(topic, message)
+
+  #   client.disconnect
+  # end
+
+  # def test_mqtt_subscribe
+  #   client = MQTT::Client.new('127.0.0.1', 1883)
+  #   client_id = "picoruby-mqtt-test-#{Time.now.to_i}"
+  #   client.connect(client_id:  client_id)
+
+  #   topic = "picoruby-test/topic-#{client_id}"
+  #   client.subscribe(topic)
+  #   client.unsubscribe(topic)
+
+  #   client.disconnect
+  # end
+end


### PR DESCRIPTION
I debugged this branch and added an MQTT client class.

https://github.com/picoruby/picoruby/tree/claude/picoruby-mqtt-gem-01F9YXMWyzg64jqcCALh1zAN/mrbgems/picoruby-mqtt

The tests are currently commented out because they require an MQTT broker to be running on `127.0.0.1`.
