### PR TITLE
Fix argument parsing in c_esp32_wifi_connect_timeout.

### DIFF
--- a/mrbgems/picoruby-esp32/src/mruby/esp32.c
+++ b/mrbgems/picoruby-esp32/src/mruby/esp32.c
@@ -42,17 +42,17 @@ c_esp32_wifi_connect_timeout(mrb_state *mrb, mrb_value self)
 {
   const char *ssid;
   const char *password;
-  int auth;
-  mrb_int timeout_ms;// = 3 < argc ? GET_INT_ARG(4)*1000 : 60*1000;
-  mrb_value timeout;
-  mrb_get_args(mrb, "zzi|o", &ssid, &password, &auth, &timeout_ms);
+  mrb_int auth;
+  mrb_int timeout_ms;
+  mrb_value timeout = mrb_nil_value();
+  mrb_get_args(mrb, "zzi|o", &ssid, &password, &auth, &timeout);
   if (mrb_nil_p(timeout)) {
     timeout_ms = 60 * 1000;
   } else {
     timeout_ms = mrb_fixnum(timeout) * 1000;
   }
 
-  int result = ESP32_WIFI_connect_timeout(ssid, password, auth, timeout_ms);
+  int result = ESP32_WIFI_connect_timeout(ssid, password, (int)auth, (int)timeout_ms);
 
   if (result == 0) {
     return mrb_true_value();


### PR DESCRIPTION
## Summary

Fix a bug in `c_esp32_wifi_connect_timeout` (`mrbgems/picoruby-esp32/src/mruby/esp32.c`) where the WiFi password
was not received correctly due to argument-type mismatches passed to `mrb_get_args`.

## Problem

This project builds with `MRB_INT64`, so `mrb_int` is 64-bit. The old code looked like:

```c
const char *ssid;
const char *password;
int auth;
mrb_int timeout_ms;
mrb_value timeout;
mrb_get_args(mrb, "zzi|o", &ssid, &password, &auth, &timeout_ms);
if (mrb_nil_p(timeout)) {
  timeout_ms = 60 * 1000;
} else {
  timeout_ms = mrb_fixnum(timeout) * 1000;
}
```

Three issues:

1. `i` expects `mrb_int*` (8 bytes) but receives `&auth` of type `int*` (4 bytes). `mrb_get_args` writes 8 bytes and clobbers adjacent stack variables — in practice this corrupted the `password` pointer, matching the reported symptom.
2. `|o` expects `mrb_value*` but receives `&timeout_ms` (`mrb_int*`).
3. `timeout` is passed to `mrb_nil_p` without being initialized or written by `mrb_get_args`.

## Fix

- Use `mrb_int auth` to match the `i` format specifier.
- Initialize `timeout` with `mrb_nil_value()` and pass `&timeout` (not `&timeout_ms`) to `mrb_get_args`.
- Cast `auth` and `timeout_ms` to `int` when calling `ESP32_WIFI_connect_timeout`, whose signature is unchanged.