### PR TITLE
load ntpdate only when CYW43 initialization succeeds

### DIFF
--- a/mrbgems/picoruby-shell/shell_executables/r2p2.rb
+++ b/mrbgems/picoruby-shell/shell_executables/r2p2.rb
@@ -5,7 +5,9 @@ if ENV['WIFI_MODULE'] == "cwy43"
   ARGV[0] = "--check-auto-connect"
   load "/bin/wifi_connect"
   ARGV.clear
-  load "/bin/ntpdate"
+  if CYW43.initialized?
+    load "/bin/ntpdate"
+  end
 end
 
 if File.exist?("#{ENV['HOME']}/app.mrb")


### PR DESCRIPTION
When I built, baked and connected R2P2 for pico2_w, I encountered a hard fault.

```
#0  hardfault_handler_c (msp=<optimized out>, psp=<optimized out>, exc_return=<optimized out>)
    at /Users/makicamel/picoruby/R2P2/src/fault_handler.c:125
#1  <signal handler called>
#2  0x1001c1d6 in async_context_acquire_lock_blocking (context=0x0)
    at /Users/makicamel/raspberrypi/pico-sdk/src/rp2_common/pico_async_context/include/pico/async_context.h:207
#3  cyw43_thread_enter ()
    at /Users/makicamel/raspberrypi/pico-sdk/src/rp2_common/pico_cyw43_driver/cyw43_driver.c:248
#4  0x10002d94 in cyw43_arch_lwip_begin ()
    at /Users/makicamel/raspberrypi/pico-sdk/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h:278
#5  0x100039c0 in UDPSocket_create (sock=0x2005bbe0 <heap_pool+347760>)
    at /Users/makicamel/picoruby/R2P2/lib/picoruby/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c:77
#6  0x10093e40 in mrb_udp_socket_initialize ()
#7  0x1004feee in mrb_vm_exec ()
#8  0x100542da in mrb_tasks_run ()
#9  0x1000456e in main () at /Users/makicamel/picoruby/R2P2/src/main.c:72
```

This is because it's trying to acquire a lock on `async_context` while `async_context` is uninitialized, before even acquiring the lock.
In `/bin/wifi_connect`, `CYW43.init` (meaning initialization of `async_context`) is not called when a Wi-Fi configuration file is absent.
To allow startup even without a Wi-Fi configuration file, we will give up setting the time using NTP.