### PR TITLE
Add machine bootsel pressed  to read bootsel button state

### DIFF
--- a/mrbgems/picoruby-machine/include/machine.h
+++ b/mrbgems/picoruby-machine/include/machine.h
@@ -50,7 +50,7 @@ uint64_t Machine_uptime_us(void);
 
 #define MACHINE_EXIT_REBOOT 120
 void Machine_uptime_formatted(char *buf, int maxlen);
-bool Machine_bootsel_pressed_q(void);
+__attribute__((weak)) bool Machine_bootsel_pressed_q(void);
 
 #ifdef __cplusplus
 }

--- a/mrbgems/picoruby-machine/include/machine.h
+++ b/mrbgems/picoruby-machine/include/machine.h
@@ -50,7 +50,7 @@ uint64_t Machine_uptime_us(void);
 
 #define MACHINE_EXIT_REBOOT 120
 void Machine_uptime_formatted(char *buf, int maxlen);
-__attribute__((weak)) bool Machine_bootsel_pressed_q(void);
+bool Machine_bootsel_pressed_q(void);
 
 #ifdef __cplusplus
 }

--- a/mrbgems/picoruby-machine/include/machine.h
+++ b/mrbgems/picoruby-machine/include/machine.h
@@ -50,6 +50,7 @@ uint64_t Machine_uptime_us(void);
 
 #define MACHINE_EXIT_REBOOT 120
 void Machine_uptime_formatted(char *buf, int maxlen);
+bool Machine_bootsel_pressed_q(void);
 
 #ifdef __cplusplus
 }

--- a/mrbgems/picoruby-machine/ports/rp2040/machine.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/machine.c
@@ -23,6 +23,10 @@
 #include <time.h>
 #include <tusb.h>
 
+#include "hardware/gpio.h"
+#include "hardware/structs/ioqspi.h"
+#include "hardware/structs/sio.h"
+
 /*-------------------------------------
  *
  * Signal flag (shared with machine.h)
@@ -456,10 +460,42 @@ Machine_tud_mounted_q(void)
 }
 
 /*
- * Defined in tinyusb BSP (hw/bsp/rp2040/family.c).
- * Returns raw QSPI CS pin state: HIGH when not pressed, LOW when pressed.
+ * Read the BOOTSEL button via the QSPI chip select pin.
+ * Based on tinyusb BSP (hw/bsp/rp2040/family.c).
+ * Weak symbol: if tinyusb_board provides get_bootsel_button,
+ * the linker uses that version instead.
+ *
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2021, Ha Thach (tinyusb.org)
+ * SPDX-License-Identifier: MIT
  */
-extern bool get_bootsel_button(void);
+__attribute__((weak))
+bool __no_inline_not_in_flash_func(get_bootsel_button)(void) {
+  const uint CS_PIN_INDEX = 1;
+
+  uint32_t flags = save_and_disable_interrupts();
+
+  hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                  GPIO_OVERRIDE_LOW << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                  IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+  for (volatile int i = 0; i < 1000; ++i);
+
+#ifdef __ARM_ARCH_6M__
+  #define CS_BIT (1u << 1)
+#else
+  #define CS_BIT SIO_GPIO_HI_IN_QSPI_CSN_BITS
+#endif
+  bool button_state = (sio_hw->gpio_hi_in & CS_BIT);
+
+  hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                  GPIO_OVERRIDE_NORMAL << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                  IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+  restore_interrupts(flags);
+
+  return button_state;
+}
 
 bool
 Machine_bootsel_pressed_q(void)

--- a/mrbgems/picoruby-machine/ports/rp2040/machine.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/machine.c
@@ -455,6 +455,18 @@ Machine_tud_mounted_q(void)
   return tud_mounted();
 }
 
