### PR TITLE
VRAM::Delegatable, Terminus::Drawable and Shinonome::Drawable

### DIFF
--- a/mrbgems/picoruby-shinonome/mrblib/shinonome.rb
+++ b/mrbgems/picoruby-shinonome/mrblib/shinonome.rb
@@ -6,4 +6,36 @@ module Shinonome
       send(name, line.chomp, scale)
     end
   end
+
+  module Drawable
+    def draw_shinonome(name, x, y, text, scale = 1)
+      # Call C method directly to avoid send -> mrb_funcall -> mrb_vm_exec recursion
+      result = case name
+               when "test12" then Shinonome.test12(text, scale)
+               when "test16" then Shinonome.test16(text, scale)
+               when "maru12" then Shinonome.maru12(text, scale)
+               when "go12"   then Shinonome.go12(text, scale)
+               when "min12"  then Shinonome.min12(text, scale)
+               when "go16"   then Shinonome.go16(text, scale)
+               when "min16"  then Shinonome.min16(text, scale)
+               else raise "Unsupported shinonome font: #{name}"
+               end
+      if result.nil?
+        return # maybe test12 or test16
+      end
+      height = result[0]
+      widths = result[2]
+      glyphs = result[3]
+      glyph_x = x
+      i = 0
+      while i < widths.size
+        char_width = widths[i]
+        char_data = glyphs[i]
+        draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
+        glyph_x += char_width
+        i += 1
+      end
+      nil
+    end
+  end
 end

--- a/mrbgems/picoruby-shinonome/sig/shinonome.rbs
+++ b/mrbgems/picoruby-shinonome/sig/shinonome.rbs
@@ -11,4 +11,9 @@ module Shinonome
 
   def self.draw: (Symbol | String name, String line, Integer scale) { (shinonome_t) -> void } -> void
                | (Symbol | String name, String line, Integer scale) -> shinonome_t
+
+  module Drawable
+    def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
+    def draw_shinonome: (String size, Integer x, Integer y, String text, ?Integer scale) -> nil
+  end
 end

--- a/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
+++ b/mrbgems/picoruby-ssd1306/mrblib/ssd1306.rb
@@ -1,8 +1,21 @@
 require "i2c"
 require "vram"
 require "terminus"
+begin
+  require "shinonome"
+rescue LoadError
+end
 
 class SSD1306
+  include VRAM::Delegatable
+  include Terminus::Drawable
+  if Object.const_defined?(:Shinonome)
+    include Shinonome::Drawable
+  else
+    def draw_shinonome(name, x, y, text, scale = 1)
+      puts "Shinonome gem not available, skip text rendering"
+    end
+  end
   DISPLAYOFF = 0xAE
   DISPLAYON = 0xAF
   SETCONTRAST = 0x81
@@ -84,39 +97,6 @@ class SSD1306
     update_display
   end
 
-  def set_pixel(x, y, color = 1)
-    return if x < 0 || x >= @width || y < 0 || y >= @height
-    @vram.set_pixel(x, y, color)
-  end
-
-  def draw_line(x0, y0, x1, y1, color = 1)
-    @vram.draw_line(x0, y0, x1, y1, color)
-    nil
-  end
-
-  def draw_rect(x, y, w, h, color = 1, fill = false)
-    if fill
-      @vram.draw_rect(x, y, w, h, color)
-    else
-      # Draw outline using lines
-      draw_line(x, y, x + w - 1, y, color)                   # Top
-      draw_line(x, y + h - 1, x + w - 1, y + h - 1, color)   # Bottom
-      draw_line(x, y, x, y + h - 1, color)                   # Left
-      draw_line(x + w - 1, y, x + w - 1, y + h - 1, color)   # Right
-    end
-    nil
-  end
-
-  def draw_bitmap(x:, y:, w:, h:, data:)
-    @vram.draw_bitmap(x: x, y: y, w: w, h: h, data: data)
-    nil
-  end
-
-  def draw_bytes(x:, y:, w:, h:, data:)
-    @vram.draw_bytes(x: x, y: y, w: w, h: h, data: data)
-    nil
-  end
-
   def draw_text(fontname, x, y, text, scale = 1)
     font, name = fontname.to_s.split("_")
     case font
