### PR TITLE
Respect negotiated ATT MTU in BLE::UART chunking

### DIFF
--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -36,7 +36,7 @@ class BLE
     ATT_EVENT_MTU_EXCHANGE_COMPLETE = 0xB5
     ATT_EVENT_CAN_SEND_NOW = 0xB7
 
-    NOTIFY_MTU = 20
+    DEFAULT_ATT_MTU = 23 # BLE 4.0 minimum; payload = MTU - 3 for notifications
 
     def initialize(role: :peripheral,
                    name: "RubyUART",
@@ -49,6 +49,7 @@ class BLE
       @rx_buffer = ""
       @tx_buffer = ""
       @connected = false
+      @notify_chunk_size = DEFAULT_ATT_MTU - 3
 
       if role == :peripheral
         adv_data = AdvertisingData.build do |a|
@@ -223,7 +224,9 @@ class BLE
         _start_advertise
       when ATT_EVENT_MTU_EXCHANGE_COMPLETE
         @connected = true
-        debug_puts "Connected (MTU exchange complete)"
+        mtu = Utils.little_endian_to_int16(event_packet.byteslice(4, 2))
+        @notify_chunk_size = mtu - 3 if mtu && mtu >= DEFAULT_ATT_MTU
+        debug_puts "Connected (MTU=#{mtu}, chunk=#{@notify_chunk_size})"
       when ATT_EVENT_CAN_SEND_NOW
         _flush_tx
       end
@@ -250,9 +253,9 @@ class BLE
 
     def _flush_tx
       return if @tx_buffer.empty?
-      chunk = @tx_buffer.byteslice(0, NOTIFY_MTU) || ""
+      chunk = @tx_buffer.byteslice(0, @notify_chunk_size) || ""
       unless chunk.empty?
-        @tx_buffer = @tx_buffer.byteslice(NOTIFY_MTU..-1) || ""
+        @tx_buffer = @tx_buffer.byteslice(@notify_chunk_size..-1) || ""
         push_read_value(@tx_handle, chunk)
         notify(@tx_handle)
         _request_send
@@ -392,9 +395,9 @@ class BLE
       rx_handle = @peer_rx_handle
       return unless rx_handle
       while !@tx_buffer.empty?
-        chunk = @tx_buffer.byteslice(0, NOTIFY_MTU) || ""
+        chunk = @tx_buffer.byteslice(0, @notify_chunk_size) || ""
         break if chunk.empty?
-        @tx_buffer = @tx_buffer.byteslice(NOTIFY_MTU..-1) || ""
+        @tx_buffer = @tx_buffer.byteslice(@notify_chunk_size..-1) || ""
         write_value_of_characteristic_without_response(@conn_handle, rx_handle, chunk)
       end
     end

--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -220,6 +220,7 @@ class BLE
         @connected = false
         @notification_enabled = false
         @advertising_started = false
+        @notify_chunk_size = DEFAULT_ATT_MTU - 3
         debug_puts "Disconnected, re-advertising"
         _start_advertise
       when ATT_EVENT_MTU_EXCHANGE_COMPLETE

--- a/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
@@ -25,7 +25,7 @@ class BLE
     ATT_EVENT_MTU_EXCHANGE_COMPLETE: Integer
     ATT_EVENT_CAN_SEND_NOW: Integer
 
-    NOTIFY_MTU: Integer
+    DEFAULT_ATT_MTU: Integer
 
     # peripheral-only state
     @adv_data: String
@@ -50,6 +50,7 @@ class BLE
     @rx_buffer: String
     @tx_buffer: String
     @connected: bool
+    @notify_chunk_size: Integer
     @user_block: (^() -> void | nil)
 
     def initialize: (


### PR DESCRIPTION
NOTIFY_MTU was hardcoded to 20, splitting notifications into BLE 4.0 minimum-sized chunks even after a larger MTU was negotiated. Read the MTU from ATT_EVENT_MTU_EXCHANGE_COMPLETE and chunk with `mtu - 3`, falling back to 20 when no exchange happened.

Verified on Raspberry Pi Pico 2 W + Chrome (Web Bluetooth):
  `Connected (MTU=255, chunk=252)`