### PR TITLE
Add BasicSocket#recv_nonblock via read(maxlen, flags) on POSIX.

### DIFF
--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -70,6 +70,7 @@ extern int Net_get_ip(const char *name, void *ip);
 
 #endif
 
+<<<<<<< HEAD
 /* Portable VM state type for socket API */
 #if defined(PICORB_VM_MRUBY) && !defined(picorb_state)
 #include "mruby.h"
@@ -85,6 +86,20 @@ bool TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host
 ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
 ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len);
 bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
+=======
+/* Flags for TCPSocket_recv */
+#define PICORB_RECV_NONBLOCK    1   /* Non-blocking receive (use MSG_DONTWAIT on POSIX) */
+
+/* Special return value from TCPSocket_recv: no data available in non-blocking mode */
+#define PICORB_RECV_WOULD_BLOCK (-2)
+
+/* TCP Socket API */
+bool TCPSocket_create(picorb_socket_t *sock);
+bool TCPSocket_connect(picorb_socket_t *sock, const char *host, int port);
+ssize_t TCPSocket_send(picorb_socket_t *sock, const void *data, size_t len);
+ssize_t TCPSocket_recv(picorb_socket_t *sock, void *buf, size_t len, int flags);
+bool TCPSocket_close(picorb_socket_t *sock);
+>>>>>>> c3b4cf74 (Add BasicSocket#recv_nonblock via read(maxlen, flags) on POSIX.)
 
 /* Get socket info */
 const char* TCPSocket_remote_host(picorb_state *vm, picorb_socket_t *sock);
@@ -169,6 +184,7 @@ typedef struct picorb_ssl_socket {
 typedef struct picorb_ssl_socket picorb_ssl_socket_t;
 #endif
 
+<<<<<<< HEAD
 picorb_ssl_socket_t* SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ssl_ctx);
 bool SSLSocket_set_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const char *hostname);
 bool SSLSocket_set_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, int port);
@@ -180,6 +196,19 @@ bool SSLSocket_closed(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 bool SSLSocket_ready(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 const char* SSLSocket_remote_host(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 int SSLSocket_remote_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
+=======
+picorb_ssl_socket_t* SSLSocket_create(picorb_ssl_context_t *ssl_ctx);
+bool SSLSocket_set_hostname(picorb_ssl_socket_t *ssl_sock, const char *hostname);
+bool SSLSocket_set_port(picorb_ssl_socket_t *ssl_sock, int port);
+bool SSLSocket_connect(picorb_ssl_socket_t *ssl_sock);
+ssize_t SSLSocket_send(picorb_ssl_socket_t *ssl_sock, const void *data, size_t len);
+ssize_t SSLSocket_recv(picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags);
+bool SSLSocket_close(picorb_ssl_socket_t *ssl_sock);
+bool SSLSocket_closed(picorb_ssl_socket_t *ssl_sock);
+bool SSLSocket_ready(picorb_ssl_socket_t *ssl_sock);
+const char* SSLSocket_remote_host(picorb_ssl_socket_t *ssl_sock);
+int SSLSocket_remote_port(picorb_ssl_socket_t *ssl_sock);
+>>>>>>> c3b4cf74 (Add BasicSocket#recv_nonblock via read(maxlen, flags) on POSIX.)
 
 /* Address resolution */
 bool resolve_address(const char *host, char *ip, size_t ip_len);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -70,7 +70,6 @@ extern int Net_get_ip(const char *name, void *ip);
 
 #endif
 
-<<<<<<< HEAD
 /* Portable VM state type for socket API */
 #if defined(PICORB_VM_MRUBY) && !defined(picorb_state)
 #include "mruby.h"
@@ -80,13 +79,6 @@ extern int Net_get_ip(const char *name, void *ip);
 #define picorb_state mrbc_vm
 #endif
 
-/* TCP Socket API */
-bool TCPSocket_create(picorb_state *vm, picorb_socket_t *sock);
-bool TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int port);
-ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
-ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len);
-bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
-=======
 /* Flags for TCPSocket_recv */
 #define PICORB_RECV_NONBLOCK    1   /* Non-blocking receive (use MSG_DONTWAIT on POSIX) */
 
@@ -94,12 +86,11 @@ bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
 #define PICORB_RECV_WOULD_BLOCK (-2)
 
 /* TCP Socket API */
-bool TCPSocket_create(picorb_socket_t *sock);
-bool TCPSocket_connect(picorb_socket_t *sock, const char *host, int port);
-ssize_t TCPSocket_send(picorb_socket_t *sock, const void *data, size_t len);
-ssize_t TCPSocket_recv(picorb_socket_t *sock, void *buf, size_t len, int flags);
-bool TCPSocket_close(picorb_socket_t *sock);
->>>>>>> c3b4cf74 (Add BasicSocket#recv_nonblock via read(maxlen, flags) on POSIX.)
+bool TCPSocket_create(picorb_state *vm, picorb_socket_t *sock);
+bool TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int port);
+ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
+ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, int flags);
+bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
 
 /* Get socket info */
 const char* TCPSocket_remote_host(picorb_state *vm, picorb_socket_t *sock);
@@ -184,31 +175,17 @@ typedef struct picorb_ssl_socket {
 typedef struct picorb_ssl_socket picorb_ssl_socket_t;
 #endif
 
-<<<<<<< HEAD
 picorb_ssl_socket_t* SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ssl_ctx);
 bool SSLSocket_set_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const char *hostname);
 bool SSLSocket_set_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, int port);
 bool SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 ssize_t SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data, size_t len);