+/*
+ * Defined in tinyusb BSP (hw/bsp/rp2040/family.c).
+ * Returns raw QSPI CS pin state: HIGH when not pressed, LOW when pressed.
+ */
+extern bool get_bootsel_button(void);
+
+bool
+Machine_bootsel_pressed_q(void)
+{
+  return !get_bootsel_button();
+}
+
 
 /*-------------------------------------
  *

--- a/mrbgems/picoruby-machine/sig/machine.rbs
+++ b/mrbgems/picoruby-machine/sig/machine.rbs
@@ -9,6 +9,7 @@ module Machine
   def self.read_memory: (Integer address, Integer size) -> String
   def self.tud_task: () -> void
   def self.tud_mounted?: () -> bool
+  def self.bootsel_pressed?: () -> bool
   def self.posix?: () -> bool
   def self.set_hwclock: (Integer tv_sec) -> Integer
   def self.get_hwclock: () -> [Integer, Integer]

--- a/mrbgems/picoruby-machine/src/mruby/machine.c
+++ b/mrbgems/picoruby-machine/src/mruby/machine.c
@@ -34,7 +34,8 @@ static mrb_value
 mrb_s_bootsel_pressed_p(mrb_state *mrb, mrb_value klass)
 {
 #if defined(PICORB_PLATFORM_POSIX)
-  return mrb_false_value();
+  mrb_raise(mrb, E_NOTIMP_ERROR, "Machine.bootsel_pressed? is not supported on this platform");
+  return mrb_nil_value();
 #else
   if (Machine_bootsel_pressed_q()) {
     return mrb_true_value();

--- a/mrbgems/picoruby-machine/src/mruby/machine.c
+++ b/mrbgems/picoruby-machine/src/mruby/machine.c
@@ -33,16 +33,15 @@ mrb_s_tud_mounted_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_s_bootsel_pressed_p(mrb_state *mrb, mrb_value klass)
 {
-#if defined(PICORB_PLATFORM_POSIX)
-  mrb_raise(mrb, E_NOTIMP_ERROR, "Machine.bootsel_pressed? is not supported on this platform");
-  return mrb_nil_value();
-#else
+  if (!Machine_bootsel_pressed_q) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "Machine.bootsel_pressed? is not supported on this platform");
+    return mrb_nil_value();
+  }
   if (Machine_bootsel_pressed_q()) {
     return mrb_true_value();
   } else {
     return mrb_false_value();
   }
-#endif
 }
 
 static mrb_value

--- a/mrbgems/picoruby-machine/src/mruby/machine.c
+++ b/mrbgems/picoruby-machine/src/mruby/machine.c
@@ -33,15 +33,16 @@ mrb_s_tud_mounted_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_s_bootsel_pressed_p(mrb_state *mrb, mrb_value klass)
 {
-  if (!Machine_bootsel_pressed_q) {
-    mrb_raise(mrb, E_NOTIMP_ERROR, "Machine.bootsel_pressed? is not supported on this platform");
-    return mrb_nil_value();
-  }
+#if defined(PICORB_PLATFORM_POSIX)
+  mrb_raise(mrb, E_NOTIMP_ERROR, "Machine.bootsel_pressed? is not supported on this platform");
+  return mrb_nil_value();
+#else
   if (Machine_bootsel_pressed_q()) {
     return mrb_true_value();
   } else {
     return mrb_false_value();
   }
+#endif
 }
 
 static mrb_value

--- a/mrbgems/picoruby-machine/src/mruby/machine.c
+++ b/mrbgems/picoruby-machine/src/mruby/machine.c
@@ -31,6 +31,20 @@ mrb_s_tud_mounted_p(mrb_state *mrb, mrb_value klass)
 }
 
 static mrb_value
+mrb_s_bootsel_pressed_p(mrb_state *mrb, mrb_value klass)
+{
+#if defined(PICORB_PLATFORM_POSIX)
+  return mrb_false_value();
+#else
+  if (Machine_bootsel_pressed_q()) {
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+#endif
+}
+
+static mrb_value
 mrb_s_delay_ms(mrb_state *mrb, mrb_value klass)
 {
   mrb_int ms;
@@ -423,6 +437,7 @@ mrb_picoruby_machine_gem_init(mrb_state* mrb)
 
   mrb_define_class_method_id(mrb, module_Machine, MRB_SYM(tud_task), mrb_s_tud_task, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, module_Machine, MRB_SYM_Q(tud_mounted), mrb_s_tud_mounted_p, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, module_Machine, MRB_SYM_Q(bootsel_pressed), mrb_s_bootsel_pressed_p, MRB_ARGS_NONE());
 
   mrb_define_class_method_id(mrb, module_Machine, MRB_SYM(delay_ms), mrb_s_delay_ms, MRB_ARGS_REQ(1));
   mrb_define_class_method_id(mrb, module_Machine, MRB_SYM(busy_wait_ms), mrb_s_busy_wait_ms, MRB_ARGS_REQ(1));

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -23,15 +23,15 @@ c_Machine_tud_mounted_q(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c_Machine_bootsel_pressed_q(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-#if defined(PICORB_PLATFORM_POSIX)
-  mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Machine.bootsel_pressed? is not supported on this platform");
-#else
+  if (!Machine_bootsel_pressed_q) {
+    mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Machine.bootsel_pressed? is not supported on this platform");
+    return;
+  }
   if (Machine_bootsel_pressed_q()) {
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
   }
-#endif
 }
 
 static void

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -23,15 +23,15 @@ c_Machine_tud_mounted_q(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c_Machine_bootsel_pressed_q(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  if (!Machine_bootsel_pressed_q) {
-    mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Machine.bootsel_pressed? is not supported on this platform");
-    return;
-  }
+#if defined(PICORB_PLATFORM_POSIX)
+  mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Machine.bootsel_pressed? is not supported on this platform");
+#else
   if (Machine_bootsel_pressed_q()) {
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
   }
+#endif
 }
 
 static void

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -24,7 +24,7 @@ static void
 c_Machine_bootsel_pressed_q(mrbc_vm *vm, mrbc_value *v, int argc)
 {
 #if defined(PICORB_PLATFORM_POSIX)
-  SET_FALSE_RETURN();
+  mrbc_raise(vm, MRBC_CLASS(NotImplementedError), "Machine.bootsel_pressed? is not supported on this platform");
 #else
   if (Machine_bootsel_pressed_q()) {
     SET_TRUE_RETURN();

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -21,6 +21,20 @@ c_Machine_tud_mounted_q(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
+c_Machine_bootsel_pressed_q(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+#if defined(PICORB_PLATFORM_POSIX)
+  SET_FALSE_RETURN();
+#else
+  if (Machine_bootsel_pressed_q()) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+#endif
+}
+
+static void
 c_Machine_delay_ms(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   if (argc != 1) {
@@ -419,6 +433,7 @@ mrbc_machine_init(mrbc_vm *vm)
 
   mrbc_define_method(vm, module_Machine, "tud_task", c_Machine_tud_task);
   mrbc_define_method(vm, module_Machine, "tud_mounted?", c_Machine_tud_mounted_q);
+  mrbc_define_method(vm, module_Machine, "bootsel_pressed?", c_Machine_bootsel_pressed_q);
 
   mrbc_define_method(vm, module_Machine, "delay_ms", c_Machine_delay_ms);
   mrbc_define_method(vm, module_Machine, "busy_wait_ms", c_Machine_busy_wait_ms);


### PR DESCRIPTION
This PR adds `Machine.bootsel_pressed?` to detect the bootsel button state.




## Implementation note

It copies the `get_bootsel_button` function from TinyUSB.
https://github.com/hathach/tinyusb/blob/86ad6e56c1700e85f1c5678607a762cfe3aa2f47/hw/bsp/rp2040/family.c#L65-L99


The original `get_bootsel_button` is not linked in `picoruby-machine`. So we need to copy the code to use it. Also, the function is linked in R2P2, so I added `__attribute__((weak))` to avoid a conflict.


I've confirmed that this method works with and without R2P2.

## Example

This is a small example program that enables the LED while the bootsel button is pressed.

```ruby
led = GPIO.new(25, GPIO::OUT)
loop do
  if Machine.bootsel_pressed?
    led.write(1)
  else
    led.write(0)
  end
  Machine.delay_ms(10)
end
```

Note: I originally implemented this feature as a picogem, but I think it's better to implement it in PicoRuby core. https://github.com/pocke/picoruby-bootsel