### PR TITLE
Introduce picoruby-uc8151 and improve picoruby-vram

### DIFF
--- a/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
+++ b/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
@@ -123,19 +123,19 @@ class SSD1306
     when 'shinonome'
       draw_shinonome(name.to_s, x, y, text, scale)
     when 'terminus'
-      draw_terminus(name.to_s, x, y, text)
+      draw_terminus(name.to_s, x, y, text, scale)
     else
       raise "Unsupported font: #{font}"
     end
   end
 
-  def draw_terminus(name, x, y, text)
+  def draw_terminus(name, x, y, text, scale = 1)
     # Call C method directly to avoid send -> mrb_funcall -> mrb_vm_exec recursion
     result = case name
-             when "6x12"  then Terminus._6x12(text)
-             when "8x16"  then Terminus._8x16(text)
-             when "12x24" then Terminus._12x24(text)
-             when "16x32" then Terminus._16x32(text)
+             when "6x12"  then Terminus._6x12(text, scale)
+             when "8x16"  then Terminus._8x16(text, scale)
+             when "12x24" then Terminus._12x24(text, scale)
+             when "16x32" then Terminus._16x32(text, scale)
              else raise "Unsupported terminus font: #{name}"
              end
     height = result[0]

--- a/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
+++ b/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
@@ -38,7 +38,7 @@ class SSD1306
   def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> nil
   def draw_text: (Symbol | String fontname, Integer x, Integer y, String text, ?Integer scale) -> nil
   def draw_shinonome: (String size, Integer x, Integer y, String text, ?Integer scale) -> nil
-  def draw_terminus: (String size, Integer x, Integer y, String text) -> nil
+  def draw_terminus: (String size, Integer x, Integer y, String text, ?Integer scale) -> nil
   def update_display: () -> Integer
   def update_display_optimized: () -> Integer # Returns number of pages updated
 end

--- a/mrbgems/picoruby-terminus/mrblib/terminus.rb
+++ b/mrbgems/picoruby-terminus/mrblib/terminus.rb
@@ -1,11 +1,10 @@
 module Terminus
-  def self.draw(name, line, scale = 0)
+  def self.draw(name, line, scale = 1)
     name = "_#{name}"
-    # No scaling available. Just for compability with Shinonome font
     if block_given?
-      yield(send(name, line.chomp))
+      yield(send(name, line.chomp, scale))
     else
-      send(name, line.chomp)
+      send(name, line.chomp, scale)
     end
   end
 end

--- a/mrbgems/picoruby-terminus/sig/terminus.rbs
+++ b/mrbgems/picoruby-terminus/sig/terminus.rbs
@@ -1,10 +1,10 @@
 module Terminus
   type terminus_t = [Integer, Integer,     Array[Integer], Array[Array[Integer]]]
   #                   height,  total_width, widths,         glyphs
-  def self._6x12: (String text) -> terminus_t
-  def self._8x16: (String text) -> terminus_t
-  def self._12x24: (String text) -> terminus_t
-  def self._16x32: (String text) -> terminus_t
+  def self._6x12: (String text, ?Integer scale) -> terminus_t
+  def self._8x16: (String text, ?Integer scale) -> terminus_t
+  def self._12x24: (String text, ?Integer scale) -> terminus_t
+  def self._16x32: (String text, ?Integer scale) -> terminus_t
 
   def self.draw: (String name, String line, ?Integer scale) { (terminus_t) -> void } -> void
                | (String name, String line, ?Integer scale) -> terminus_t

--- a/mrbgems/picoruby-terminus/src/mruby/terminus.c
+++ b/mrbgems/picoruby-terminus/src/mruby/terminus.c
@@ -11,7 +11,15 @@ array_of_terminus(mrb_state *mrb, int w, int h, bool (*array_func)(const char **
   mrb_int total_width = 0;
   mrb_value glyphs = mrb_ary_new(mrb);
   const char *text;
-  mrb_get_args(mrb, "z", &text);
+  mrb_int scale = 1;
+  mrb_get_args(mrb, "z|i", &text, &scale);
+
+  if (scale < 1 || 4 < scale) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "Invalid scale. Expect 1..4");
+  }
+
+  mrb_int scaled_w = w * scale;
+  mrb_int scaled_h = h * scale;
 
   const char *p = text;
   while (*p) {
@@ -20,17 +28,57 @@ array_of_terminus(mrb_state *mrb, int w, int h, bool (*array_func)(const char **
       mrb_raise(mrb, E_ARGUMENT_ERROR, "Invalid character (ASCII only)");
     }
 
-    mrb_value ch = mrb_ary_new_capa(mrb, h);
-    total_width += w;
-    mrb_ary_push(mrb, widths, mrb_fixnum_value(w));
+    uint64_t output[scaled_h] __attribute__((aligned(8)));
 
-    for (int i = 1; i <= h; i++) {
-      mrb_ary_push(mrb, ch, mrb_int_value(mrb, lines[i]));
+    if (1 < scale) {
+      for (int i = 1; i <= h; i++) {
+        lines[i] = expand_bits(lines[i], w, scale);
+      }
+      for (int i = 0; i < h; i++) {
+        for (int j = 0; j < scale; j++) {
+          output[i * scale + j] = lines[i + 1];
+        }
+      }
+      smooth_edges(output, scaled_w, scaled_h);
     }
+
+    total_width += scaled_w;
+
+    if (32 < scaled_w) {
+      mrb_ary_push(mrb, widths, mrb_fixnum_value(scaled_w - 32));
+      mrb_ary_push(mrb, widths, mrb_fixnum_value(32));
+    } else {
+      mrb_ary_push(mrb, widths, mrb_fixnum_value(scaled_w));
+    }
+
+    mrb_value ch = mrb_ary_new_capa(mrb, scaled_h);
+
+    if (scale == 1) {
+      for (int i = 1; i <= h; i++) {
+        mrb_ary_push(mrb, ch, mrb_int_value(mrb, lines[i]));
+      }
+    } else {
+      for (int i = 0; i < scaled_h; i++) {
+        if (32 < scaled_w) {
+          mrb_ary_push(mrb, ch, mrb_int_value(mrb, (mrb_int)(uint32_t)(output[i] >> 32)));
+        } else {
+          mrb_ary_push(mrb, ch, mrb_int_value(mrb, (mrb_int)(uint32_t)output[i]));
+        }
+      }
+    }
+
     mrb_ary_push(mrb, glyphs, ch);
+
+    if (32 < scaled_w) {
+      mrb_value ch2 = mrb_ary_new_capa(mrb, scaled_h);
+      for (int i = 0; i < scaled_h; i++) {
+        mrb_ary_push(mrb, ch2, mrb_int_value(mrb, (mrb_int)(uint32_t)output[i]));
+      }
+      mrb_ary_push(mrb, glyphs, ch2);
+    }
   }
 
-  mrb_ary_push(mrb, result, mrb_fixnum_value(h));
+  mrb_ary_push(mrb, result, mrb_fixnum_value(scaled_h));
   mrb_ary_push(mrb, result, mrb_fixnum_value(total_width));
   mrb_ary_push(mrb, result, widths);
   mrb_ary_push(mrb, result, glyphs);
@@ -66,10 +114,10 @@ mrb_picoruby_terminus_gem_init(mrb_state* mrb)
 {
   struct RClass *module_Terminus = mrb_define_module_id(mrb, MRB_SYM(Terminus));
 
-  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_6x12), mrb_s_6x12, MRB_ARGS_REQ(1));
-  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_8x16), mrb_s_8x16, MRB_ARGS_REQ(1));
-  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_12x24), mrb_s_12x24, MRB_ARGS_REQ(1));
-  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_16x32), mrb_s_16x32, MRB_ARGS_REQ(1));
+  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_6x12), mrb_s_6x12, MRB_ARGS_ARG(1,1));
+  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_8x16), mrb_s_8x16, MRB_ARGS_ARG(1,1));
+  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_12x24), mrb_s_12x24, MRB_ARGS_ARG(1,1));
+  mrb_define_class_method_id(mrb, module_Terminus, MRB_SYM(_16x32), mrb_s_16x32, MRB_ARGS_ARG(1,1));
 }
 
 void