-ssize_t SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len);
+ssize_t SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags);
 bool SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 bool SSLSocket_closed(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 bool SSLSocket_ready(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 const char* SSLSocket_remote_host(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 int SSLSocket_remote_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
-=======
-picorb_ssl_socket_t* SSLSocket_create(picorb_ssl_context_t *ssl_ctx);
-bool SSLSocket_set_hostname(picorb_ssl_socket_t *ssl_sock, const char *hostname);
-bool SSLSocket_set_port(picorb_ssl_socket_t *ssl_sock, int port);
-bool SSLSocket_connect(picorb_ssl_socket_t *ssl_sock);
-ssize_t SSLSocket_send(picorb_ssl_socket_t *ssl_sock, const void *data, size_t len);
-ssize_t SSLSocket_recv(picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags);
-bool SSLSocket_close(picorb_ssl_socket_t *ssl_sock);
-bool SSLSocket_closed(picorb_ssl_socket_t *ssl_sock);
-bool SSLSocket_ready(picorb_ssl_socket_t *ssl_sock);
-const char* SSLSocket_remote_host(picorb_ssl_socket_t *ssl_sock);
-int SSLSocket_remote_port(picorb_ssl_socket_t *ssl_sock);
->>>>>>> c3b4cf74 (Add BasicSocket#recv_nonblock via read(maxlen, flags) on POSIX.)
 
 /* Address resolution */
 bool resolve_address(const char *host, char *ip, size_t ip_len);

--- a/mrbgems/picoruby-socket/mrblib/basic_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/basic_socket.rb
@@ -1,6 +1,8 @@
 class SocketError < StandardError; end
 
 class BasicSocket
+  O_NONBLOCK = 1
+
   # IO-compatible methods
 
   def puts(*args)
@@ -47,8 +49,11 @@ class BasicSocket
   end
 
   def recv(maxlen, flags = 0)
-    # For now, ignore flags (not supported in basic implementation)
-    read(maxlen)
+    read(maxlen, flags)
+  end
+
+  def recv_nonblock(maxlen, flags = 0)
+    read(maxlen, O_NONBLOCK | flags)
   end
 
   def peeraddr

--- a/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
@@ -361,7 +361,7 @@ SSLSocket_ready(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   if (!ssl_sock || !ssl_sock->base_socket) {
     return false;
   }
-  return Socket_ready(ssl_sock->base_socket);
+  return Socket_ready(vm, ssl_sock->base_socket);
 }
 
 const char*

--- a/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
@@ -307,7 +307,7 @@ SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data
 }
 
 ssize_t
-SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len)
+SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags)
 {
   if (!ssl_sock || ssl_sock->state != SSL_STATE_CONNECTED || !buf) return -1;
 

--- a/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
@@ -5,6 +5,8 @@
 #include "../../include/socket.h"
 #include "picoruby.h"
 
+#include <fcntl.h>
+
 /* mbedtls includes */
 #include "mbedtls/net_sockets.h"
 #include "mbedtls/ssl.h"
@@ -311,19 +313,45 @@ SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_
 {
   if (!ssl_sock || ssl_sock->state != SSL_STATE_CONNECTED || !buf) return -1;
 
+  if (flags & PICORB_RECV_NONBLOCK) {
+    int fd = ssl_sock->net_ctx.fd;
+    int old_flags = fcntl(fd, F_GETFL, 0);
+    if (old_flags == -1) return -1;
+    fcntl(fd, F_SETFL, old_flags | O_NONBLOCK);
+
+    int ret = mbedtls_ssl_read(&ssl_sock->ssl, (unsigned char *)buf, len);
+
+    fcntl(fd, F_SETFL, old_flags); /* restore */
+
+    if (ret > 0) return (ssize_t)ret;
+    if (ret == 0) {
+      ssl_sock->state = SSL_STATE_NONE;
+      return 0;
+    }
+    if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+      return PICORB_RECV_WOULD_BLOCK;
+    }
+    if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+      ssl_sock->state = SSL_STATE_NONE;
+      return 0;
+    }
+    ssl_sock->state = SSL_STATE_ERROR;
+    return -1;
+  }
+
+  /* Blocking path */
   int ret = mbedtls_ssl_read(&ssl_sock->ssl, (unsigned char *)buf, len);
   if (ret < 0) {
     if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
-      return 0; // Would block
+      return 0;
     }
     if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-      // Connection closed by peer
+      /* Connection closed by peer */
     }
     ssl_sock->state = SSL_STATE_ERROR;
     return -1;
   }
   if (ret == 0) {
-    // EOF
     ssl_sock->state = SSL_STATE_NONE;
   }
   return (ssize_t)ret;

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
@@ -108,6 +108,21 @@ TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, i
     return -1;
   }
 
