### PR TITLE
Apply patch to fix type mismatch

### DIFF
--- a/mrbgems/picoruby-net/mrbgem.rake
+++ b/mrbgems/picoruby-net/mrbgem.rake
@@ -67,6 +67,19 @@ MRuby::Gem::Specification.new('picoruby-net') do |spec|
       sh "git clone -b #{LWIP_VERSION} #{LWIP_REPO} #{lwip_dir}"
     end
 
+    # Apply patches to LwIP
+    patch_file = "#{dir}/patches/lwip-altcp-proxyconnect.patch"
+    if File.exist?(patch_file)
+      proxyconnect_file = "#{lwip_dir}/src/apps/http/altcp_proxyconnect.c"
+      if File.exist?(proxyconnect_file)
+        patch_applied = `cd #{lwip_dir} && git apply --check #{patch_file} 2>&1`.strip
+        if patch_applied.empty?
+          sh "cd #{lwip_dir} && git apply #{patch_file}"
+          puts "Applied patch: lwip-altcp-proxyconnect.patch"
+        end
+      end
+    end
+
     spec.cc.defines << 'PICO_CYW43_ARCH_POLL=1'
 
     spec.cc.include_paths << "#{lwip_dir}/src/include"

--- a/mrbgems/picoruby-net/patches/lwip-altcp-proxyconnect.patch
+++ b/mrbgems/picoruby-net/patches/lwip-altcp-proxyconnect.patch
@@ -1,0 +1,13 @@
+--- a/src/apps/http/altcp_proxyconnect.c
++++ b/src/apps/http/altcp_proxyconnect.c
+@@ -576,6 +576,10 @@ const struct altcp_functions altcp_proxyconnect_functions = {
+   altcp_default_get_tcp_addrinfo,
+   altcp_default_get_ip,
+   altcp_default_get_port
++#if LWIP_TCP_KEEPALIVE
++  , altcp_default_keepalive_disable
++  , altcp_default_keepalive_enable
++#endif
+ #ifdef LWIP_DEBUG
+   , altcp_default_dbg_get_tcp_state
+ #endif


### PR DESCRIPTION
Apply patch to fix type mismatch for picow build.

When I built R2P2 for pico_w, I met next error:

```
❯ rake picoruby:pico_w:prod > build.log
MRUBY_CONFIG=/Users/makicamel/src/github.com/picoruby/R2P2/build_config/r2p2-picoruby-pico_w.rb  rake
arm-none-eabi-ar: creating /Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/build/r2p2-picoruby-pico_w/lib/libmruby_core.a
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/src/apps/http/altcp_proxyconnect.c:580:5: error: initialization of 'void (*)(struct altcp_pcb *)' from incompatible pointer type 'enum tcp_state (*)(struct altcp_pcb *)' [-Wincompatible-pointer-types]
  580 |   , altcp_default_dbg_get_tcp_state
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/src/apps/http/altcp_proxyconnect.c:580:5: note: (near initialization for 'altcp_proxyconnect_functions.keepalive_disable')
rake aborted!
Command failed with status (1): [arm-none-eabi-gcc -MMD -c -std=gnu99 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -mcpu=cortex-m0plus -mthumb -fshort-enums -Wall -Wno-format -Wno-unused-function -ffunction-sections -fdata-sections -Os -finline-functions -ffunction-sections -fdata-sections -fomit-frame-pointer -s -DPICORUBY_INT64 -DMRBC_REQUIRE_32BIT_ALIGNMENT=1 -DMRBC_CONVERT_CRLF=1 -DMRBC_USE_MATH=1 -DMRBC_TICK_UNIT=1 -DMRBC_TIMESLICE_TICK_COUNT=10 -DUSE_FAT_FLASH_DISK=1 -DNO_CLOCK_GETTIME=1 -DUSE_FAT_SD_DISK=1 -DMAX_SYMBOLS_COUNT=2000 -DMRBC_USE_FLOAT=2 -DUSE_WIFI -DMRBC_TICK_UNIT=1 -DMRBC_TIMESLICE_TICK_COUNT=10 -DMRB_NO_PRESYM -DPICORB_VM_MRUBYC -DMRBC_NO_STDIO -DMRBC_USE_ALLOC_PROF -DDISABLE_MRUBY -DMRBC_INT64 -DMAX_VM_COUNT=255 -DMAX_REGS_SIZE=255 -DNDEBUG=1 -DPICO_CYW43_ARCH_POLL=1 -DMRBGEM_PICORUBY_NET_VERSION=0.0.0 -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/mruby-compiler2/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/mruby-compiler2/lib/prism/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-mruby/lib/mruby/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-machine/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-mrubyc/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/include/picoruby" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/build/r2p2-picoruby-pico_w/mrbgems" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-mrubyc/lib/mrubyc/src" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/src/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/contrib/ports/unix/port/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/src/apps/altcp_tls" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-mbedtls/lib/mbedtls/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-time/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-env/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-mbedtls/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-rng/include" -I"/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-cyw43/include" -o "/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/build/r2p2-picoruby-pico_w/mrbgems/picoruby-net/lib/lwip/src/apps/http/altcp_proxyconnect.o" "/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-net/lib/lwip/src/apps/http/altcp_proxyconnect.c"]
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/lib/mruby/build/command.rb:33:in 'MRuby::Command#_run'
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/lib/mruby/build/command.rb:95:in 'MRuby::Command::Compiler#run'
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/lib/mruby/build/command.rb:120:in 'block (2 levels) in MRuby::Command::Compiler#define_rules'
/Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/Rakefile:51:in 'block in <top (required)>'
Tasks: TOP => build => /Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/build/r2p2-picoruby-pico_w/lib/libmruby.a => /Users/makicamel/src/github.com/picoruby/R2P2/lib/picoruby/build/r2p2-picoruby-pico_w/mrbgems/picoruby-net/lib/lwip/src/apps/http/altcp_proxyconnect.o
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [MRUBY_CONFIG=/Users/makicamel/src/github.com/picoruby/R2P2/build_config/r2p2-picoruby-pico_w.rb  rake]
/Users/makicamel/src/github.com/picoruby/R2P2/Rakefile:77:in 'block (7 levels) in <top (required)>'
/Users/makicamel/src/github.com/picoruby/R2P2/Rakefile:75:in 'block (6 levels) in <top (required)>'
Tasks: TOP => picoruby:pico_w:prod
(See full trace by running task with --trace)
```

To resolve this error, apply a patch to the picoruby-net spec, similar to picoruby-socket.