--- a/mrbgems/picoruby-terminus/src/mrubyc/terminus.c
+++ b/mrbgems/picoruby-terminus/src/mrubyc/terminus.c
@@ -4,11 +4,18 @@ static mrbc_value
 array_of_terminus(mrbc_vm *vm, mrbc_value *v, int argc, int w, int h, bool (*array_func)(const char **, uint64_t *))
 {
   const char *text = (const char *)GET_STRING_ARG(1);
+  mrbc_int_t scale = (argc > 1) ? GET_INT_ARG(2) : 1;
+
+  if (scale < 1 || 4 < scale) {
+    return mrbc_nil_value();
+  }
 
   mrbc_value result = mrbc_array_new(vm, 4);
   mrbc_value widths = mrbc_array_new(vm, 0);
   mrbc_int_t total_width = 0;
   mrbc_value glyphs = mrbc_array_new(vm, 0);
+  mrbc_int_t scaled_w = w * scale;
+  mrbc_int_t scaled_h = h * scale;
 
   const char *p = text;
   while (*p) {
@@ -17,19 +24,64 @@ array_of_terminus(mrbc_vm *vm, mrbc_value *v, int argc, int w, int h, bool (*arr
       return mrbc_nil_value();
     }
 
-    mrbc_value ch = mrbc_array_new(vm, h);
-    total_width += w;
-    mrbc_value width_val = mrbc_integer_value(w);
-    mrbc_array_push(&widths, &width_val);
+    uint64_t output[scaled_h] __attribute__((aligned(8)));
 
-    for (int i = 1; i <= h; i++) {
-      mrbc_value val = mrbc_integer_value(lines[i]);
-      mrbc_array_push(&ch, &val);
+    if (1 < scale) {
+      for (int i = 1; i <= h; i++) {
+        lines[i] = expand_bits(lines[i], w, scale);
+      }
+      for (int i = 0; i < h; i++) {
+        for (int j = 0; j < scale; j++) {
+          output[i * scale + j] = lines[i + 1];
+        }
+      }
+      smooth_edges(output, scaled_w, scaled_h);
     }
+
+    total_width += scaled_w;
+
+    if (32 < scaled_w) {
+      mrbc_value val1 = mrbc_integer_value(scaled_w - 32);
+      mrbc_value val2 = mrbc_integer_value(32);
+      mrbc_array_push(&widths, &val1);
+      mrbc_array_push(&widths, &val2);
+    } else {
+      mrbc_value val = mrbc_integer_value(scaled_w);
+      mrbc_array_push(&widths, &val);
+    }
+
+    mrbc_value ch = mrbc_array_new(vm, scaled_h);
+
+    if (scale == 1) {
+      for (int i = 1; i <= h; i++) {
+        mrbc_value val = mrbc_integer_value(lines[i]);
+        mrbc_array_push(&ch, &val);
+      }
+    } else {
+      for (int i = 0; i < scaled_h; i++) {
+        if (32 < scaled_w) {
+          mrbc_value val = mrbc_integer_value((mrbc_int_t)(uint32_t)(output[i] >> 32));
+          mrbc_array_push(&ch, &val);
+        } else {
+          mrbc_value val = mrbc_integer_value((mrbc_int_t)(uint32_t)output[i]);
+          mrbc_array_push(&ch, &val);
+        }
+      }
+    }
+
     mrbc_array_push(&glyphs, &ch);
+
+    if (32 < scaled_w) {
+      mrbc_value ch2 = mrbc_array_new(vm, scaled_h);
+      for (int i = 0; i < scaled_h; i++) {
+        mrbc_value val = mrbc_integer_value((mrbc_int_t)(uint32_t)output[i]);
+        mrbc_array_push(&ch2, &val);
+      }
+      mrbc_array_push(&glyphs, &ch2);
+    }
   }
 
-  mrbc_value height_val = mrbc_integer_value(h);
+  mrbc_value height_val = mrbc_integer_value(scaled_h);
   mrbc_value total_width_val = mrbc_integer_value(total_width);
   mrbc_array_push(&result, &height_val);
   mrbc_array_push(&result, &total_width_val);

--- a/mrbgems/picoruby-terminus/src/terminus.c
+++ b/mrbgems/picoruby-terminus/src/terminus.c
@@ -7,6 +7,51 @@
 #include "terminus_12x24_table.h"
 #include "terminus_16x32_table.h"
 
+static uint64_t
+expand_bits(uint64_t src, int bit_count, int scale)
+{
+  uint64_t dst __attribute__((aligned(8))) = 0;
+  for (int i = 0; i < bit_count; i++) {
+    uint8_t bit = (src >> (bit_count - 1 - i)) & 1;
+    dst <<= scale;
+    if (bit) {
+      dst |= (1 << scale) - 1;
+    }
+  }
+  return dst;
+}
+
+#define GET_BIT(row, x, w) (((row) >> (w - 1 - (x))) & 1)
+#define SET_BIT(row, x, w) ((row) |= ((uint64_t)1 << (w - 1 - (x))))
+
+static void
+smooth_edges(uint64_t *input, int w, int h)
+{
+  uint64_t tmp[h] __attribute__((aligned(8)));
+  memcpy(tmp, input, sizeof(uint64_t) * h);
+
+  for (int y = 0; y < h - 1; y++) {
+    for (int x = 0; x < w - 1; x++) {
+      int a = GET_BIT(input[y], x, w);
+      int b = GET_BIT(input[y], x + 1, w);
+      int c = GET_BIT(input[y + 1], x, w);
+      int d = GET_BIT(input[y + 1], x + 1, w);
+
+      if (b && c && !a && !d) {
+        SET_BIT(tmp[y], x, w);
+        SET_BIT(tmp[y + 1], x + 1, w);
+      }
+      if (a && d && !b && !c) {
+        SET_BIT(tmp[y], x + 1, w);
+        SET_BIT(tmp[y + 1], x, w);
+      }
+    }
+  }
+  for (int i = 0; i < h; i++) {
+    input[i] = tmp[i];
+  }
+}
+
 static inline uint32_t
 utf8_to_unicode(const char **p)
 {

--- a/mrbgems/picoruby-uc8151/example/badger.rb
+++ b/mrbgems/picoruby-uc8151/example/badger.rb
@@ -1,0 +1,19 @@
+require "uc8151"
+
+spi = SPI.new(
+  unit: :RP2040_SPI0,
+  frequency: 2_000_000,
+  sck_pin:  18,
+  copi_pin: 19
+)
+display = UC8151.new(
+  spi:      spi,
+  cs_pin:   17,
+  dc_pin:   20,
+  rst_pin:  21,
+  busy_pin: 26
+)
+display.fill(0)
+display.draw_text("shinonome_min16", 28, 20, "Lチカは情操教育", 2)
+display.draw_text("terminus_12x24", 28, 70, "@hasumikin", 2)
+display.update

--- a/mrbgems/picoruby-uc8151/mrbgem.rake
+++ b/mrbgems/picoruby-uc8151/mrbgem.rake
@@ -1,0 +1,10 @@
+MRuby::Gem::Specification.new('picoruby-uc8151') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'HASUMI Hitoshi'
+  spec.summary = 'UC8151 e-ink display driver using SPI'
+
+  spec.add_dependency 'picoruby-spi'
+  spec.add_dependency 'picoruby-gpio'
+  spec.add_dependency 'picoruby-vram'
+  spec.add_dependency 'picoruby-terminus'
+end

--- a/mrbgems/picoruby-uc8151/mrblib/uc8151.rb
+++ b/mrbgems/picoruby-uc8151/mrblib/uc8151.rb
@@ -1,0 +1,247 @@
+require "spi"
+require "gpio"
+require "vram"
+require "terminus"
+
+class UC8151
+  WIDTH  = 296
+  HEIGHT = 128
+
+  # UC8151 command registers
+  PSR  = 0x00  # Panel Setting
+  PWR  = 0x01  # Power Setting
+  POF  = 0x02  # Power OFF
+  POFS = 0x03  # Power OFF Sequence Setting
+  PON  = 0x04  # Power ON
+  BTST = 0x06  # Booster Soft Start
+  DSLP = 0x07  # Deep Sleep
+  DTM1 = 0x10  # Data Transmission 1 (old/background data)
+  DSP  = 0x11  # Data Stop
+  DRF  = 0x12  # Display Refresh
+  DTM2 = 0x13  # Data Transmission 2 (new data)
+  PLL  = 0x30  # PLL Control
+  CDI  = 0x50  # VCOM and Data Interval Setting
+  TCON = 0x60  # Gate/Source Non-overlap Period
+  TRES = 0x61  # Resolution Setting
+
+  FRAME_SIZE = WIDTH * HEIGHT / 8  # 4736 bytes
+
+  def initialize(spi:, cs_pin:, dc_pin:, rst_pin:, busy_pin:)
+    @spi  = spi
+    @cs   = GPIO.new(cs_pin,   GPIO::OUT)
+    @cs.write(1)
+    @dc   = GPIO.new(dc_pin,   GPIO::OUT)
+    @rst  = GPIO.new(rst_pin,  GPIO::OUT)
+    @busy = GPIO.new(busy_pin, GPIO::IN)
+    # rotate: 90 maps landscape (x=0..295, y=0..127) to the column-major
+    # buffer format the UC8151 expects: (buf_x=y, buf_y=295-x).
+    # invert: true because bit=1 means white (paper) in KW mode.
+    @vram = VRAM.new(w: WIDTH, h: HEIGHT, cols: 1, rows: 1,
+                     layout: :horizontal, invert: true, rotate: 90)
+    @vram.name = "UC8151"
+    reset
+    init_display
+    deep_clean
+  end
+
+  private def reset
+    @rst.write(1)
+    sleep_ms 100
+    @rst.write(0)
+    sleep_ms 100
+    @rst.write(1)
+    sleep_ms 100
+  end
+
+  # UC8151 BUSY pin: LOW = busy, HIGH = idle
+  private def busy_wait
+    sleep_ms 10
+    while @busy.read == 0
+      sleep_ms 10
+    end
+  end
+
+  # Send command byte in its own CS transaction (DC=0).
+  private def command(cmd)
+    @dc.write(0)
+    @cs.write(0)
+    @spi.write(cmd)
+    @cs.write(1)
+  end
+
+  # Send data bytes in their own CS transaction (DC=1).
+  private def send_data(*bytes)
+    @dc.write(1)
+    @cs.write(0)
+    i = 0
+    while i < bytes.size
+      @spi.write(bytes[i])
+      i += 1
+    end
+    @cs.write(1)
+  end
+
+  # Send a data string in 1024-byte chunks in one CS transaction (DC=1).
+  private def send_data_chunked(data)
+    @dc.write(1)
+    @cs.write(0)
+    i = 0
+    while i < data.size
+      chunk_size = (data.size - i) < 1024 ? (data.size - i) : 1024
+      @spi.write(data[i, chunk_size])
+      i += 1024
+    end
+    @cs.write(1)
+  end
+
+  private def init_display
+    # PSR: 128x296, KW mode (black/white), booster on, soft reset off
+    command(PSR); send_data(0x5f)
+    # PWR: VDS/VDG internal, VCOM internal, VGH=20V, VGL=-20V, VDH=15V, VDL=-15V
+    #      5th byte is VCOM voltage: raised from 0x17 to 0x1e for stronger drive
+    command(PWR); send_data(0x03, 0x00, 0x2b, 0x2b, 0x1e)
+    # BTST: booster soft start phases A/B/C strength and minimum OFF time
+    command(BTST); send_data(0x17, 0x17, 0x17)
+    # PLL: 50Hz frame rate (must be sent before PON)
+    command(PLL); send_data(0x3c)
+    # PON: power on, then wait for panel to become ready
+    command(PON)
+    busy_wait
+    # TRES: gate resolution (128 = 0x80) first, then source resolution (296 = 0x0128)
+    command(TRES); send_data(0x80, 0x01, 0x28)
+    # CDI: border control and VCOM data interval
+    #      0x13 optimizes border handling and pixel polarity
+    command(CDI); send_data(0x13)
+    # TCON: gate/source non-overlap periods
+    command(TCON); send_data(0x22)
+  end
+
+  # Reset the panel memory before first use to avoid ghost images.
+  private def deep_clean
+    command(DTM1)
+    send_data_chunked("\x00" * FRAME_SIZE)
+    command(DTM2)
+    send_data_chunked("\xFF" * FRAME_SIZE)
+    command(DRF)
+    busy_wait
+  end
+
+  # Send VRAM contents to display and trigger refresh.
+  def update
+    pages = @vram.pages
+    # DTM1 carries the previous frame (all-white = no ghost)
+    command(DTM1)
+    send_data_chunked("\xFF" * FRAME_SIZE)
+    # DTM2 carries the new frame
+    command(DTM2)
+    send_data_chunked(pages[0][2])
+    command(DRF)
+    busy_wait
+    command(POF)
+  end
+
+  def fill(color = 0)
+    @vram.fill(color)
+  end
+
+  def set_pixel(x, y, color = 1)
+    return if x < 0 || WIDTH <= x
+    return if y < 0 || HEIGHT <= y
+    @vram.set_pixel(x, y, color)
+  end
+
+  def draw_line(x0, y0, x1, y1, color = 1)
+    @vram.draw_line(x0, y0, x1, y1, color)
+  end
+
+  def draw_rect(x, y, w, h, color = 1, fill = false)
+    if fill
+      @vram.draw_rect(x, y, w, h, color)
+    else
+      draw_line(x,         y,         x + w - 1, y,         color)
+      draw_line(x,         y + h - 1, x + w - 1, y + h - 1, color)
+      draw_line(x,         y,         x,         y + h - 1, color)
+      draw_line(x + w - 1, y,         x + w - 1, y + h - 1, color)
+    end
+    nil
+  end
+
+  def draw_bitmap(x:, y:, w:, h:, data:)
+    @vram.draw_bitmap(x: x, y: y, w: w, h: h, data: data)
+    nil
+  end
+
+  def draw_bytes(x:, y:, w:, h:, data:)
+    @vram.draw_bytes(x: x, y: y, w: w, h: h, data: data)
+    nil
+  end
+
+  def draw_text(fontname, x, y, text, scale = 1)
+    font, name = fontname.to_s.split("_")
+    case font
+    when "terminus"
+      draw_terminus(name.to_s, x, y, text, scale)
+    when "shinonome"
+      draw_shinonome(name.to_s, x, y, text, scale)
+    else
+      raise "Unsupported font: #{font}"
+    end
+  end
+
+  def draw_terminus(name, x, y, text, scale = 1)
+    result = case name
+             when "6x12"  then Terminus._6x12(text, scale)
+             when "8x16"  then Terminus._8x16(text, scale)
+             when "12x24" then Terminus._12x24(text, scale)
+             when "16x32" then Terminus._16x32(text, scale)
+             else raise "Unsupported terminus font: #{name}"
+             end
+    height = result[0]
+    widths = result[2]
+    glyphs = result[3]
+    glyph_x = x
+    i = 0
+    while i < widths.size
+      char_width = widths[i]
+      char_data = glyphs[i]
+      draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
+      glyph_x += char_width
+      i += 1
+    end
+    nil
+  end
+
+  begin
+    require "shinonome"
+    def draw_shinonome(name, x, y, text, scale = 1)
+      result = case name
+               when "test12" then Shinonome.test12(text, scale)
+               when "test16" then Shinonome.test16(text, scale)
+               when "maru12" then Shinonome.maru12(text, scale)
+               when "go12"   then Shinonome.go12(text, scale)
+               when "min12"  then Shinonome.min12(text, scale)
+               when "go16"   then Shinonome.go16(text, scale)
+               when "min16"  then Shinonome.min16(text, scale)
+               else raise "Unsupported shinonome font: #{name}"
+               end
+      return if result.nil?
+      height = result[0]
+      widths = result[2]
+      glyphs = result[3]
+      glyph_x = x
+      i = 0
+      while i < widths.size
+        char_width = widths[i]
+        char_data = glyphs[i]
+        draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
+        glyph_x += char_width
+        i += 1
+      end
+      nil
+    end
+  rescue LoadError
+    def draw_shinonome(name, x, y, text, scale = 1)
+      puts "Shinonome gem not available, skip text rendering"
+    end
+  end
+end

--- a/mrbgems/picoruby-uc8151/sig/uc8151.rbs
+++ b/mrbgems/picoruby-uc8151/sig/uc8151.rbs
@@ -1,0 +1,34 @@
+class UC8151
+  WIDTH: 296
+  HEIGHT: 128
+
+  PSR:  Integer
+  PWR:  Integer
+  POF:  Integer
+  POFS: Integer
+  PON:  Integer
+  BTST: Integer
+  DSLP: Integer
+  DTM1: Integer
+  DSP:  Integer
+  DRF:  Integer
+  DTM2: Integer
+  PLL:  Integer
+  CDI:  Integer
+  TCON: Integer
+  TRES: Integer
+
+  def initialize: (spi: SPI, cs_pin: Integer, dc_pin: Integer,
+                   rst_pin: Integer, busy_pin: Integer) -> void
+
+  def update: () -> void
+  def fill: (?Integer color) -> void
+  def set_pixel: (Integer x, Integer y, ?Integer color) -> void
+  def draw_line: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color) -> void
+  def draw_rect: (Integer x, Integer y, Integer w, Integer h, ?Integer color, ?bool fill) -> nil
+  def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
+  def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> nil
+  def draw_text: (String fontname, Integer x, Integer y, String text, ?Integer scale) -> void
+  def draw_terminus: (String name, Integer x, Integer y, String text, ?Integer scale) -> nil
+  def draw_shinonome: (String name, Integer x, Integer y, String text, ?Integer scale) -> nil
+end

--- a/mrbgems/picoruby-vram/include/vram.h
+++ b/mrbgems/picoruby-vram/include/vram.h
@@ -2,6 +2,7 @@
 #define VRAM_DEFINED_H_
 
 #include "picoruby.h"
+#include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -9,24 +10,30 @@ extern "C" {
 #endif
 
 typedef enum {
-  PIXEL_FORMAT_MONO,        //  1bit/pixel
-  PIXEL_FORMAT_GRAY4,       //  4bit/pixel
-  PIXEL_FORMAT_GRAY8,       //  8bit/pixel
-  PIXEL_FORMAT_RGB565,      // 16bit/pixel
-  PIXEL_FORMAT_RGB888,      // 24bit/pixel
-  PIXEL_FORMAT_ARGB8888,    // 32bit/pixel
+  PIXEL_FORMAT_MONO,        /*  1bit/pixel, vertical layout (SSD1306 style) */
+  PIXEL_FORMAT_MONO_H,      /*  1bit/pixel, horizontal layout (UC8151 style) */
+  PIXEL_FORMAT_GRAY4,       /*  4bit/pixel */
+  PIXEL_FORMAT_GRAY8,       /*  8bit/pixel */
+  PIXEL_FORMAT_RGB565,      /* 16bit/pixel */
+  PIXEL_FORMAT_RGB888,      /* 24bit/pixel */
+  PIXEL_FORMAT_ARGB8888,    /* 32bit/pixel */
 } pixel_format_t;
 
-// Abstract Display Page Structure
+/* Abstract Display Page Structure */
 typedef struct display_page {
   int page_id;
-  int x, y;          // Offset position in the overall display
-  int w, h;          // Page pixel size
+  int x, y;          /* Offset position in the overall display */
+  int w, h;          /* Logical pixel size (user-facing coordinates) */
+  int buf_w, buf_h;  /* Buffer pixel size (swapped from w,h when rotate=90/270) */
+  int rotate;        /* Clockwise rotation in degrees: 0, 90, 180, 270 */
   pixel_format_t pixel_format;
+  bool invert;       /* When true, flip bit polarity on set/get/fill */
+  uint8_t *raw_data; /* Direct pointer into VM-managed buffer data */
+  size_t raw_size;   /* Byte count of raw_data */
 #if defined(PICORB_VM_MRUBY)
-  mrb_value buffer;   // Pixel data
+  mrb_value buffer;   /* Pixel data */
 #elif defined(PICORB_VM_MRUBYC)
-  mrbc_value buffer;  // Pixel data
+  mrbc_value buffer;  /* Pixel data */
 #endif
   bool  dirty;
   size_t buffer_size;
@@ -51,4 +58,3 @@ typedef struct display {
 #endif
 
 #endif /* VRAM_DEFINED_H_ */
-

--- a/mrbgems/picoruby-vram/sig/vram.rbs
+++ b/mrbgems/picoruby-vram/sig/vram.rbs
@@ -2,7 +2,9 @@ class VRAM
   type page_t = [Integer, Integer, String]
   attr_accessor name: String
 
-  def self.new: (w: Integer, h: Integer, cols: Integer, rows: Integer) -> VRAM
+  def self.new: (w: Integer, h: Integer, cols: Integer, rows: Integer,
+                 ?layout: :vertical | :horizontal, ?invert: bool,
+                 ?rotate: 0 | 90 | 180 | 270) -> VRAM
   def pages: (?bool clear_dirty) -> Array[page_t]
   def dirty_pages: (?bool clear_dirty) -> Array[page_t]
   def set_pixel: (Integer x, Integer y, Integer color) -> self

--- a/mrbgems/picoruby-vram/src/mruby/vram.c
+++ b/mrbgems/picoruby-vram/src/mruby/vram.c
@@ -26,64 +26,47 @@ struct mrb_data_type mrb_vram_type = {
   "VRAM", mrb_vram_free,
 };
 
-static void
-mono_page_set_pixel(struct display_page *page, int x, int y, uint32_t color)
-{
-  if (x < 0 || x >= page->w || y < 0 || y >= page->h) return;
-
-  unsigned char *data = (unsigned char *)RSTRING_PTR(page->buffer);
-  int byte_idx = x + (y / 8) * page->w;
-  int bit_idx = y % 8;
-
-  if (byte_idx < 0 || byte_idx >= RSTRING_LEN(page->buffer)) return;
-
-  if (color) {
-    data[byte_idx] |= (1 << bit_idx);
-  } else {
-    data[byte_idx] &= ~(1 << bit_idx);
-  }
-  page->dirty = true;
-}
-
-static uint32_t
-mono_page_get_pixel(struct display_page *page, int x, int y)
-{
-  if (x < 0 || x >= page->w || y < 0 || y >= page->h) return 0;
-
-  unsigned char *data = (unsigned char *)RSTRING_PTR(page->buffer);
-  int byte_idx = x + (y / 8) * page->w;
-  int bit_idx = y % 8;
-
-  if (byte_idx < 0 || byte_idx >= RSTRING_LEN(page->buffer)) return 0;
-
-  return (data[byte_idx] >> bit_idx) & 1;
-}
-
-static void
-mono_page_fill(struct display_page *page, uint32_t color)
-{
-  unsigned char *data = (unsigned char *)RSTRING_PTR(page->buffer);
-  memset(data, color ? 0xFF : 0x00, RSTRING_LEN(page->buffer));
-  page->dirty = true;
-}
-
 /*
  * vram = VRAM.new(w: 128, h: 64, cols: 1, rows: 8)
- * vram.name = "SSD1306"
-*/
+ * vram = VRAM.new(w: 200, h: 200, cols: 1, rows: 1, layout: :horizontal, invert: true)
+ */
 static mrb_value
 mrb_vram_s_new(mrb_state* mrb, mrb_value klass)
 {
-  const mrb_sym kw_names[] = { MRB_SYM(w), MRB_SYM(h), MRB_SYM(cols), MRB_SYM(rows) };
-  mrb_value kw_values[4];
+  const mrb_sym kw_names[] = {
+    MRB_SYM(w), MRB_SYM(h), MRB_SYM(cols), MRB_SYM(rows),
+    MRB_SYM(layout), MRB_SYM(invert), MRB_SYM(rotate)
+  };
+  mrb_value kw_values[7];
   mrb_value kw_rest;
-  mrb_kwargs kwargs = { 4, 4, kw_names, kw_values, &kw_rest };
+  mrb_kwargs kwargs = { 7, 4, kw_names, kw_values, &kw_rest };
   mrb_get_args(mrb, ":", &kwargs);
 
-  mrb_int w = mrb_fixnum(kw_values[0]);
-  mrb_int h = mrb_fixnum(kw_values[1]);
+  mrb_int w    = mrb_fixnum(kw_values[0]);
+  mrb_int h    = mrb_fixnum(kw_values[1]);
   mrb_int cols = mrb_fixnum(kw_values[2]);
   mrb_int rows = mrb_fixnum(kw_values[3]);
+
+  /* Optional: layout (:vertical default, :horizontal for UC8151) */
+  bool horizontal = false;
+  if (!mrb_undef_p(kw_values[4]) && mrb_symbol_p(kw_values[4])) {
+    if (mrb_symbol(kw_values[4]) == mrb_intern_lit(mrb, "horizontal")) {
+      horizontal = true;
+    }
+  }
+
+  /* Optional: invert (false default) */
+  bool invert = false;
+  if (!mrb_undef_p(kw_values[5])) {
+    invert = mrb_test(kw_values[5]);
+  }
+
+  /* Optional: rotate (0 default, clockwise degrees: 0/90/180/270) */
+  int rotate = 0;
+  if (!mrb_undef_p(kw_values[6]) && mrb_integer_p(kw_values[6])) {
+    rotate = (int)mrb_integer(kw_values[6]);
+  }
+
   mrb_int page_w = w / cols;
   mrb_int page_h = h / rows;
 
@@ -95,7 +78,7 @@ mrb_vram_s_new(mrb_state* mrb, mrb_value klass)
 
   mrb_value vram = mrb_obj_value(Data_Wrap_Struct(mrb, mrb_class_ptr(klass), &mrb_vram_type, disp));
 
-  mrb_int page_size = page_w * ((page_h + 7) / 8); // TODO: support formats
+  size_t page_size = display_page_buffer_size(page_w, page_h, horizontal, rotate);
 
   for (mrb_int ty = 0; ty < rows; ty++) {
     for (mrb_int tx = 0; tx < cols; tx++) {
@@ -104,18 +87,16 @@ mrb_vram_s_new(mrb_state* mrb, mrb_value klass)
       page->y = ty * page_h;
       page->w = page_w;
       page->h = page_h;
-      // Create buffer with exact size needed
-      page->buffer = mrb_str_new(mrb, NULL, page_size);
+      page->invert = invert;
+      page->rotate = rotate;
+      page->buffer = mrb_str_new(mrb, NULL, (mrb_int)page_size);
       char *data = RSTRING_PTR(page->buffer);
       memset(data, 0, page_size);
+      page->raw_data = (uint8_t *)data;
+      page->raw_size = page_size;
       mrb_gc_register(mrb, page->buffer);
       page->dirty = false;
-      { // TODO: support formats
-        page->pixel_format = PIXEL_FORMAT_MONO;
-        page->set_pixel = mono_page_set_pixel;
-        page->get_pixel = mono_page_get_pixel;
-        page->fill = mono_page_fill;
-      }
+      display_page_init_format(page, horizontal);
       page->fill(page, 0);
     }
   }
@@ -168,43 +149,8 @@ mrb_vram_draw_line(mrb_state* mrb, mrb_value self)
 {
   mrb_int x0, y0, x1, y1, color;
   mrb_get_args(mrb, "iiiii", &x0, &y0, &x1, &y1, &color);
-
   display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
-
-  // Bresenham's line algorithm
-  mrb_int dx = x1 > x0 ? x1 - x0 : x0 - x1;
-  mrb_int dy = y1 > y0 ? y1 - y0 : y0 - y1;
-  mrb_int sx = x0 < x1 ? 1 : -1;
-  mrb_int sy = y0 < y1 ? 1 : -1;
-  mrb_int err = dx - dy;
-
-  mrb_int x = x0;
-  mrb_int y = y0;
-
-  while (1) {
-    // Set pixel at current position
-    for (mrb_int i = 0; i < disp->page_count; i++) {
-      display_page_t *page = &disp->pages[i];
-      if (x >= page->x && x < page->x + page->w &&
-          y >= page->y && y < page->y + page->h) {
-        page->set_pixel(page, x - page->x, y - page->y, color);
-        break;
-      }
-    }
-
-    if (x == x1 && y == y1) break;
-
-    mrb_int e2 = 2 * err;
-    if (e2 > -dy) {
-      err -= dy;
-      x += sx;
-    }
-    if (e2 < dx) {
-      err += dx;
-      y += sy;
-    }
-  }
-
+  display_draw_line(disp, x0, y0, x1, y1, (uint32_t)color);
   return self;
 }
 
@@ -213,24 +159,8 @@ mrb_vram_draw_rect(mrb_state* mrb, mrb_value self)
 {
   mrb_int x, y, w, h, color;
   mrb_get_args(mrb, "iiiii", &x, &y, &w, &h, &color);
-
   display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
-
-  for (mrb_int i = 0; i < h; i++) {
-    for (mrb_int j = 0; j < w; j++) {
-      mrb_int px = x + j;
-      mrb_int py = y + i;
-      for (mrb_int k = 0; k < disp->page_count; k++) {
-        display_page_t *page = &disp->pages[k];
-        if (px >= page->x && px < page->x + page->w &&
-            py >= page->y && py < page->y + page->h) {
-          page->set_pixel(page, px - page->x, py - page->y, color);
-          break;
-        }
-      }
-    }
-  }
-
+  display_draw_rect(disp, x, y, w, h, (uint32_t)color);
   return self;
 }
 
@@ -239,18 +169,8 @@ mrb_vram_set_pixel(mrb_state* mrb, mrb_value self)
 {
   mrb_int x, y, color;
   mrb_get_args(mrb, "iii", &x, &y, &color);
-
   display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
-
-  for (mrb_int i = 0; i < disp->page_count; i++) {
-    display_page_t *page = &disp->pages[i];
-    if (x >= page->x && x < page->x + page->w &&
-        y >= page->y && y < page->y + page->h) {
-      page->set_pixel(page, x - page->x, y - page->y, color);
-      break;
-    }
-  }
-
+  display_set_pixel(disp, x, y, (uint32_t)color);
   return self;
 }
 
@@ -260,13 +180,21 @@ mrb_vram_fill(mrb_state* mrb, mrb_value self)
   mrb_int color;
   mrb_get_args(mrb, "i", &color);
   display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
-  for (mrb_int i = 0; i < disp->page_count; i++) {
-    display_page_t *page = &disp->pages[i];
-    page->fill(page, color);
-  }
+  display_fill(disp, (uint32_t)color);
   return self;
 }
 
+static mrb_value
+mrb_vram_erase(mrb_state* mrb, mrb_value self)
+{
+  mrb_int x, y, w, h;
+  mrb_get_args(mrb, "iiii", &x, &y, &w, &h);
+  display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
+  display_erase(disp, x, y, w, h);
+  return self;
+}
+
+/* draw_bitmap: VM-specific because it takes an Array[Integer] */
 static mrb_value
 mrb_vram_draw_bitmap(mrb_state* mrb, mrb_value self)
 {
@@ -301,17 +229,7 @@ mrb_vram_draw_bitmap(mrb_state* mrb, mrb_value self)
       uint64_t row_data = (uint64_t)mrb_integer(row_val);
       for (mrb_int img_x = 0; img_x < width; img_x++) {
         uint8_t pixel = (row_data >> (width - 1 - img_x)) & 1;
-        mrb_int screen_x = x + img_x;
-        mrb_int screen_y = y + img_y;
-
-        for (mrb_int i = 0; i < disp->page_count; i++) {
-          display_page_t *page = &disp->pages[i];
-          if (screen_x >= page->x && screen_x < page->x + page->w &&
-              screen_y >= page->y && screen_y < page->y + page->h) {
-            page->set_pixel(page, screen_x - page->x, screen_y - page->y, pixel);
-            break;
-          }
-        }
+        display_set_pixel(disp, x + img_x, y + img_y, pixel);
       }
     }
   }
@@ -345,62 +263,11 @@ mrb_vram_draw_bytes(mrb_state* mrb, mrb_value self)
 
   if (width <= 0 || height <= 0) return self;
 
-  const uint8_t *image_data = (const uint8_t *)RSTRING_PTR(data_val);
-  mrb_int data_size = RSTRING_LEN(data_val);
-
-  for (mrb_int img_y = 0; img_y < height; img_y++) {
-    for (mrb_int img_x = 0; img_x < width; img_x++) {
-      mrb_int byte_idx = (img_y * ((width + 7) / 8)) + (img_x / 8);
-      mrb_int bit_idx = 7 - (img_x % 8);
-
-      uint8_t pixel = 0;
-      if (byte_idx < data_size) {
-        pixel = (image_data[byte_idx] >> bit_idx) & 1;
-      }
-
-      mrb_int screen_x = x + img_x;
-      mrb_int screen_y = y + img_y;
-
-      for (mrb_int i = 0; i < disp->page_count; i++) {
-        display_page_t *page = &disp->pages[i];
-        if (screen_x >= page->x && screen_x < page->x + page->w &&
-            screen_y >= page->y && screen_y < page->y + page->h) {
-          page->set_pixel(page, screen_x - page->x, screen_y - page->y, pixel);
-          break;
-        }
-      }
-    }
-  }
-
+  display_draw_bytes(disp, x, y, width, height,
+                     (const uint8_t *)RSTRING_PTR(data_val),
+                     (size_t)RSTRING_LEN(data_val));
   return self;
 }
-
-static mrb_value
-mrb_vram_erase(mrb_state* mrb, mrb_value self)
-{
-  mrb_int x, y, w, h;
-  mrb_get_args(mrb, "iiii", &x, &y, &w, &h);
-
-  display_t *disp = (display_t *)mrb_data_get_ptr(mrb, self, &mrb_vram_type);
-
-  for (mrb_int i = 0; i < h; i++) {
-    for (mrb_int j = 0; j < w; j++) {
-      mrb_int px = x + j;
-      mrb_int py = y + i;
-      for (mrb_int k = 0; k < disp->page_count; k++) {
-        display_page_t *page = &disp->pages[k];
-        if (px >= page->x && px < page->x + page->w &&
-            py >= page->y && py < page->y + page->h) {
-          page->set_pixel(page, px - page->x, py - page->y, 0);
-          break;
-        }
-      }
-    }
-  }
-
-  return self;
-}
-
 
 void
 mrb_picoruby_vram_gem_init(mrb_state* mrb)
@@ -408,7 +275,7 @@ mrb_picoruby_vram_gem_init(mrb_state* mrb)
   struct RClass *class_VRAM = mrb_define_class_id(mrb, MRB_SYM(VRAM), mrb->object_class);
   MRB_SET_INSTANCE_TT(class_VRAM, MRB_TT_CDATA);
 
-  mrb_define_class_method_id(mrb, class_VRAM, MRB_SYM(new), mrb_vram_s_new, MRB_ARGS_KEY(4, 4));
+  mrb_define_class_method_id(mrb, class_VRAM, MRB_SYM(new), mrb_vram_s_new, MRB_ARGS_KEY(4, 3));
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(pages), mrb_vram_pages, MRB_ARGS_OPT(1));
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(dirty_pages), mrb_vram_dirty_pages, MRB_ARGS_OPT(1));
   mrb_define_method_id(mrb, class_VRAM, MRB_SYM(draw_line), mrb_vram_draw_line, MRB_ARGS_REQ(5));

--- a/mrbgems/picoruby-vram/src/mrubyc/vram.c
+++ b/mrbgems/picoruby-vram/src/mrubyc/vram.c
@@ -18,55 +18,15 @@ mrbc_vram_free(mrb_value *self)
   }
 }
 