+  if (flags & PICORB_RECV_NONBLOCK) {
+    ssize_t received = recv(sock->fd, buf, len, MSG_DONTWAIT);
+    if (received < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return PICORB_RECV_WOULD_BLOCK;
+      }
+      return -1;
+    }
+    if (received == 0) {
+      sock->connected = false;
+    }
+    return received;
+  }
+
+  /* Blocking path */
   ssize_t received = recv(sock->fd, buf, len, 0);
   if (received < 0) {
     return -1;

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
@@ -102,7 +102,7 @@ TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t
 }
 
 ssize_t
-TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len)
+TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, int flags)
 {
   if (!sock || !buf || sock->fd < 0 || sock->closed) {
     return -1;

--- a/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 
 #include <openssl/ssl.h>
@@ -492,20 +493,42 @@ SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data
 }
 
 /*
- * Receive data from SSL socket
+ * Receive data from SSL socket.
+ * When flags has PICORB_RECV_NONBLOCK set, the underlying fd is temporarily
+ * set to O_NONBLOCK so that SSL_read returns immediately if no data is available.
  */
 ssize_t
-SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len)
+SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags)
 {
   if (!ssl_sock || !ssl_sock->connected) {
     return -1;
+  }
+
+  if (flags & PICORB_RECV_NONBLOCK) {
+    int fd = ssl_sock->base_socket->fd;
+    int fd_flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK);
+
+    int ret = SSL_read(ssl_sock->ssl, buf, (int)len);
+    fcntl(fd, F_SETFL, fd_flags); /* restore */
+
+    if (ret < 0) {
+      int err = SSL_get_error(ssl_sock->ssl, ret);
+      if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+        return PICORB_RECV_WOULD_BLOCK;
+      }
+      return -1;
+    }
+    if (ret == 0) {
+      ssl_sock->connected = false;
+    }
+    return (ssize_t)ret;
   }
 
   int ret = SSL_read(ssl_sock->ssl, buf, (int)len);
   if (ret < 0) {
     int err = SSL_get_error(ssl_sock->ssl, ret);
     if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-      // Would block
       return 0;
     }
     fprintf(stderr, "SSL: SSL_read failed with error %d\n", err);

