### PR TITLE
Support USB Serial JTAG console for ESP32 HAL I/O

### DIFF
--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -17,6 +17,10 @@
 #include "hal/efuse_hal.h"
 #include "rom/ets_sys.h"
 
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#include "hal/usb_serial_jtag_ll.h"
+#endif
+
 #define ESP32_MSEC_PER_TICK       (10)
 #define ESP32_TIMER_UNIT_PER_SEC  (1000000)
 
@@ -120,25 +124,46 @@ hal_write(int fd, const void *buf, int nbytes)
     fputc(((char*)buf)[i], stream);
   }
   fflush(stream);
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  usb_serial_jtag_ll_txfifo_flush();
+#endif
   return nbytes;
 }
 
 int hal_flush(int fd) {
   FILE *stream = (fd == 1) ? stdout : stderr;
-  return fflush(stream);
+  int ret = fflush(stream);
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  usb_serial_jtag_ll_txfifo_flush();
+#endif
+  return ret;
 }
+
 
 int
 hal_read_available(void)
 {
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  return usb_serial_jtag_ll_rxfifo_data_available() ? 1 : 0;
+#else
   int c = fgetc(stdin);
   return ungetc(c, stdin) == EOF ? 0 : 1;
+#endif
 }
 
 int
 hal_getchar(void)
 {
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  if (usb_serial_jtag_ll_rxfifo_data_available()) {
+    uint8_t ch;
+    usb_serial_jtag_ll_read_rxfifo(&ch, 1);
+    return (int)ch;
+  }
+  return HAL_GETCHAR_NODATA;
+#else
   return fgetc(stdin);
+#endif
 }
 
 void


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                
- Add USB Serial JTAG console I/O support for ESP32 HAL layer                                                                                                                                                                                                                                                                 
- When `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` is enabled, use `usb_serial_jtag_ll` low-level API directly for read/write/flush operations instead of standard I/O functions

## Background

Some ESP32 variants (e.g., ESP32-C3, ESP32-S3) use USB Serial JTAG as their console interface. The standard `fgetc(stdin)` / `fputc()` / `fflush()` functions do not work reliably with USB Serial JTAG, causing issues with console I/O in PicoRuby's interactive shell.

This PR conditionally switches to the `usb_serial_jtag_ll` API when `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` is enabled:                                                                                                                                                                                                          

- **`hal_write`** / **`hal_flush`**: Call `usb_serial_jtag_ll_txfifo_flush()` after writing to ensure data is actually sent over USB                                                                                                                                                                                          
- **`hal_read_available`**: Use `usb_serial_jtag_ll_rxfifo_data_available()` instead of `fgetc`/`ungetc` polling
- **`hal_getchar`**: Read directly from the RX FIFO via `usb_serial_jtag_ll_read_rxfifo()`