@@ -126,68 +106,6 @@ class SSD1306
       draw_terminus(name.to_s, x, y, text, scale)
     else
       raise "Unsupported font: #{font}"
-    end
-  end
-
-  def draw_terminus(name, x, y, text, scale = 1)
-    # Call C method directly to avoid send -> mrb_funcall -> mrb_vm_exec recursion
-    result = case name
-             when "6x12"  then Terminus._6x12(text, scale)
-             when "8x16"  then Terminus._8x16(text, scale)
-             when "12x24" then Terminus._12x24(text, scale)
-             when "16x32" then Terminus._16x32(text, scale)
-             else raise "Unsupported terminus font: #{name}"
-             end
-    height = result[0]
-    widths = result[2]
-    glyphs = result[3]
-    glyph_x = x
-    i = 0
-    while i < widths.size
-      char_width = widths[i]
-      char_data = glyphs[i]
-      draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
-      glyph_x += char_width
-      i += 1
-    end
-    nil
-  end
-
-  begin
-    require "shinonome"
-    shinonome_available = true
-    def draw_shinonome(name, x, y, text, scale = 1)
-      # Call C method directly to avoid send -> mrb_funcall -> mrb_vm_exec recursion
-      result = case name
-               when "test12" then Shinonome.test12(text, scale)
-               when "test16" then Shinonome.test16(text, scale)
-               when "maru12" then Shinonome.maru12(text, scale)
-               when "go12"   then Shinonome.go12(text, scale)
-               when "min12"  then Shinonome.min12(text, scale)
-               when "go16"   then Shinonome.go16(text, scale)
-               when "min16"  then Shinonome.min16(text, scale)
-               else raise "Unsupported shinonome font: #{name}"
-               end
-      if result.nil?
-        return # maybe test12 or test16
-      end
-      height = result[0]
-      widths = result[2]
-      glyphs = result[3]
-      glyph_x = x
-      i = 0
-      while i < widths.size
-        char_width = widths[i]
-        char_data = glyphs[i]
-        draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
-        glyph_x += char_width
-        i += 1
-      end
-      nil
-    end
-  rescue LoadError
-    def draw_shinonome(fontname, x, y, text, scale = 1)
-      puts "Shinonome gem not available, skip text rendering"
     end
   end
 

--- a/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
+++ b/mrbgems/picoruby-ssd1306/sig/ssd1306.rbs
@@ -31,14 +31,10 @@ class SSD1306
   def clear: () -> Integer
   def erase: (Integer x, Integer y, Integer w, Integer h) -> nil
   def fill_screen: (?Integer pattern) -> Integer
-  def set_pixel: (Integer x, Integer y, ?Integer color) -> void
-  def draw_line: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color) -> nil
-  def draw_rect: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color, ?bool fill) -> nil
-  def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
-  def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> nil
+  include VRAM::Delegatable
+  include Terminus::Drawable
+  include Shinonome::Drawable
   def draw_text: (Symbol | String fontname, Integer x, Integer y, String text, ?Integer scale) -> nil
-  def draw_shinonome: (String size, Integer x, Integer y, String text, ?Integer scale) -> nil
-  def draw_terminus: (String size, Integer x, Integer y, String text, ?Integer scale) -> nil
   def update_display: () -> Integer
   def update_display_optimized: () -> Integer # Returns number of pages updated
 end

--- a/mrbgems/picoruby-terminus/mrblib/terminus.rb
+++ b/mrbgems/picoruby-terminus/mrblib/terminus.rb
@@ -7,5 +7,30 @@ module Terminus
       send(name, line.chomp, scale)
     end
   end
+
+  module Drawable
+    def draw_terminus(name, x, y, text, scale = 1)
+      result = case name
+               when "6x12"  then Terminus._6x12(text, scale)
+               when "8x16"  then Terminus._8x16(text, scale)
+               when "12x24" then Terminus._12x24(text, scale)
+               when "16x32" then Terminus._16x32(text, scale)
+               else raise "Unsupported terminus font: #{name}"
+               end
+      height = result[0]
+      widths = result[2]
+      glyphs = result[3]
+      glyph_x = x
+      i = 0
+      while i < widths.size
+        char_width = widths[i]
+        char_data = glyphs[i]
+        draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
+        glyph_x += char_width
+        i += 1
+      end
+      nil
+    end
+  end
 end
 