-static void
-mrubyc_mono_page_set_pixel(struct display_page *page, int x, int y, uint32_t color)
-{
-  if (x < 0 || x >= page->w || y < 0 || y >= page->h) return;
-
-  unsigned char *data = (unsigned char *)page->buffer.string->data;
-  int byte_idx = x + (y / 8) * page->w;
-  int bit_idx = y % 8;
-
-  if (byte_idx < 0 || byte_idx >= (int)page->buffer.string->size) return;
-
-  if (color) {
-    data[byte_idx] |= (1 << bit_idx);
-  } else {
-    data[byte_idx] &= ~(1 << bit_idx);
-  }
-  page->dirty = true;
-}
-
-static uint32_t
-mrubyc_mono_page_get_pixel(struct display_page *page, int x, int y)
-{
-  if (x < 0 || x >= page->w || y < 0 || y >= page->h) return 0;
-
-  unsigned char *data = (unsigned char *)page->buffer.string->data;
-  int byte_idx = x + (y / 8) * page->w;
-  int bit_idx = y % 8;
-
-  if (byte_idx < 0 || byte_idx >= (int)page->buffer.string->size) return 0;
-
-  return (data[byte_idx] >> bit_idx) & 1;
-}
-
-static void
-mrubyc_mono_page_fill(struct display_page *page, uint32_t color)
-{
-  unsigned char *data = (unsigned char *)page->buffer.string->data;
-  memset(data, color ? 0xFF : 0x00, page->buffer.string->size);
-  page->dirty = true;
-}
-
 /*
  * VRAM.new(w: 128, h: 64, cols: 1, rows: 8)
+ * VRAM.new(w: 200, h: 200, cols: 1, rows: 1, layout: :horizontal, invert: true)
  */
 static void
 c_vram_new(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  mrbc_value w_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
-  mrbc_value h_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("h")));
+  mrbc_value w_val    = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
+  mrbc_value h_val    = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("h")));
   mrbc_value cols_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("cols")));
   mrbc_value rows_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("rows")));
 