--- a/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
@@ -507,6 +507,9 @@ SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_
   if (flags & PICORB_RECV_NONBLOCK) {
     int fd = ssl_sock->base_socket->fd;
     int fd_flags = fcntl(fd, F_GETFL, 0);
+    if (fd_flags == -1) {
+      return -1;
+    }
     fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK);
 
     int ret = SSL_read(ssl_sock->ssl, buf, (int)len);

--- a/mrbgems/picoruby-socket/ports/posix/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/posix/tcp_socket.c
@@ -115,15 +115,32 @@ TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t
   return sent;
 }
 
-/* Receive data - blocks until len bytes are read or EOF/error.
+/* Receive data.
+ * If flags has PICORB_RECV_NONBLOCK set, uses MSG_DONTWAIT and returns
+ * PICORB_RECV_WOULD_BLOCK when no data is available.
+ * Otherwise blocks until len bytes are read or EOF/error.
  * MSG_WAITALL tells the kernel to wait until the full request is satisfied,
  * which avoids partial-read issues without requiring application-level loops
  * or setsockopt calls between recv() invocations. */
 ssize_t
-TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len)
+TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, int flags)
 {
   if (!sock || !buf || sock->fd < 0 || sock->closed) {
     return -1;
+  }
+
+  if (flags & PICORB_RECV_NONBLOCK) {
+    ssize_t received = recv(sock->fd, buf, len, MSG_DONTWAIT);
+    if (received < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return PICORB_RECV_WOULD_BLOCK;
+      }
+      return -1;
+    }
+    if (received == 0) {
+      sock->connected = false;
+    }
+    return received;
   }
 
 #ifdef MSG_WAITALL

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -561,7 +561,7 @@ SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data
 }
 
 ssize_t
-SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len)
+SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, int flags)
 {
   if (!ssl_sock || !ssl_sock->base_socket || !buf) {
     return -1;

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -569,20 +569,31 @@ SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_
 
   picorb_socket_t *sock = ssl_sock->base_socket;
 
-  /* Wait for data with timeout */
-  int max_wait = 600;  /* 60 seconds */
-  while (sock->recv_len == 0 && ssl_sock->connected && max_wait-- > 0) {
-    Net_busy_wait_ms(100);
-  }
+  if (flags & PICORB_RECV_NONBLOCK) {
+    /* Non-blocking: return immediately if no data available */
+    if (sock->recv_len == 0) {
+      if (!ssl_sock->connected) {
+        return 0; /* EOF */
+      }
+      return PICORB_RECV_WOULD_BLOCK;
+    }
+    /* Fall through to copy data below */
+  } else {
+    /* Wait for data with timeout */
+    int max_wait = 600;  /* 60 seconds */
+    while (sock->recv_len == 0 && ssl_sock->connected && max_wait-- > 0) {
+      Net_busy_wait_ms(100);
+    }
 
-  /* Check if connection was closed */
-  if (sock->recv_len == 0 && !ssl_sock->connected) {
-    return 0;  /* EOF */
-  }
+    /* Check if connection was closed */
+    if (sock->recv_len == 0 && !ssl_sock->connected) {
+      return 0;  /* EOF */
+    }
 
-  /* Check for timeout */
-  if (sock->recv_len == 0) {
-    return 0;
+    /* Check for timeout */
+    if (sock->recv_len == 0) {
+      return 0;
+    }
   }
 
   /* Copy available data */

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -295,27 +295,38 @@ TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, i
   D("TCPSocket_recv: start, state=%d, recv_len=%zu, connected=%d\n",
     sock->state, sock->recv_len, sock->connected);
 
-  /* Wait for data with timeout */
-  int max_wait = 600; /* 60 seconds */
-  while (sock->recv_len == 0 &&
-         sock->state == SOCKET_STATE_CONNECTED &&
-         max_wait-- > 0) {
-    Net_busy_wait_ms(100);
-  }
+  if (flags & PICORB_RECV_NONBLOCK) {
+    /* Non-blocking: return immediately if no data available */
+    if (sock->recv_len == 0) {
+      if (sock->state == SOCKET_STATE_CLOSED) {
+        return 0; /* EOF */
+      }
+      return PICORB_RECV_WOULD_BLOCK;
+    }
+    /* Fall through to copy data below */
+  } else {
+    /* Wait for data with timeout */
+    int max_wait = 600; /* 60 seconds */
+    while (sock->recv_len == 0 &&
+           sock->state == SOCKET_STATE_CONNECTED &&
+           max_wait-- > 0) {
+      Net_busy_wait_ms(100);
+    }
 
-  D("TCPSocket_recv: after wait, recv_len=%zu, state=%d, max_wait=%d\n",
-    sock->recv_len, sock->state, max_wait);
+    D("TCPSocket_recv: after wait, recv_len=%zu, state=%d, max_wait=%d\n",
+      sock->recv_len, sock->state, max_wait);
 
-  /* Check if connection was closed */
-  if (sock->recv_len == 0 && sock->state == SOCKET_STATE_CLOSED) {
-    D("TCPSocket_recv: connection closed (EOF)");
-    return 0; /* EOF */
-  }
+    /* Check if connection was closed */
+    if (sock->recv_len == 0 && sock->state == SOCKET_STATE_CLOSED) {
+      D("TCPSocket_recv: connection closed (EOF)");
+      return 0; /* EOF */
+    }
 
-  /* Check for timeout or error */
-  if (sock->recv_len == 0) {
-    D("TCPSocket_recv: timeout or no data");
-    return 0;
+    /* Check for timeout or error */
+    if (sock->recv_len == 0) {
+      D("TCPSocket_recv: timeout or no data");
+      return 0;
+    }
   }
 
   /* Copy available data */

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -284,7 +284,7 @@ TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t
 
 /* Receive data */
 ssize_t
-TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len)
+TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, int flags)
 {
   if (!sock || !buf || sock->state == SOCKET_STATE_ERROR) {
     D("TCPSocket_recv: sock=%p, buf=%p, state=%d (ERROR)\n",

--- a/mrbgems/picoruby-socket/sig/basic_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/basic_socket.rbs
@@ -2,18 +2,21 @@ class SocketError < StandardError
 end
 
 class BasicSocket
+  O_NONBLOCK: Integer
+
   def puts: (*untyped args) -> nil
   def gets: (?String sep) -> String?
   def print: (*untyped args) -> nil
   def eof?: () -> bool
   def send: (String data, Integer flags) -> Integer
   def recv: (Integer maxlen, ?Integer flags) -> String?
+  def recv_nonblock: (Integer maxlen, ?Integer flags) -> String?
   def peeraddr: () -> Array[String | Integer]
   def remote_address: () -> String
   def local_address: () -> nil
 
   def write: (String data) -> Integer
-  def read: (Integer maxlen) -> String?
+  def read: (Integer maxlen, ?Integer flags) -> String?
   def closed?: () -> bool
   def ready?: () -> bool
   def close: () -> void

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -475,7 +475,7 @@ mrb_ssl_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate read buffer");
   }
 
-  ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen);
+  ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen, 0);
   if (received < 0) {
     mrb_free(mrb, read_buf);
     mrb_raise(mrb, E_RUNTIME_ERROR, "SSL recv failed");

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -450,12 +450,13 @@ mrb_ssl_socket_write(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(sent);
 }
 
-/* ssl_socket.read(maxlen = nil) */
+/* ssl_socket.read(maxlen = 4096, flags = 0) */
 static mrb_value
 mrb_ssl_socket_read(mrb_state *mrb, mrb_value self)
 {
   picorb_ssl_socket_t *ssl_sock;
   mrb_int maxlen = 4096;
+  mrb_int flags = 0;
   mrb_value buf;
 
   ssl_sock = (picorb_ssl_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_ssl_socket_type);
@@ -463,7 +464,7 @@ mrb_ssl_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "SSL socket is not initialized");
   }
 
-  mrb_get_args(mrb, "|i", &maxlen);
+  mrb_get_args(mrb, "|ii", &maxlen, &flags);
 
   if (maxlen <= 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "maxlen must be positive");
@@ -475,7 +476,13 @@ mrb_ssl_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate read buffer");
   }
 
-  ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen, 0);
+  ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen, (int)flags);
+
+  if (received == PICORB_RECV_WOULD_BLOCK) {
+    mrb_free(mrb, read_buf);
+    return mrb_nil_value();
+  }
+
   if (received < 0) {
     mrb_free(mrb, read_buf);
     mrb_raise(mrb, E_RUNTIME_ERROR, "SSL recv failed");
@@ -615,7 +622,7 @@ ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   mrb_define_class_method_id(mrb, ssl_socket_class, MRB_SYM(open), mrb_ssl_socket_s_open, MRB_ARGS_REQ(3));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(connect), mrb_ssl_socket_connect, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(write), mrb_ssl_socket_write, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(read), mrb_ssl_socket_read, MRB_ARGS_OPT(1));
+  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(read), mrb_ssl_socket_read, MRB_ARGS_OPT(2));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(close), mrb_ssl_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM_Q(closed), mrb_ssl_socket_closed_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM_Q(ready), mrb_ssl_socket_ready_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -68,12 +68,13 @@ mrb_tcp_socket_write(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(sent);
 }
 