--- a/mrbgems/picoruby-terminus/sig/terminus.rbs
+++ b/mrbgems/picoruby-terminus/sig/terminus.rbs
@@ -8,4 +8,9 @@ module Terminus
 
   def self.draw: (String name, String line, ?Integer scale) { (terminus_t) -> void } -> void
                | (String name, String line, ?Integer scale) -> terminus_t
+
+  module Drawable
+    def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
+    def draw_terminus: (String name, Integer x, Integer y, String text, ?Integer scale) -> nil
+  end
 end

--- a/mrbgems/picoruby-uc8151/mrblib/uc8151.rb
+++ b/mrbgems/picoruby-uc8151/mrblib/uc8151.rb
@@ -2,10 +2,21 @@ require "spi"
 require "gpio"
 require "vram"
 require "terminus"
+begin
+  require "shinonome"
+rescue LoadError
+end
 
 class UC8151
-  WIDTH  = 296
-  HEIGHT = 128
+  include VRAM::Delegatable
+  include Terminus::Drawable
+  if Object.const_defined?(:Shinonome)
+    include Shinonome::Drawable
+  else
+    def draw_shinonome(name, x, y, text, scale = 1)
+      puts "Shinonome gem not available, skip text rendering"
+    end
+  end
 
   # UC8151 command registers
   PSR  = 0x00  # Panel Setting
@@ -24,19 +35,20 @@ class UC8151
   TCON = 0x60  # Gate/Source Non-overlap Period
   TRES = 0x61  # Resolution Setting
 
-  FRAME_SIZE = WIDTH * HEIGHT / 8  # 4736 bytes
-
-  def initialize(spi:, cs_pin:, dc_pin:, rst_pin:, busy_pin:)
+  def initialize(spi:, cs_pin:, dc_pin:, rst_pin:, busy_pin:, w: 296, h: 128)
     @spi  = spi
     @cs   = GPIO.new(cs_pin,   GPIO::OUT)
     @cs.write(1)
     @dc   = GPIO.new(dc_pin,   GPIO::OUT)
     @rst  = GPIO.new(rst_pin,  GPIO::OUT)
     @busy = GPIO.new(busy_pin, GPIO::IN)
+    @width  = w
+    @height = h
+    @frame_size = @width * @height / 8
     # rotate: 90 maps landscape (x=0..295, y=0..127) to the column-major
     # buffer format the UC8151 expects: (buf_x=y, buf_y=295-x).
     # invert: true because bit=1 means white (paper) in KW mode.