@@ -76,8 +36,21 @@ c_vram_new(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
-  int w = w_val.i;
-  int h = h_val.i;
+  /* Optional: layout (:vertical default, :horizontal for UC8151) */
+  mrbc_value layout_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("layout")));
+  bool horizontal = (mrbc_type(layout_val) == MRBC_TT_SYMBOL) &&
+                    (layout_val.i == (int32_t)mrbc_str_to_symid("horizontal"));
+
+  /* Optional: invert (false default) */
+  mrbc_value invert_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("invert")));
+  bool invert = (mrbc_type(invert_val) == MRBC_TT_TRUE);
+
+  /* Optional: rotate (0 default, clockwise degrees: 0/90/180/270) */
+  mrbc_value rotate_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("rotate")));
+  int rotate = (mrbc_type(rotate_val) == MRBC_TT_INTEGER) ? rotate_val.i : 0;
+
+  int w    = w_val.i;
+  int h    = h_val.i;
   int cols = cols_val.i;
   int rows = rows_val.i;
   int page_w = w / cols;
@@ -94,7 +67,7 @@ c_vram_new(mrbc_vm *vm, mrbc_value *v, int argc)
   disp->h = h;
   disp->page_count = rows * cols;
 
-  int page_size = page_w * ((page_h + 7) / 8);
+  size_t page_size = display_page_buffer_size(page_w, page_h, horizontal, rotate);
 
   for (int ty = 0; ty < rows; ty++) {
     for (int tx = 0; tx < cols; tx++) {
@@ -103,17 +76,18 @@ c_vram_new(mrbc_vm *vm, mrbc_value *v, int argc)
       page->y = ty * page_h;
       page->w = page_w;
       page->h = page_h;
+      page->invert = invert;
+      page->rotate = rotate;
 
-      // Create buffer string
-      page->buffer = mrbc_string_new(vm, NULL, page_size);
+      /* Create buffer string */
+      page->buffer = mrbc_string_new(vm, NULL, (int)page_size);
       memset(page->buffer.string->data, 0, page_size);
-      // TODO: memory leak of page->buffer happens
+      page->raw_data = (uint8_t *)page->buffer.string->data;
+      page->raw_size = page_size;
+      /* TODO: memory leak of page->buffer happens */
 
       page->dirty = false;
-      page->pixel_format = PIXEL_FORMAT_MONO;
-      page->set_pixel = mrubyc_mono_page_set_pixel;
-      page->get_pixel = mrubyc_mono_page_get_pixel;
-      page->fill = mrubyc_mono_page_fill;
+      display_page_init_format(page, horizontal);
       page->fill(page, 0);
     }
   }
