### PR TITLE
Let the user block run at a finer cadence than BLE polling

### DIFF
--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -38,6 +38,8 @@ class BLE
 
     DEFAULT_ATT_MTU = 23 # BLE 4.0 minimum; payload = MTU - 3 for notifications
 
+    USER_BLOCK_CALL_COUNT_PER_POLL = 5
+
     def initialize(role: :peripheral,
                    name: "RubyUART",
                    service_uuid: NUS_SERVICE_UUID,
@@ -124,8 +126,13 @@ class BLE
         else
           _flush_tx_central if @connected
         end
-        @user_block&.call
-        sleep_ms POLLING_UNIT_MS
+        sub_sleep_ms = POLLING_UNIT_MS / USER_BLOCK_CALL_COUNT_PER_POLL
+        i = 0
+        while i < USER_BLOCK_CALL_COUNT_PER_POLL do
+          i += 1
+          @user_block&.call
+          sleep_ms sub_sleep_ms
+        end
         total_timeout_ms += POLLING_UNIT_MS
       end
       return total_timeout_ms

--- a/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
@@ -27,6 +27,8 @@ class BLE
 
     DEFAULT_ATT_MTU: Integer
 
+    USER_BLOCK_CALL_COUNT_PER_POLL: Integer
+
     # peripheral-only state
     @adv_data: String
     @rx_handle: Integer


### PR DESCRIPTION
`BLE::UART#start` previously invoked the user block once per `POLLING_UNIT_MS` (100ms) tick, capping its cadence at 10Hz. Workloads wanting the block to run at a shorter, steady interval had no way to do so from inside the block.

Subdivide each polling cycle into `USER_BLOCK_CALL_COUNT_PER_POLL` (=5) sub-intervals, calling the user block between each. Packet handling still runs at `POLLING_UNIT_MS`; only the idle sleep is split, so the user block now fires every ~20ms at an even cadence.
The scope is kept narrow on purpose to avoid affecting surrounding behavior (BTstack packet pacing, heartbeat timing, idle CPU, etc.).