-    @vram = VRAM.new(w: WIDTH, h: HEIGHT, cols: 1, rows: 1,
+    @vram = VRAM.new(w: @width, h: @height, cols: 1, rows: 1,
                      layout: :horizontal, invert: true, rotate: 90)
     @vram.name = "UC8151"
     reset
@@ -88,7 +100,7 @@ class UC8151
     i = 0
     while i < data.size
       chunk_size = (data.size - i) < 1024 ? (data.size - i) : 1024
-      @spi.write(data[i, chunk_size])
+      @spi.write(data[i, chunk_size]) # steep:ignore
       i += 1024
     end
     @cs.write(1)
@@ -119,9 +131,9 @@ class UC8151
   # Reset the panel memory before first use to avoid ghost images.
   private def deep_clean
     command(DTM1)
-    send_data_chunked("\x00" * FRAME_SIZE)
+    send_data_chunked("\x00" * @frame_size)
     command(DTM2)
-    send_data_chunked("\xFF" * FRAME_SIZE)
+    send_data_chunked("\xFF" * @frame_size)
     command(DRF)
     busy_wait
   end
@@ -131,7 +143,7 @@ class UC8151
     pages = @vram.pages
     # DTM1 carries the previous frame (all-white = no ghost)
     command(DTM1)
-    send_data_chunked("\xFF" * FRAME_SIZE)
+    send_data_chunked("\xFF" * @frame_size)
     # DTM2 carries the new frame
     command(DTM2)
     send_data_chunked(pages[0][2])
@@ -144,38 +156,6 @@ class UC8151
     @vram.fill(color)
   end
 
-  def set_pixel(x, y, color = 1)
-    return if x < 0 || WIDTH <= x
-    return if y < 0 || HEIGHT <= y
-    @vram.set_pixel(x, y, color)
-  end
-
-  def draw_line(x0, y0, x1, y1, color = 1)
-    @vram.draw_line(x0, y0, x1, y1, color)
-  end
-
-  def draw_rect(x, y, w, h, color = 1, fill = false)
-    if fill
-      @vram.draw_rect(x, y, w, h, color)
-    else
-      draw_line(x,         y,         x + w - 1, y,         color)
-      draw_line(x,         y + h - 1, x + w - 1, y + h - 1, color)
-      draw_line(x,         y,         x,         y + h - 1, color)
-      draw_line(x + w - 1, y,         x + w - 1, y + h - 1, color)
-    end
-    nil
-  end
-
-  def draw_bitmap(x:, y:, w:, h:, data:)
-    @vram.draw_bitmap(x: x, y: y, w: w, h: h, data: data)
-    nil
-  end
-
-  def draw_bytes(x:, y:, w:, h:, data:)
-    @vram.draw_bytes(x: x, y: y, w: w, h: h, data: data)
-    nil
-  end
-
   def draw_text(fontname, x, y, text, scale = 1)
     font, name = fontname.to_s.split("_")
     case font
@@ -185,63 +165,6 @@ class UC8151
       draw_shinonome(name.to_s, x, y, text, scale)
     else
       raise "Unsupported font: #{font}"
-    end
-  end
-
-  def draw_terminus(name, x, y, text, scale = 1)
-    result = case name
-             when "6x12"  then Terminus._6x12(text, scale)
-             when "8x16"  then Terminus._8x16(text, scale)
-             when "12x24" then Terminus._12x24(text, scale)
-             when "16x32" then Terminus._16x32(text, scale)
-             else raise "Unsupported terminus font: #{name}"
-             end
-    height = result[0]
-    widths = result[2]
-    glyphs = result[3]
-    glyph_x = x
-    i = 0
-    while i < widths.size
-      char_width = widths[i]
-      char_data = glyphs[i]
-      draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
-      glyph_x += char_width
-      i += 1
-    end
-    nil
-  end
-
-  begin
-    require "shinonome"
-    def draw_shinonome(name, x, y, text, scale = 1)
-      result = case name
-               when "test12" then Shinonome.test12(text, scale)
-               when "test16" then Shinonome.test16(text, scale)
-               when "maru12" then Shinonome.maru12(text, scale)
-               when "go12"   then Shinonome.go12(text, scale)
-               when "min12"  then Shinonome.min12(text, scale)
-               when "go16"   then Shinonome.go16(text, scale)
-               when "min16"  then Shinonome.min16(text, scale)
-               else raise "Unsupported shinonome font: #{name}"
-               end
-      return if result.nil?
-      height = result[0]
-      widths = result[2]
-      glyphs = result[3]
-      glyph_x = x
-      i = 0
-      while i < widths.size
-        char_width = widths[i]
-        char_data = glyphs[i]
-        draw_bitmap(x: glyph_x, y: y, w: char_width, h: height, data: char_data)
-        glyph_x += char_width
-        i += 1
-      end
-      nil
-    end
-  rescue LoadError
-    def draw_shinonome(name, x, y, text, scale = 1)
-      puts "Shinonome gem not available, skip text rendering"
     end
   end
 end

--- a/mrbgems/picoruby-uc8151/sig/uc8151.rbs
+++ b/mrbgems/picoruby-uc8151/sig/uc8151.rbs
@@ -1,8 +1,4 @@
 class UC8151
-  WIDTH: 296
-  HEIGHT: 128
-  FRAME_SIZE: Integer
-
   PSR:  Integer
   PWR:  Integer
   POF:  Integer
@@ -19,19 +15,22 @@ class UC8151
   TCON: Integer
   TRES: Integer
 
+  @spi: SPI
+  @width: Integer
+  @height: Integer
+  @frame_size: Integer
+  @vram: VRAM
+
   def initialize: (spi: SPI, cs_pin: Integer, dc_pin: Integer,
-                   rst_pin: Integer, busy_pin: Integer) -> void
+                   rst_pin: Integer, busy_pin: Integer,
+                   ?w: Integer, ?h: Integer) -> void
 
   def update: () -> void
   def fill: (?Integer color) -> void