-/* socket.read(maxlen = nil) */
+/* socket.read(maxlen = 4096, flags = 0) */
 static mrb_value
 mrb_tcp_socket_read(mrb_state *mrb, mrb_value self)
 {
   picorb_socket_t *sock;
   mrb_int maxlen = 4096;
+  mrb_int flags = 0;
   mrb_value buf;
 
   sock = (picorb_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_socket_type);
@@ -81,7 +82,7 @@ mrb_tcp_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "socket is not initialized");
   }
 
-  mrb_get_args(mrb, "|i", &maxlen);
+  mrb_get_args(mrb, "|ii", &maxlen, &flags);
 
   if (maxlen <= 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "maxlen must be positive");
@@ -93,7 +94,13 @@ mrb_tcp_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate read buffer");
   }
 
-  ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen, 0);
+  ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen, (int)flags);
+
+  if (received == PICORB_RECV_WOULD_BLOCK) {
+    mrb_free(mrb, read_buf);
+    return mrb_nil_value();
+  }
+
   if (received < 0) {
     mrb_free(mrb, read_buf);
     mrb_raise(mrb, E_RUNTIME_ERROR, "recv failed");
@@ -205,7 +212,7 @@ tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(initialize), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(write), mrb_tcp_socket_write, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(read), mrb_tcp_socket_read, MRB_ARGS_OPT(1));
+  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(read), mrb_tcp_socket_read, MRB_ARGS_OPT(2));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(close), mrb_tcp_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM_Q(closed), mrb_tcp_socket_closed_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM_Q(ready), mrb_tcp_socket_ready_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -93,7 +93,7 @@ mrb_tcp_socket_read(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate read buffer");
   }
 
