### PR TITLE
Type check individually

### DIFF
--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -30,11 +30,12 @@ class CYW43
 
   # @sidebar hardware_device
   class GPIO
+    type gpio_logic_t = (0 | 1)
     LED_PIN: Integer
     @pin: Integer
     def initialize: (Integer pin) -> void
     def write: (Integer) -> Integer
-    def read: () -> GPIO::gpio_logic_t
+    def read: () -> gpio_logic_t
     def high?: () -> bool
     def low?: () -> bool
   end

--- a/mrbgems/picoruby-filesystem-fat/sig/polyfill.rbs
+++ b/mrbgems/picoruby-filesystem-fat/sig/polyfill.rbs
@@ -1,0 +1,5 @@
+class SPI
+end
+
+class SDMMC
+end

--- a/mrbgems/picoruby-irq/mrbgem.rake
+++ b/mrbgems/picoruby-irq/mrbgem.rake
@@ -2,4 +2,6 @@ MRuby::Gem::Specification.new('picoruby-irq') do |spec|
   spec.license = 'MIT'
   spec.author  = 'HASUMI Hitoshi'
   spec.summary = 'IRQ module'
+
+  spec.add_dependency 'picoruby-gpio'
 end

--- a/mrbgems/picoruby-littlefs/sig/polyfill.rbs
+++ b/mrbgems/picoruby-littlefs/sig/polyfill.rbs
@@ -1,0 +1,4 @@
+class SPI
+end
+class SDMMC
+end

--- a/mrbgems/picoruby-network/sig/polyfill.rbs
+++ b/mrbgems/picoruby-network/sig/polyfill.rbs
@@ -1,0 +1,7 @@
+class CYW43
+end
+
+class ESP32
+  class WiFi
+  end
+end

--- a/mrbgems/picoruby-prk-keyboard/sig/keyboard.rbs
+++ b/mrbgems/picoruby-prk-keyboard/sig/keyboard.rbs
@@ -105,7 +105,6 @@ class Keyboard
   @joystick: Joystick
   @mouse: Mouse
   @output_report_cb: ^(Integer)->void
-  @prev_rgb_effect: RGB::rgb_effect_t
   @rgb_sandbox: Sandbox
   @irb: Keyboard::Irb
   @via: VIA

--- a/mrbgems/picoruby-prk-keyboard/sig/polyfill.rbs
+++ b/mrbgems/picoruby-prk-keyboard/sig/polyfill.rbs
@@ -1,0 +1,29 @@
+class Sounder
+end
+
+class RotaryEncoder
+end
+
+class Joystick
+end
+
+class Mouse
+end
+
+class RGB
+end
+
+class VIA
+end
+
+class DebounceBase
+end
+
+class DebounceNone < DebounceBase
+end
+
+class DebouncePerRow < DebounceBase
+end
+
+class DebouncePerKey < DebounceBase
+end

--- a/mrbgems/picoruby-prk-mouse/sig/polyfill.rbs
+++ b/mrbgems/picoruby-prk-mouse/sig/polyfill.rbs
@@ -1,0 +1,14 @@
+class Keyboard
+end
+
+class I2C
+end
+
+class SPI
+end
+
+class ADC
+end
+
+class Task
+end

--- a/mrbgems/picoruby-prk-via/sig/polyfill.rbs
+++ b/mrbgems/picoruby-prk-via/sig/polyfill.rbs
@@ -1,0 +1,2 @@
+class Keyboard
+end

--- a/mrbgems/picoruby-psg/sig/polyfill.rbs
+++ b/mrbgems/picoruby-psg/sig/polyfill.rbs
@@ -1,0 +1,2 @@
+class Task
+end

--- a/mrbgems/picoruby-rtd/sig/polyfill.rbs
+++ b/mrbgems/picoruby-rtd/sig/polyfill.rbs
@@ -1,0 +1,11 @@
+class MCP3424
+end
+
+class MCP3208
+end
+
+class GPIO
+end
+
+class ADC
+end

--- a/mrbgems/picoruby-shell/sig/polyfill.rbs
+++ b/mrbgems/picoruby-shell/sig/polyfill.rbs
@@ -1,0 +1,32 @@
+class BLE
+  class Utils
+  end
+end
+
+class GPIO
+end
+
+class ADC
+end
+
+class I2C
+end
+
+class UART
+end
+
+class PWM
+end
+
+class CYW43
+  class GPIO
+  end
+end
+
+class ESP32
+  class WiFi
+  end
+end
+
+class PCF8523
+end

--- a/mrbgems/picoruby-vfs/sig/polyfill.rbs
+++ b/mrbgems/picoruby-vfs/sig/polyfill.rbs
@@ -1,0 +1,21 @@
+class FAT
+  class File
+  end
+
+  class Dir
+  end
+
+  class VFSMethods
+  end
+end
+
+class Littlefs
+  class File
+  end
+
+  class Dir
+  end
+
+  class VFSMethods
+  end
+end


### PR DESCRIPTION
This PR fixes type errors when Steep runs with picogems individually.

## Problem

Currently, the RBS environment is valid only when all picogems are combined. However, it can become invalid when only a subset of picogems is used.
For example, `steep check` reports type errors for the picogems used by R2P2. As a result, users can't run type checking only with the picogems used by R2P2.

## Background

I'm developing a tool to use Steep for PicoRuby applications.
It resolves the necessary picogem signatures from build configs.

I tried this tool in various environments and found some missing type definitions.

I'll publish this tool soon.
We can then add a test that runs `rbs validate` with each individual picogem.

## Solution

I fixed the RBS files to pass type checking with each picogem (and its dependencies).

This PR includes the following four changes:

* Add `polyfill.rbs`
  * Some gems have optional dependencies. These optional dependencies are not listed in the dependency list, but the RBS files refer to their class definitions.
  * Add empty classes to fix the errors.
  * I often use this approach. [e.g.](https://github.com/ruby/gem_rbs_collection/blob/291289079f2e89ffb397d73f2da371b2e13555b6/gems/parser/3.2/polyfill.rbs#L3)
  * Alternative solution: We could also solve this problem by specifying optional deps explicitly in `Steepfile`. However, I think the polyfill approach is better because users don't need to write deps manually.
  * These polyfills do not affect the documentation as I confirmed because they just include empty classes.
* Define the `CYW43::GPIO::gpio_logic_t` type alias
  * `CYW43::GPIO` refers to `::GPIO::gpio_logic_t`, but `GPIO` is not available in its dependencies.
  * So I defined `CYW43::GPIO::gpio_logic_t` instead.
* Specify the `picoruby-gpio` dependency from `picoruby-irq`
  * `picoruby-gpio` is necessary to run `picoruby-irq`, but `mrbgem.rake` didn't declare the dependency.
  * So I added it.
  * The problem doesn't surface in practice because [peripherals.gembox](https://github.com/picoruby/picoruby/blob/db42ae9a50954e0f912317fccb9ab27c695003ee/mrbgems/peripherals.gembox) includes both.
* Remove the unused type annotation for `@prev_rgb_effect`
  * This ivar's type is `RGB::rgb_effect_t`, but `picoruby-rpk-rgb` is not included in the dependencies.
  * Since this ivar is unused, we can simply remove it.


## Note


I checked that most gems' RBS files are valid, but I couldn't check the following gems because they raise some errors on resolving dependenceis.

```
["mruby-bin-mrbc2", "mruby-file-stat", "picoruby-picotest", "picoruby-prk-sounder", "picoruby-r2p2", "picoruby-task-ext", "prk_firmware"]
```
