### PR TITLE
Fix a host build failure on macOS caused by unsupported linker flags.

### DIFF
--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -167,7 +167,7 @@ module MRuby
         cc.flags << "-fomit-frame-pointer"
         # cc.flags << "-flto" # Build fails with -flto
         unless cc.command == "clang" || cc.command == "emcc"
-          cc.flags << "-s" unless RUBY_PLATFORM.include?("darwin")
+          linker.flags << "-s" unless RUBY_PLATFORM.include?("darwin")
           linker.flags << (RUBY_PLATFORM.include?("darwin") ? "-Wl,-dead_strip" : "-Wl,--gc-sections")
         end
       end

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -167,8 +167,9 @@ module MRuby
         cc.flags << "-fomit-frame-pointer"
         # cc.flags << "-flto" # Build fails with -flto
         unless cc.command == "clang" || cc.command == "emcc"
-          cc.flags << "-s"
-          linker.flags << "-Wl,--gc-sections"
+          cc.flags << "-s" unless RUBY_PLATFORM.include?("darwin")
+          linker.flags << "-Wl"
+          linker.flags << (RUBY_PLATFORM.include?("darwin") ? "-dead_strip" : "--gc-sections")
         end
       end
     end

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -168,8 +168,7 @@ module MRuby
         # cc.flags << "-flto" # Build fails with -flto
         unless cc.command == "clang" || cc.command == "emcc"
           cc.flags << "-s" unless RUBY_PLATFORM.include?("darwin")
-          linker.flags << "-Wl"
-          linker.flags << (RUBY_PLATFORM.include?("darwin") ? "-dead_strip" : "--gc-sections")
+          linker.flags << (RUBY_PLATFORM.include?("darwin") ? "-Wl,-dead_strip" : "-Wl,--gc-sections")
         end
       end
     end


### PR DESCRIPTION
## Summary

Fix a host build failure on macOS caused by unsupported linker flags.

## Problem

Running `rake` on macOS fails with the following error:

```
❯ rake
CPP   src/version.c -> build/host/src/version.pi
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CPP   src/version.c -> build/host/mrbc/src/version.pi
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
GEN   build/host/mrbc/include/mruby/presym/id.h 
GEN   build/host/mrbc/include/mruby/presym/table.h 
GEN   build/host/mrbc/presym 
CC    mrbgems/mruby-bin-mrbc2/tools/mrbc/mrbc.c -> build/host/mrbc/mrbgems/mruby-bin-mrbc2/tools/mrbc/mrbc.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/ccontext.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/ccontext.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/cdump.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/cdump.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/codedump.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/codedump.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/codegen.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/codegen.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/compile.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/compile.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/debug.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/debug.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/diagnostic.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/diagnostic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/dump.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/dump.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/irep.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/irep.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/mrc_presym.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/mrc_presym.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/parser_util.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/parser_util.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/src/pool.c -> build/host/mrbc/mrbgems/mruby-compiler2/src/pool.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/diagnostic.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/diagnostic.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/encoding.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/encoding.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/node.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/node.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/options.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/options.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/pack.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pack.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/prettyprint.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/prettyprint.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/prism.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/prism.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/regexp.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/regexp.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/serialize.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/serialize.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/static_literals.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/static_literals.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/token_type.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/token_type.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_buffer.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_buffer.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_char.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_char.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_constant_pool.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_constant_pool.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_integer.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_integer.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_list.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_list.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_memchr.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_memchr.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_newline_list.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_newline_list.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_string.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_string.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_strncasecmp.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_strncasecmp.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
CC    mrbgems/mruby-compiler2/lib/prism/src/util/pm_strpbrk.c -> build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_strpbrk.o
clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
LD    build/host/mrbc/bin/picorbc 
ld: unknown options: --gc-sections 
clang: error: linker command failed with exit code 1 (use -v to see invocation)
rake aborted!
Command failed with status (1): [gcc -L/opt/homebrew/lib -Wl,--gc-sections -o "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/bin/picorbc" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-bin-mrbc2/tools/mrbc/mrbc.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/ccontext.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/cdump.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/codedump.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/codegen.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/compile.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/debug.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/diagnostic.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/dump.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/irep.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/mrc_presym.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/parser_util.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/src/pool.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/diagnostic.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/encoding.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/node.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/options.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pack.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/prettyprint.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/prism.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/regexp.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/serialize.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/static_literals.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/token_type.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_buffer.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_char.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_constant_pool.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_integer.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_list.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_memchr.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_newline_list.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_string.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_strncasecmp.o" "/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/mrbgems/mruby-compiler2/lib/pm_strpbrk.o"  -lm -lssl -lcrypto ]
/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/lib/mruby/build/command.rb:33:in 'MRuby::Command#_run'
/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/lib/mruby/build/command.rb:223:in 'MRuby::Command::Linker#run'
/Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/mrbgems/mruby-bin-mrbc2/mrbgem.rake:19:in 'block (2 levels) in <top (required)>'
Tasks: TOP => default => all => gensym => /Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/presym => /Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrblib/mrblib.pi => /Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrblib/mrblib.c => /Users/yuhei/Desktop/R2P2-ESP32/components/picoruby-esp32/picoruby/build/host/mrbc/bin/picorbc
(See full trace by running task with --trace)
```

The `debug_flag` method in `lib/picoruby/build.rb` unconditionally
passed `-s` (strip) and `-Wl,--gc-sections` to the compiler and linker
when `cc.command` is not `"clang"` or `"emcc"`. On macOS, `cc.command`
resolves to `"gcc"` (an alias for Apple clang), so this guard did not
exclude the macOS case. Since `-s` and `--gc-sections` are GNU
toolchain options not supported by Apple's linker, the build failed.

**Environment where the breakage was observed:**

- macOS 26.3.1 (Darwin 25.3.0)
- Apple clang 17.0.0 (clang-1700.6.4.2)
- ld-1230.1 (Command Line Tools 26.3.0.0.1)

## Fix

Inside the existing `unless cc.command == "clang" || cc.command == "emcc"` guard,
add a `RUBY_PLATFORM.include?("darwin")` check to apply platform-appropriate flags:

- **macOS**: skip `-s`; use `-Wl` + `-dead_strip` (Apple linker equivalent of `--gc-sections`)
- **Linux / other**: keep the original `-s` and `-Wl` + `--gc-sections`

```diff
 unless cc.command == "clang" || cc.command == "emcc"
-  cc.flags << "-s"
-  linker.flags << "-Wl,--gc-sections"
+  cc.flags << "-s" unless RUBY_PLATFORM.include?("darwin")
+  linker.flags << "-Wl"
+  linker.flags << (RUBY_PLATFORM.include?("darwin") ? "-dead_strip" : "--gc-sections")
 end
```
