### PR TITLE
Fix type error on picoruby-psg with picoruby/debug

### DIFF
--- a/mrbgems/picoruby-psg/src/mruby/psg.c
+++ b/mrbgems/picoruby-psg/src/mruby/psg.c
@@ -56,7 +56,7 @@ mrb_driver_s_select_pwm(mrb_state *mrb, mrb_value klass)
   psg_drv = &psg_drv_pwm;
   mrb_int left, right;
   mrb_get_args(mrb, "ii", &left, &right);
-  D(mrb, "PSG: PWM left=%d, right=%d\n", left, right);
+  D("PSG: PWM left=%d, right=%d\n", left, right);
   reset_psg(mrb);
   PSG_tick_start_core1((uint8_t)left, (uint8_t)right);
   return mrb_nil_value();


### PR DESCRIPTION
`rake r2p2:picoruby:pico2:debug` fails with the following error. This PR fixes it.

```
$ rake r2p2:picoruby:pico2:debug
(...snip...)
CC    mrbgems/picoruby-psg/src/psg.c -> build/r2p2-picoruby-pico2/mrbgems/picoruby-psg/src/psg.o
In file included from /home/kgt/picoruby/include/picoruby.h:5,
                 from /home/kgt/picoruby/mrbgems/picoruby-psg/src/mruby/psg.c:7,
                 from /home/kgt/picoruby/mrbgems/picoruby-psg/src/psg.c:3:
/home/kgt/picoruby/mrbgems/picoruby-psg/src/mruby/psg.c: In function 'mrb_driver_s_select_pwm':
/home/kgt/picoruby/mrbgems/picoruby-psg/src/mruby/psg.c:59:5: error: passing argument 1 of 'debug_printf' from incompatible pointer type [-Wincompatible-pointer-types]
   59 |   D(mrb, "PSG: PWM left=%d, right=%d\n", left, right);
      |     ^~~
      |     |
      |     mrb_state *
/home/kgt/picoruby/include/picoruby/debug.h:13:29: note: in definition of macro 'D'
   13 | #define D(...) debug_printf(__VA_ARGS__)
      |                             ^~~~~~~~~~~
/home/kgt/picoruby/include/picoruby/debug.h:10:30: note: expected 'const char *' but argument is of type 'mrb_state *'
   10 | int debug_printf(const char *format, ...);
      |                  ~~~~~~~~~~~~^~~~~~
rake aborted!
Command failed with status (1): [arm-none-eabi-gcc -MMD -c -std=gnu99 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -mcpu=cortex-m33 -mthumb -fno-strict-aliasing -fno-unroll-loops -mslow-flash-data -fshort-enums -Wall -Wno-format -Wno-unused-function -ffunction-sections -fdata-sections -O0 -g3 -fno-inline -DPICORB_PLATFORM_RP2 -DMRB_TICK_UNIT=1 -DMRB_TIMESLICE_TICK_COUNT=10 -DMRB_UTF8_STRING -DMRB_INT64 -DMRB_NO_BOXING -DMRB_32BIT -DPICORB_ALLOC_ESTALLOC -DPICORB_ALLOC_ALIGN=8 -DUSE_FAT_FLASH_DISK=1 -DMRB_USE_CUSTOM_RO_DATA_P -DMRB_LINK_TIME_RO_DATA_P -DNO_CLOCK_GETTIME=1 -DPICORUBY_VERSION=\"4.0.0\" -DMRC_COMMIT_TIMESTAMP=\"2026-04-20T07:33:35Z\" -DMRC_COMMIT_BRANCH=\"master\" -DMRC_COMMIT_HASH=\"c0df4388\" -DPICORB_VM_MRUBY -DMRB_USE_TASK_SCHEDULER -DPICORB_DEBUG=1 -DMRB_INT64 -DMRB_NO_BOXING -DMRB_UTF8_STRING -DMRBGEM_PICORUBY_PSG_VERSION=0.0.0 -DMRB_CONSTRAINED_BASELINE_PROFILE=1 -DMRB_USE_TASK_SCHEDULER -I"/home/kgt/picoruby/include" -I"/home/kgt/picoruby/mrbgems/mruby-compiler2/include" -I"/home/kgt/picoruby/mrbgems/mruby-compiler2/lib/prism/include" -I"/home/kgt/picoruby/mrbgems/picoruby-mruby/lib/mruby/include" -I"/home/kgt/picoruby/mrbgems/picoruby-mruby/include" -I"/home/kgt/picoruby/mrbgems/picoruby-psg/include" -I"/home/kgt/picoruby/build/r2p2-picoruby-pico2/include" -o "/home/kgt/picoruby/build/r2p2-picoruby-pico2/mrbgems/picoruby-psg/src/psg.o" "/home/kgt/picoruby/mrbgems/picoruby-psg/src/psg.c"]
/home/kgt/picoruby/lib/mruby/build/command.rb:33:in 'MRuby::Command#_run'
/home/kgt/picoruby/lib/mruby/build/command.rb:95:in 'MRuby::Command::Compiler#run'
/home/kgt/picoruby/lib/mruby/build/command.rb:120:in 'block (2 levels) in MRuby::Command::Compiler#define_rules'
/home/kgt/picoruby/Rakefile:50:in 'block in <top (required)>'
Tasks: TOP => build => /home/kgt/picoruby/build/r2p2-picoruby-pico2/lib/libmruby.a => /home/kgt/picoruby/build/r2p2-picoruby-pico2/mrbgems/picoruby-psg/src/psg.o
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [MRUBY_CONFIG=/home/kgt/picoruby/build_config/r2p2-picoruby-pico2.rb PICORB_BOARD=pico2 PICORB_DEBUG=1 rake]
/home/kgt/picoruby/tasks/picoruby/r2p2.rake:118:in 'block (8 levels) in <top (required)>'
/home/kgt/picoruby/tasks/picoruby/r2p2.rake:117:in 'block (7 levels) in <top (required)>'
Tasks: TOP => r2p2:picoruby:pico2:debug
(See full trace by running task with --trace)
```