@@ -181,22 +155,7 @@ c_vram_set_pixel(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
-
-  int x = GET_INT_ARG(1);
-  int y = GET_INT_ARG(2);
-  int color = GET_INT_ARG(3);
-
-  for (int i = 0; i < disp->page_count; i++) {
-    display_page_t *page = &disp->pages[i];
-    if (x >= page->x && x < page->x + page->w &&
-        y >= page->y && y < page->y + page->h) {
-      page->set_pixel(page, x - page->x, y - page->y, color);
-      break;
-    }
-  }
-
-  //mrbc_incref(&v[0]);
-  //SET_RETURN(v[0]);
+  display_set_pixel(disp, GET_INT_ARG(1), GET_INT_ARG(2), (uint32_t)GET_INT_ARG(3));
 }
 
 /*
@@ -207,49 +166,10 @@ c_vram_draw_line(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
-
-  int x0 = GET_INT_ARG(1);
-  int y0 = GET_INT_ARG(2);
-  int x1 = GET_INT_ARG(3);
-  int y1 = GET_INT_ARG(4);
-  int color = GET_INT_ARG(5);
-
-  // Bresenham's line algorithm
-  int dx = x1 > x0 ? x1 - x0 : x0 - x1;
-  int dy = y1 > y0 ? y1 - y0 : y0 - y1;
-  int sx = x0 < x1 ? 1 : -1;
-  int sy = y0 < y1 ? 1 : -1;
-  int err = dx - dy;
-
-  int x = x0;
-  int y = y0;
-
-  while (1) {
-    // Set pixel at current position
-    for (int i = 0; i < disp->page_count; i++) {
-      display_page_t *page = &disp->pages[i];
-      if (x >= page->x && x < page->x + page->w &&
-          y >= page->y && y < page->y + page->h) {
-        page->set_pixel(page, x - page->x, y - page->y, color);
-        break;
-      }
-    }
-
-    if (x == x1 && y == y1) break;
-
-    int e2 = 2 * err;
-    if (e2 > -dy) {
-      err -= dy;
-      x += sx;
-    }
-    if (e2 < dx) {
-      err += dx;
-      y += sy;
-    }
-  }
-
-  //mrbc_incref(&v[0]);
-  //SET_RETURN(v[0]);
+  display_draw_line(disp,
+                    GET_INT_ARG(1), GET_INT_ARG(2),
+                    GET_INT_ARG(3), GET_INT_ARG(4),
+                    (uint32_t)GET_INT_ARG(5));
 }
 
 /*
@@ -260,30 +180,10 @@ c_vram_draw_rect(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
-
-  int x = GET_INT_ARG(1);
-  int y = GET_INT_ARG(2);
-  int w = GET_INT_ARG(3);
-  int h = GET_INT_ARG(4);
-  int color = GET_INT_ARG(5);
-
-  for (int i = 0; i < h; i++) {
-    for (int j = 0; j < w; j++) {
-      int px = x + j;
-      int py = y + i;
-      for (int k = 0; k < disp->page_count; k++) {
-        display_page_t *page = &disp->pages[k];
-        if (px >= page->x && px < page->x + page->w &&
-            py >= page->y && py < page->y + page->h) {
-          page->set_pixel(page, px - page->x, py - page->y, color);
-          break;
-        }
-      }
-    }
-  }
-
-  //mrbc_incref(&v[0]);
-  //SET_RETURN(v[0]);
+  display_draw_rect(disp,
+                    GET_INT_ARG(1), GET_INT_ARG(2),
+                    GET_INT_ARG(3), GET_INT_ARG(4),
+                    (uint32_t)GET_INT_ARG(5));
 }
 
 /*
@@ -294,32 +194,21 @@ c_vram_fill(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
-
-  int color = GET_INT_ARG(1);
-  for (int i = 0; i < disp->page_count; i++) {
-    display_page_t *page = &disp->pages[i];
-    page->fill(page, color);
-  }
-
-  //mrbc_incref(&v[0]);
-  //SET_RETURN(v[0]);
+  display_fill(disp, (uint32_t)GET_INT_ARG(1));
 }
 
-/*
- * vram.draw_bitmap(x:, y:, w:, h:, data:)
- * data: Array[Integer] - each element represents a row's bit pattern
- */
+/* draw_bitmap: VM-specific because it takes an Array[Integer] */
 static void
 c_vram_draw_bitmap(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
 
-  mrbc_value x_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("x")));
-  mrbc_value y_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("y")));
-  mrbc_value width_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
+  mrbc_value x_val      = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("x")));
+  mrbc_value y_val      = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("y")));
+  mrbc_value width_val  = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
   mrbc_value height_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("h")));
