### PR TITLE
Fix stdlib.gembox to select the correct pack gem for the target VM

### DIFF
--- a/mrbgems/stdlib.gembox
+++ b/mrbgems/stdlib.gembox
@@ -5,14 +5,15 @@ MRuby::GemBox.new do |conf|
   conf.gem core: 'picoruby-json'
   conf.gem core: 'picoruby-yaml'
   conf.gem core: "picoruby-eval"
-  conf.gem core: "picoruby-pack"
   conf.gem core: "picoruby-marshal"
   conf.gem core: 'picoruby-data'
   conf.gem core: 'picoruby-logger'
   if vm_mrubyc?
+    conf.gem core: "picoruby-pack"
     conf.gem core: "picoruby-numeric-ext"
     conf.gem core: "picoruby-metaprog"
   elsif vm_mruby?
+    conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-pack"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-kernel-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-string-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-array-ext"


### PR DESCRIPTION
## Summary
Fix a MicroRuby build failure caused by `stdlib.gembox` not selecting the appropriate pack `mrbgem` depending on whether the target VM is `mrubyc` or `mruby`.

## Changes
- Update `stdlib.gembox` to choose:
  - `picoruby-pack` when building for the `mrubyc` VM
  - `mruby-pack` when building for the `mruby` VM
- Ensure the correct `mrbgem` is included so the MicroRuby build does not fail due to a mismatched pack implementation.