-  ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen);
+  ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen, 0);
   if (received < 0) {
     mrb_free(mrb, read_buf);
     mrb_raise(mrb, E_RUNTIME_ERROR, "recv failed");

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -253,12 +253,15 @@ c_ssl_socket_write(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 /*
- * ssl_socket.read(maxlen = 4096) -> String or nil
+ * ssl_socket.read(maxlen = 4096, flags = 0) -> String or nil
+ *
+ * When flags has PICORB_RECV_NONBLOCK set (i.e. BasicSocket::O_NONBLOCK),
+ * the receive is non-blocking and returns nil if no data is available.
  */
 static void
 c_ssl_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  if (argc > 1) {
+  if (argc > 2) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
     return;
   }
@@ -272,7 +275,7 @@ c_ssl_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* Get maxlen parameter (default: 4096) */
   int maxlen = 4096;
-  if (argc == 1) {
+  if (argc >= 1) {
     mrbc_value maxlen_arg = GET_ARG(1);
     if (maxlen_arg.tt != MRBC_TT_INTEGER) {
       mrbc_raise(vm, MRBC_CLASS(TypeError), "maxlen must be an Integer");
@@ -285,6 +288,17 @@ c_ssl_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
     }
   }
 
+  /* Get flags parameter (default: 0) */
+  int flags = 0;
+  if (argc >= 2) {
+    mrbc_value flags_arg = GET_ARG(2);
+    if (flags_arg.tt != MRBC_TT_INTEGER) {
+      mrbc_raise(vm, MRBC_CLASS(TypeError), "flags must be an Integer");
+      return;
+    }
+    flags = (int)flags_arg.i;
+  }
+
   /* Allocate buffer */
   char *buffer = (char *)picorb_alloc(vm, maxlen);
   if (!buffer) {
@@ -293,7 +307,14 @@ c_ssl_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
   /* Receive data */
-  ssize_t received = SSLSocket_recv(vm, wrapper->ptr, buffer, maxlen);
+  ssize_t received = SSLSocket_recv(vm, wrapper->ptr, buffer, maxlen, flags);
+
+  if (received == PICORB_RECV_WOULD_BLOCK) {
+    /* Non-blocking mode: no data available */
+    mrbc_raw_free(buffer);
+    SET_NIL_RETURN();
+    return;
+  }
 
   if (received < 0) {
     picorb_free(vm, buffer);

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -351,7 +351,7 @@ tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 
   mrbc_define_method(vm, class_TCPSocket, "new", c_tcp_socket_new);
   mrbc_define_method(vm, class_TCPSocket, "write", c_tcp_socket_write);
-  mrbc_define_method(vm, class_TCPSocket, "read",  c_tcp_socket_read);
+  mrbc_define_method(vm, class_TCPSocket, "read", c_tcp_socket_read);
   mrbc_define_method(vm, class_TCPSocket, "close", c_tcp_socket_close);
   mrbc_define_method(vm, class_TCPSocket, "closed?", c_tcp_socket_closed_q);
   mrbc_define_method(vm, class_TCPSocket, "ready?", c_tcp_socket_ready_q);

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -121,12 +121,15 @@ c_tcp_socket_write(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 /*
- * socket.read(maxlen = 4096) -> String or nil
+ * socket.read(maxlen = 4096, flags = 0) -> String or nil
+ *
+ * When flags has PICORB_RECV_NONBLOCK set (i.e. BasicSocket::O_NONBLOCK),
+ * the receive is non-blocking and returns nil if no data is available.
  */
 static void
 c_tcp_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  if (argc > 1) {
+  if (argc > 2) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
     return;
   }
@@ -140,7 +143,7 @@ c_tcp_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* Get maxlen parameter (default: 4096) */
   int maxlen = 4096;
-  if (argc == 1) {
+  if (argc >= 1) {
     mrbc_value maxlen_arg = GET_ARG(1);
     if (maxlen_arg.tt != MRBC_TT_INTEGER) {
       mrbc_raise(vm, MRBC_CLASS(TypeError), "maxlen must be an Integer");
@@ -153,6 +156,17 @@ c_tcp_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
     }
   }
 
+  /* Get flags parameter (default: 0) */
+  int flags = 0;
+  if (argc >= 2) {
+    mrbc_value flags_arg = GET_ARG(2);
+    if (flags_arg.tt != MRBC_TT_INTEGER) {
+      mrbc_raise(vm, MRBC_CLASS(TypeError), "flags must be an Integer");
+      return;
+    }
+    flags = (int)flags_arg.i;
+  }
+
   /* Allocate buffer */
   char *buffer = (char *)picorb_alloc(vm, maxlen);
   if (!buffer) {
@@ -161,7 +175,14 @@ c_tcp_socket_read(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
   /* Receive data */
-  ssize_t received = TCPSocket_recv(vm, sock, buffer, maxlen);
+  ssize_t received = TCPSocket_recv(vm, sock, buffer, maxlen, flags);
+
+  if (received == PICORB_RECV_WOULD_BLOCK) {
+    /* Non-blocking mode: no data available */
+    mrbc_raw_free(buffer);
+    SET_NIL_RETURN();
+    return;
+  }
 
   if (received < 0) {
     picorb_free(vm, buffer);
@@ -330,7 +351,7 @@ tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 
   mrbc_define_method(vm, class_TCPSocket, "new", c_tcp_socket_new);
   mrbc_define_method(vm, class_TCPSocket, "write", c_tcp_socket_write);
-  mrbc_define_method(vm, class_TCPSocket, "read", c_tcp_socket_read);
+  mrbc_define_method(vm, class_TCPSocket, "read",  c_tcp_socket_read);
   mrbc_define_method(vm, class_TCPSocket, "close", c_tcp_socket_close);
   mrbc_define_method(vm, class_TCPSocket, "closed?", c_tcp_socket_closed_q);
   mrbc_define_method(vm, class_TCPSocket, "ready?", c_tcp_socket_ready_q);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                 
  - Add `BasicSocket#recv_nonblock(maxlen, flags = 0)`                                                                                                                                                                                                                                             
  - Add optional `flags` argument to `TCPSocket#read` and `SSLSocket#read` so that passing `BasicSocket::O_NONBLOCK` performs a non-blocking receive
  - POSIX TCP uses `MSG_DONTWAIT`; POSIX SSL temporarily sets `O_NONBLOCK` on the underlying fd
  - ~Fix `TCPSocket_connect` on POSIX failing with `EINTR` due to periodic SIGALRM from picoruby-machine's `hal_init`~
                                                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                   
  ### Ruby layer (`mrblib/basic_socket.rb`)                                                                                                                                                                                                                                                      
  - Add `BasicSocket::O_NONBLOCK = 1` constant
  - Update `BasicSocket#recv` to pass `flags` through to `read`                                                                                                                                                                                                                                    
  - Add `BasicSocket#recv_nonblock(maxlen, flags = 0)` which calls `read(maxlen, O_NONBLOCK | flags)`
                                                                                                                                                                                                                                                                                                   
  ### C interface (`include/socket.h`)                                                                                                                                                                                                                                                           
  - Add `PICORB_RECV_NONBLOCK = 1` macro                                                                                                                                                                                                                                                           
  - Add `PICORB_RECV_WOULD_BLOCK = -2` macro (return value indicating no data available in non-blocking mode)                                                                                                                                                                                    
  - Add `int flags` parameter to `TCPSocket_recv` and `SSLSocket_recv`                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                   
  ### POSIX implementation                                                                                                                                                                                                                                                                         
  - `ports/posix/tcp_socket.c`: Use `MSG_DONTWAIT` when `PICORB_RECV_NONBLOCK` is set; return `PICORB_RECV_WOULD_BLOCK` on `EAGAIN`/`EWOULDBLOCK`                                                                                                                                                  
  - `ports/posix/tcp_socket.c`: Retry `connect(2)` on `EINTR` to handle interruption by SIGALRM                                                                                                                                                                                                    
  - `ports/posix/ssl_socket.c`: Temporarily set `O_NONBLOCK` on the fd when `PICORB_RECV_NONBLOCK` is set; return `PICORB_RECV_WOULD_BLOCK` on `SSL_ERROR_WANT_READ`/`WANT_WRITE`                                                                                                                  
                                                                                                                                                                                                                                                                                                   
  ### Other ports (esp32, rp2040)                                                                                                                                                                                                                                                                  
  - Update `TCPSocket_recv` and `SSLSocket_recv` signatures to accept `int flags` (ignored for now)                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                   
  ### mrubyc (`src/mrubyc/`)
  - Update `c_tcp_socket_read` and `c_ssl_socket_read` to accept `read(maxlen, flags = 0)`; return `nil` when `PICORB_RECV_WOULD_BLOCK` is received                                                                                                                                                
                                                                                                                                                                                                                                                                                                   
  ### mruby (`src/mruby/`)                                                                                                                                                                                                                                                                         
  - Pass `flags = 0` to updated `TCPSocket_recv` and `SSLSocket_recv` call sites to keep compilation working (feature support deferred)                                                                                                                                                            
                                                                                                                                                                                                                                                                                                   
  ### RBS (`sig/basic_socket.rbs`)                                                                                                                                                                                                                                                               
  - Add `O_NONBLOCK` constant, `recv_nonblock` method, and `flags` argument to `read`