### PR TITLE
Fix IRB crash after uncaught ScriptError exceptions

### DIFF
--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -482,7 +482,7 @@ class Shell
         when "quit", "exit"
           break
         else
-          if buffer.lines[-1][-1] == "\\" || !sandbox.compile("begin; _ = (#{script}); rescue => _; end; _")
+          if buffer.lines[-1][-1] == "\\" || !sandbox.compile("begin; _ = (#{script}); rescue Exception => _; end; _")
             buffer.put :ENTER
           else
             editor.feed_at_bottom


### PR DESCRIPTION
I fixed IRB crash that occurred after exceptions not under `StandardError` .

## How to reproduce

In R2P2:

```
$> irb
irb> 5.times
fiber required for enumerator (NotImplementedError)
irb> 5.times
zsh: segmentation fault (core dumped)
```

The bare rescue only catches `StandardError`, so `NotImplementedError` was not caught.