-  def set_pixel: (Integer x, Integer y, ?Integer color) -> void
-  def draw_line: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color) -> void
-  def draw_rect: (Integer x, Integer y, Integer w, Integer h, ?Integer color, ?bool fill) -> nil
-  def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
-  def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> nil
+  include VRAM::Delegatable
+  include Terminus::Drawable
+  include Shinonome::Drawable
   def draw_text: (String fontname, Integer x, Integer y, String text, ?Integer scale) -> void
-  def draw_terminus: (String name, Integer x, Integer y, String text, ?Integer scale) -> nil
-  def draw_shinonome: (String name, Integer x, Integer y, String text, ?Integer scale) -> nil
   private def reset: () -> void
   private def busy_wait: () -> void
   private def command: (Integer cmd) -> void

--- a/mrbgems/picoruby-vram/mrblib/vram.rb
+++ b/mrbgems/picoruby-vram/mrblib/vram.rb
@@ -1,3 +1,37 @@
 class VRAM
   attr_accessor :name
 end
+
+module VRAM::Delegatable
+  def set_pixel(x, y, color = 1)
+    return if x < 0 || x >= @width || y < 0 || y >= @height
+    @vram.set_pixel(x, y, color)
+  end
+
+  def draw_bitmap(x:, y:, w:, h:, data:)
+    @vram.draw_bitmap(x: x, y: y, w: w, h: h, data: data)
+    nil
+  end
+
+  def draw_bytes(x:, y:, w:, h:, data:)
+    @vram.draw_bytes(x: x, y: y, w: w, h: h, data: data)
+    nil
+  end
+
+  def draw_line(x0, y0, x1, y1, color = 1)
+    @vram.draw_line(x0, y0, x1, y1, color)
+    nil
+  end
+
+  def draw_rect(x, y, w, h, color = 1, fill = false)
+    if fill
+      @vram.draw_rect(x, y, w, h, color)
+    else
+      draw_line(x,         y,         x + w - 1, y,         color)
+      draw_line(x,         y + h - 1, x + w - 1, y + h - 1, color)
+      draw_line(x,         y,         x,         y + h - 1, color)
+      draw_line(x + w - 1, y,         x + w - 1, y + h - 1, color)
+    end
+    nil
+  end
+end

--- a/mrbgems/picoruby-vram/sig/vram.rbs
+++ b/mrbgems/picoruby-vram/sig/vram.rbs
@@ -14,4 +14,15 @@ class VRAM
   def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> self
   def fill: (Integer color) -> self
   def erase: (Integer x, Integer y, Integer w, Integer h) -> self
+
+  module Delegatable
+    @width: Integer
+    @height: Integer
+    @vram: VRAM
+    def set_pixel: (Integer x, Integer y, ?Integer color) -> void
+    def draw_bitmap: (x: Integer, y: Integer, w: Integer, h: Integer, data: Array[Integer]) -> nil
+    def draw_bytes: (x: Integer, y: Integer, w: Integer, h: Integer, data: String) -> nil
+    def draw_line: (Integer x0, Integer y0, Integer x1, Integer y1, ?Integer color) -> nil
+    def draw_rect: (Integer x, Integer y, Integer w, Integer h, ?Integer color, ?bool fill) -> nil
+  end
 end


### PR DESCRIPTION
This patch moves some duplicated methods to dedicated modules:
- VRAM::Delegatable ... methods like `draw_bitmap`
- Terminus::Drawable ... draw_terminus
- Shinonome::Drawable ... draw_shononome

UC8151 and SSD1306 use these modules