-  mrbc_value data_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("data")));
+  mrbc_value data_val   = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("data")));
 
   if (mrbc_type(x_val) != MRBC_TT_INTEGER || mrbc_type(y_val) != MRBC_TT_INTEGER ||
       mrbc_type(width_val) != MRBC_TT_INTEGER || mrbc_type(height_val) != MRBC_TT_INTEGER ||
@@ -341,17 +230,7 @@ c_vram_draw_bitmap(mrbc_vm *vm, mrbc_value *v, int argc)
       uint64_t row_data = (uint64_t)row_val.i;
       for (int img_x = 0; img_x < width; img_x++) {
         uint8_t pixel = (row_data >> (width - 1 - img_x)) & 1;
-        int screen_x = x + img_x;
-        int screen_y = y + img_y;
-
-        for (int i = 0; i < disp->page_count; i++) {
-          display_page_t *page = &disp->pages[i];
-          if (screen_x >= page->x && screen_x < page->x + page->w &&
-              screen_y >= page->y && screen_y < page->y + page->h) {
-            page->set_pixel(page, screen_x - page->x, screen_y - page->y, pixel);
-            break;
-          }
-        }
+        display_set_pixel(disp, x + img_x, y + img_y, pixel);
       }
     }
   }
@@ -359,7 +238,6 @@ c_vram_draw_bitmap(mrbc_vm *vm, mrbc_value *v, int argc)
 
 /*
  * vram.draw_bytes(x:, y:, w:, h:, data:)
- * data: String - packed byte array
  */
 static void
 c_vram_draw_bytes(mrbc_vm *vm, mrbc_value *v, int argc)
