### PR TITLE
Fix packet loss and duplication in BLE notifications on wasm

### DIFF
--- a/mrbgems/picoruby-wasm/src/mruby/ble.c
+++ b/mrbgems/picoruby-wasm/src/mruby/ble.c
@@ -2,6 +2,7 @@
 
 #include "mruby.h"
 #include "mruby/presym.h"
+#include "mruby/array.h"
 #include "mruby/class.h"
 #include "mruby/data.h"
 #include "mruby/string.h"
@@ -107,16 +108,20 @@ ble_notify_callback(uintptr_t callback_id, const uint8_t *data, int length)
 {
   if (!global_mrb) return;
 
-  /* Store binary data in global variable */
+  /* Push binary data to queue array */
+  mrb_sym queue_sym = mrb_intern_lit(global_mrb, "$_ble_notify_queue");
+  mrb_value queue = mrb_gv_get(global_mrb, queue_sym);
+  if (!mrb_array_p(queue)) {
+    queue = mrb_ary_new(global_mrb);
+    mrb_gv_set(global_mrb, queue_sym, queue);
+  }
   mrb_value data_str = mrb_str_new(global_mrb, (const char *)data, length);
-  mrb_gv_set(global_mrb,
-    mrb_intern_lit(global_mrb, "$_ble_notify_data"),
-    data_str);
+  mrb_ary_push(global_mrb, queue, data_str);
 
   /* Build and execute callback script */
   static char script[256];
   snprintf(script, sizeof(script),
-    "JS::Object::CALLBACKS[%lu]&.call($_ble_notify_data)",
+    "JS::Object::CALLBACKS[%lu]&.call($_ble_notify_queue.shift)",
     (unsigned long)callback_id);
 
   mrc_ccontext *cc = mrc_ccontext_new(global_mrb);

--- a/mrbgems/picoruby-wasm/src/mruby/ble.c
+++ b/mrbgems/picoruby-wasm/src/mruby/ble.c
@@ -5,6 +5,7 @@
 #include "mruby/array.h"
 #include "mruby/class.h"
 #include "mruby/data.h"
+#include "mruby/hash.h"
 #include "mruby/string.h"
 #include "mruby/variable.h"
 
@@ -108,6 +109,13 @@ ble_notify_callback(uintptr_t callback_id, const uint8_t *data, int length)
 {
   if (!global_mrb) return;
 
+  mrb_value callbacks = mrb_const_get(global_mrb,
+    mrb_obj_value(class_JS_Object), mrb_intern_lit(global_mrb, "CALLBACKS"));
+  if (!mrb_hash_p(callbacks)) return;
+  mrb_value callback = mrb_hash_get(global_mrb, callbacks,
+    mrb_fixnum_value((mrb_int)callback_id));
+  if (mrb_nil_p(callback)) return;
+
   /* Push binary data to queue array */
   mrb_sym queue_sym = mrb_intern_lit(global_mrb, "$_ble_notify_queue");
   mrb_value queue = mrb_gv_get(global_mrb, queue_sym);
@@ -121,7 +129,7 @@ ble_notify_callback(uintptr_t callback_id, const uint8_t *data, int length)
   /* Build and execute callback script */
   static char script[256];
   snprintf(script, sizeof(script),
-    "JS::Object::CALLBACKS[%lu]&.call($_ble_notify_queue.shift)",
+    "JS::Object::CALLBACKS[%lu].call($_ble_notify_queue.shift)",
     (unsigned long)callback_id);
 
   mrc_ccontext *cc = mrc_ccontext_new(global_mrb);


### PR DESCRIPTION
This patch fixes packet loss and duplication in BLE notifications caused by the single global slot being overwritten before Ruby callbacks ran.

`ble_notify_callback` stored each incoming packet in `$_ble_notify_data`, a single global slot, and scheduled a Ruby callback script to read it later. When a second notification arrived before the scheduled script ran, the slot was overwritten, so the earlier packet was lost and the later one was read twice.

Each notification should look like:
```
a=-1.80769,b=-1.81502,c=-1.87851
```
but was observed as broken streams such as:
```
a=-1.81502,58059,b=-1.67094,c=-58059,b=-1.67094,c=-58059,b=-1.67094,c=-
```
or:
```
2,c=-1.87851
2,c=-1.87851
```

where the same fragment is repeated while the preceding packet is dropped.

Replace the single slot with $_ble_notify_queue, an mrb_array, and push/shift per notification so each callback receives its own packet in order.