@@ -367,11 +245,11 @@ c_vram_draw_bytes(mrbc_vm *vm, mrbc_value *v, int argc)
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
 
-  mrbc_value x_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("x")));
-  mrbc_value y_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("y")));
-  mrbc_value width_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
+  mrbc_value x_val      = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("x")));
+  mrbc_value y_val      = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("y")));
+  mrbc_value width_val  = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("w")));
   mrbc_value height_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("h")));
-  mrbc_value data_val = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("data")));
+  mrbc_value data_val   = mrbc_hash_get(v + 1, &mrbc_symbol_value(mrbc_str_to_symid("data")));
 
   if (mrbc_type(x_val) != MRBC_TT_INTEGER || mrbc_type(y_val) != MRBC_TT_INTEGER ||
       mrbc_type(width_val) != MRBC_TT_INTEGER || mrbc_type(height_val) != MRBC_TT_INTEGER ||
@@ -387,32 +265,9 @@ c_vram_draw_bytes(mrbc_vm *vm, mrbc_value *v, int argc)
 
   if (width <= 0 || height <= 0) return;
 
-  const uint8_t *image_data = (const uint8_t *)data_val.string->data;
-  int data_size = data_val.string->size;
-
-  for (int img_y = 0; img_y < height; img_y++) {
-    for (int img_x = 0; img_x < width; img_x++) {
-      int byte_idx = (img_y * ((width + 7) / 8)) + (img_x / 8);
-      int bit_idx = 7 - (img_x % 8);
-
-      uint8_t pixel = 0;
-      if (byte_idx < data_size) {
-        pixel = (image_data[byte_idx] >> bit_idx) & 1;
-      }
-
-      int screen_x = x + img_x;
-      int screen_y = y + img_y;
-
-      for (int i = 0; i < disp->page_count; i++) {
-        display_page_t *page = &disp->pages[i];
-        if (screen_x >= page->x && screen_x < page->x + page->w &&
-            screen_y >= page->y && screen_y < page->y + page->h) {
-          page->set_pixel(page, screen_x - page->x, screen_y - page->y, pixel);
-          break;
-        }
-      }
-    }
-  }
+  display_draw_bytes(disp, x, y, width, height,
+                     (const uint8_t *)data_val.string->data,
+                     (size_t)data_val.string->size);
 }
 
 /*
@@ -423,26 +278,7 @@ c_vram_erase(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   display_t *disp = (display_t *)v[0].instance->data;
   if (!disp) return;
-
-  int x = GET_INT_ARG(1);
-  int y = GET_INT_ARG(2);
-  int w = GET_INT_ARG(3);
-  int h = GET_INT_ARG(4);
-
-  for (int i = 0; i < h; i++) {
-    for (int j = 0; j < w; j++) {
-      int px = x + j;
-      int py = y + i;
-      for (int k = 0; k < disp->page_count; k++) {
-        display_page_t *page = &disp->pages[k];
-        if (px >= page->x && px < page->x + page->w &&
-            py >= page->y && py < page->y + page->h) {
-          page->set_pixel(page, px - page->x, py - page->y, 0);
-          break;
-        }
-      }
-    }
-  }
+  display_erase(disp, GET_INT_ARG(1), GET_INT_ARG(2), GET_INT_ARG(3), GET_INT_ARG(4));
 }
 
 void

--- a/mrbgems/picoruby-vram/src/vram.c
+++ b/mrbgems/picoruby-vram/src/vram.c
@@ -1,4 +1,248 @@
 #include "../include/vram.h"
+#include <string.h>
+
+/*
+ * Buffer size calculation.
+ * When rotate=90 or 270, the buffer stores the transposed image (buf_w=h, buf_h=w).
+ *   vertical   layout: buf_w * ceil(buf_h / 8)
+ *   horizontal layout: ceil(buf_w / 8) * buf_h
+ */
+static size_t
+display_page_buffer_size(int page_w, int page_h, bool horizontal, int rotate)
+{
+  int bw = (rotate == 90 || rotate == 270) ? page_h : page_w;
+  int bh = (rotate == 90 || rotate == 270) ? page_w : page_h;
+  if (horizontal) {
+    return (size_t)(((bw + 7) / 8) * bh);
+  } else {
+    return (size_t)(bw * ((bh + 7) / 8));
+  }
+}
+
+/*
+ * Vertical layout (SSD1306 style): 8 vertical pixels per byte, LSB = topmost pixel.
+ *   byte_idx = x + (y / 8) * page_w
+ *   bit_idx  = y % 8
+ */
+static void
+mono_page_set_pixel(struct display_page *page, int x, int y, uint32_t color)
+{
+  if (x < 0 || x >= page->buf_w || y < 0 || y >= page->buf_h) return;
+  if (page->invert) color = color ? 0 : 1;
+  int byte_idx = x + (y / 8) * page->buf_w;
+  int bit_idx = y % 8;
+  if (byte_idx < 0 || (size_t)byte_idx >= page->raw_size) return;
+  if (color) {
+    page->raw_data[byte_idx] |= (uint8_t)(1 << bit_idx);
+  } else {
+    page->raw_data[byte_idx] &= (uint8_t)~(1 << bit_idx);
+  }
+  page->dirty = true;
+}
+
+static uint32_t
+mono_page_get_pixel(struct display_page *page, int x, int y)
+{
+  if (x < 0 || x >= page->buf_w || y < 0 || y >= page->buf_h) return 0;
+  int byte_idx = x + (y / 8) * page->buf_w;
+  int bit_idx = y % 8;
+  if (byte_idx < 0 || (size_t)byte_idx >= page->raw_size) return 0;
+  uint32_t pixel = (page->raw_data[byte_idx] >> bit_idx) & 1;
+  if (page->invert) pixel = pixel ? 0 : 1;
+  return pixel;
+}
+
+static void
+mono_page_fill(struct display_page *page, uint32_t color)
+{
+  if (page->invert) color = color ? 0 : 1;
+  memset(page->raw_data, color ? 0xFF : 0x00, page->raw_size);
+  page->dirty = true;
+}
+
+/*
+ * Horizontal layout (UC8151 style): 8 horizontal pixels per byte, MSB = leftmost pixel.
+ *   byte_idx = (x / 8) + y * ((page_w + 7) / 8)
+ *   bit_idx  = 7 - (x % 8)
+ */
+static void
+mono_h_page_set_pixel(struct display_page *page, int x, int y, uint32_t color)
+{
+  if (x < 0 || x >= page->buf_w || y < 0 || y >= page->buf_h) return;
+  if (page->invert) color = color ? 0 : 1;
+  int byte_idx = (x / 8) + y * ((page->buf_w + 7) / 8);
+  int bit_idx = 7 - (x % 8);
+  if (byte_idx < 0 || (size_t)byte_idx >= page->raw_size) return;
+  if (color) {
+    page->raw_data[byte_idx] |= (uint8_t)(1 << bit_idx);
+  } else {
+    page->raw_data[byte_idx] &= (uint8_t)~(1 << bit_idx);
+  }
+  page->dirty = true;
+}
+
+static uint32_t
+mono_h_page_get_pixel(struct display_page *page, int x, int y)
+{
+  if (x < 0 || x >= page->buf_w || y < 0 || y >= page->buf_h) return 0;
+  int byte_idx = (x / 8) + y * ((page->buf_w + 7) / 8);
+  int bit_idx = 7 - (x % 8);
+  if (byte_idx < 0 || (size_t)byte_idx >= page->raw_size) return 0;
+  uint32_t pixel = (page->raw_data[byte_idx] >> bit_idx) & 1;
+  if (page->invert) pixel = pixel ? 0 : 1;
+  return pixel;
+}
+
+static void
+mono_h_page_fill(struct display_page *page, uint32_t color)
+{
+  if (page->invert) color = color ? 0 : 1;
+  memset(page->raw_data, color ? 0xFF : 0x00, page->raw_size);
+  page->dirty = true;
+}
+
+/*
+ * Select pixel format function pointers and compute buffer dimensions.
+ * Must be called after page->w, page->h, and page->rotate are set.
+ */
+static void
+display_page_init_format(display_page_t *page, bool horizontal)
+{
+  if (page->rotate == 90 || page->rotate == 270) {
+    page->buf_w = page->h;
+    page->buf_h = page->w;
+  } else {
+    page->buf_w = page->w;
+    page->buf_h = page->h;
+  }
+  if (horizontal) {
+    page->pixel_format = PIXEL_FORMAT_MONO_H;
+    page->set_pixel = mono_h_page_set_pixel;
+    page->get_pixel = mono_h_page_get_pixel;
+    page->fill = mono_h_page_fill;
+  } else {
+    page->pixel_format = PIXEL_FORMAT_MONO;
+    page->set_pixel = mono_page_set_pixel;
+    page->get_pixel = mono_page_get_pixel;
+    page->fill = mono_page_fill;
+  }
+}
+
+/* Display-level helpers: route (x,y) to the correct page */
+
+static void
+display_set_pixel(display_t *disp, int x, int y, uint32_t color)
+{
+  int i = 0;
+  while (i < disp->page_count) {
+    display_page_t *page = &disp->pages[i];
+    if (x >= page->x && x < page->x + page->w &&
+        y >= page->y && y < page->y + page->h) {
+      int lx = x - page->x;
+      int ly = y - page->y;
+      int bx, by;
+      switch (page->rotate) {
+        case 90:
+          bx = ly;
+          by = page->w - 1 - lx;
+          break;
+        case 180:
+          bx = page->w - 1 - lx;
+          by = page->h - 1 - ly;
+          break;
+        case 270:
+          bx = page->h - 1 - ly;
+          by = lx;
+          break;
+        default:
+          bx = lx;
+          by = ly;
+          break;
+      }
+      page->set_pixel(page, bx, by, color);
+      break;
+    }
+    i++;
+  }
+}
+
+static void
+display_draw_line(display_t *disp, int x0, int y0, int x1, int y1, uint32_t color)
+{
+  int dx = x1 > x0 ? x1 - x0 : x0 - x1;
+  int dy = y1 > y0 ? y1 - y0 : y0 - y1;
+  int sx = x0 < x1 ? 1 : -1;
+  int sy = y0 < y1 ? 1 : -1;
+  int err = dx - dy;
+  int x = x0;
+  int y = y0;
+  while (1) {
+    display_set_pixel(disp, x, y, color);
+    if (x == x1 && y == y1) break;
+    int e2 = 2 * err;
+    if (e2 > -dy) { err -= dy; x += sx; }
+    if (e2 < dx)  { err += dx; y += sy; }
+  }
+}
+
+static void
+display_draw_rect(display_t *disp, int x, int y, int w, int h, uint32_t color)
+{
+  int i = 0;
+  while (i < h) {
+    int j = 0;
+    while (j < w) {
+      display_set_pixel(disp, x + j, y + i, color);
+      j++;
+    }
+    i++;
+  }
+}
+
+static void
+display_fill(display_t *disp, uint32_t color)
+{
+  int i = 0;
+  while (i < disp->page_count) {
+    disp->pages[i].fill(&disp->pages[i], color);
+    i++;
+  }
+}
+
+static void
+display_erase(display_t *disp, int x, int y, int w, int h)
+{
+  int i = 0;
+  while (i < h) {
+    int j = 0;
+    while (j < w) {
+      display_set_pixel(disp, x + j, y + i, 0);
+      j++;
+    }
+    i++;
+  }
+}
+
+static void
+display_draw_bytes(display_t *disp, int x, int y, int w, int h,
+                   const uint8_t *data, size_t data_size)
+{
+  int img_y = 0;
+  while (img_y < h) {
+    int img_x = 0;
+    while (img_x < w) {
+      int byte_idx = (img_y * ((w + 7) / 8)) + (img_x / 8);
+      int bit_idx = 7 - (img_x % 8);
+      uint8_t pixel = 0;
+      if ((size_t)byte_idx < data_size) {
+        pixel = (data[byte_idx] >> bit_idx) & 1;
+      }
+      display_set_pixel(disp, x + img_x, y + img_y, pixel);
+      img_x++;
+    }
+    img_y++;
+  }
+}
 
 #if defined(PICORB_VM_MRUBY)
 


### PR DESCRIPTION
This pull request introduces a new UC8151 e-ink display driver gem (`picoruby-uc8151`) and enhances the Terminus font rendering system to support scalable bitmap fonts, including both Ruby and C-level changes. The update also improves the VRAM interface for more flexible display layouts and adds an example for the new display driver. The most important changes are summarized below:

---

**New UC8151 e-ink display support:**

* Added the `picoruby-uc8151` gem, including its gemspec, Ruby driver (`uc8151.rb`), type signature (`uc8151.rbs`), and an example script (`badger.rb`). The driver supports drawing primitives, scalable text (Terminus and Shinonome fonts), and efficient display updates for the UC8151 e-ink panel. [[1]](diffhunk://#diff-5b5636699b141a107a9c4413f31a777a71573d19d3ab39a4b35e1c32967cf089R1-R10) [[2]](diffhunk://#diff-237ae4153b5087e14b36f3c40c6e21a6f54c4c5cad640c8b8ead575154568f6fR1-R247) [[3]](diffhunk://#diff-3b7dd9ab23ea5882366849837996e8ec557401deeb603cd3941909325fc48357R1-R34) [[4]](diffhunk://#diff-13d5e4a5453dea8dfa049e2fc508efe3fda6c57fbc43c6869d88c0b1e690fc8dR1-R19)

**Font rendering and scaling improvements:**

* Enhanced the Terminus font system to support scaling (1x–4x) for all font sizes via both Ruby and C APIs. This includes changes to function signatures, argument parsing, and bit manipulation routines for scalable glyph rendering. [[1]](diffhunk://#diff-01b788ce0179189ede80ac0529c760ee862c4168b787a2c9da30329880be89e1L4-R7) [[2]](diffhunk://#diff-3e919885a874bed309116d8789d2d5bf143c467bfcb9ad8a83c3e8b380103af0L14-R22) [[3]](diffhunk://#diff-3e919885a874bed309116d8789d2d5bf143c467bfcb9ad8a83c3e8b380103af0L23-R81) [[4]](diffhunk://#diff-3e919885a874bed309116d8789d2d5bf143c467bfcb9ad8a83c3e8b380103af0L69-R120) [[5]](diffhunk://#diff-8f5c4d685f97fde8cafad28ae1ad715c05817d25fba9954acba5fe3338e0c5a7R7-R18) [[6]](diffhunk://#diff-8f5c4d685f97fde8cafad28ae1ad715c05817d25fba9954acba5fe3338e0c5a7L20-R84) [[7]](diffhunk://#diff-7c291a2193dc1f501f678ef76db030a0661048b97f54423257d5949190bd6ef5R10-R54) [[8]](diffhunk://#diff-09294635eb4a78915b640ed7e5525205b2dae785132f9874388f12f69900dc3cL2-R7)
* Updated the SSD1306 driver to pass the scale parameter through to Terminus rendering, and updated type signatures accordingly. [[1]](diffhunk://#diff-a78efa3471932047be03a803e33c312ae10b1e9d4cd989cd090d3e02407a9d81L126-R138) [[2]](diffhunk://#diff-a263c34acf36f2dfe7461105436028e2b52dddfd4d6d2a2a0d477be90bff1792L41-R41)

**VRAM and display abstraction enhancements:**

* Extended the VRAM interface to support horizontal 1bpp layouts (needed for UC8151), buffer inversion, and flexible rotation, enabling compatibility with a wider range of display hardware.

---

These changes collectively enable scalable, high-quality text rendering on both OLED and e-ink displays, and introduce a new, fully-featured e-ink display driver for the PicoRuby ecosystem.