### PR TITLE
Add PIO::StateMachine#freq and #freq= accessors

### DIFF
--- a/mrbgems/picoruby-pio/include/pio.h
+++ b/mrbgems/picoruby-pio/include/pio.h
@@ -68,6 +68,7 @@ void PIO_clear_fifos(pio_sm_config_t *config);
 void PIO_drain_tx(pio_sm_config_t *config);
 void PIO_restart(pio_sm_config_t *config);
 void PIO_exec(pio_sm_config_t *config, uint16_t instruction);
+void PIO_set_freq(pio_sm_config_t *config, uint32_t freq);
 void PIO_deinit(pio_sm_config_t *config);
 
 #ifdef __cplusplus

--- a/mrbgems/picoruby-pio/ports/rp2040/pio.c
+++ b/mrbgems/picoruby-pio/ports/rp2040/pio.c
@@ -262,6 +262,17 @@ PIO_exec(pio_sm_config_t *config, uint16_t instruction)
 }
 
 void
+PIO_set_freq(pio_sm_config_t *config, uint32_t freq)
+{
+  PIO pio = pio_instance(config->pio_num);
+  if (!pio) return;
+  float clk_div = (float)clock_get_hz(clk_sys) / (float)freq;
+  if (clk_div < 1.0f) clk_div = 1.0f;
+  pio_sm_set_clkdiv(pio, config->sm_num, clk_div);
+  config->freq = freq;
+}
+
+void
 PIO_deinit(pio_sm_config_t *config)
 {
   PIO pio = pio_instance(config->pio_num);

--- a/mrbgems/picoruby-pio/sig/pio.rbs
+++ b/mrbgems/picoruby-pio/sig/pio.rbs
@@ -200,5 +200,7 @@ module PIO
     def clear_fifos: () -> void
     def drain_tx: () -> void
     def put_bytes: (String data) -> void
+    def freq: () -> Integer
+    def freq=: (Integer) -> Integer
   end
 end

--- a/mrbgems/picoruby-pio/src/mruby/pio.c
+++ b/mrbgems/picoruby-pio/src/mruby/pio.c
@@ -260,6 +260,24 @@ mrb_sm_exec(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
+static mrb_value
+mrb_sm_freq(mrb_state *mrb, mrb_value self)
+{
+  pio_sm_config_t *config = (pio_sm_config_t *)mrb_data_get_ptr(mrb, self, &mrb_pio_sm_type);
+  return mrb_int_value(mrb, (mrb_int)config->freq);
+}
+
+static mrb_value
+mrb_sm_freq_e(mrb_state *mrb, mrb_value self)
+{
+  pio_sm_config_t *config = (pio_sm_config_t *)mrb_data_get_ptr(mrb, self, &mrb_pio_sm_type);
+  mrb_int freq;
+  mrb_get_args(mrb, "i", &freq);
+  if (freq <= 0) mrb_raise(mrb, E_ARGUMENT_ERROR, "freq must be positive");
+  PIO_set_freq(config, (uint32_t)freq);
+  return mrb_int_value(mrb, freq);
+}
+
 void
 mrb_picoruby_pio_gem_init(mrb_state* mrb)
 {
@@ -286,6 +304,8 @@ mrb_picoruby_pio_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_SM, MRB_SYM(clear_fifos), mrb_sm_clear_fifos, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SM, MRB_SYM(drain_tx), mrb_sm_drain_tx, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SM, MRB_SYM(exec), mrb_sm_exec, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_SM, MRB_SYM(freq), mrb_sm_freq, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SM, MRB_SYM_E(freq), mrb_sm_freq_e, MRB_ARGS_REQ(1));
 }
 
 void

--- a/mrbgems/picoruby-pio/src/mrubyc/pio.c
+++ b/mrbgems/picoruby-pio/src/mrubyc/pio.c
@@ -206,6 +206,26 @@ c_sm_exec(mrbc_vm *vm, mrbc_value *v, int argc)
   PIO_exec(config, (uint16_t)GET_INT_ARG(1));
 }
 
+static void
+c_sm_freq(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  pio_sm_config_t *config = (pio_sm_config_t *)v->instance->data;
+  SET_INT_RETURN((mrbc_int_t)config->freq);
+}
+
+static void
+c_sm_freq_eq(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  pio_sm_config_t *config = (pio_sm_config_t *)v->instance->data;
+  mrbc_int_t freq = GET_INT_ARG(1);
+  if (freq <= 0) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "freq must be positive");
+    return;
+  }
+  PIO_set_freq(config, (uint32_t)freq);
+  SET_INT_RETURN(freq);
+}
+
 void
 mrbc_pio_init(mrbc_vm *vm)
 {
@@ -230,4 +250,6 @@ mrbc_pio_init(mrbc_vm *vm)
   mrbc_define_method(vm, mrbc_class_SM, "clear_fifos", c_sm_clear_fifos);
   mrbc_define_method(vm, mrbc_class_SM, "drain_tx", c_sm_drain_tx);
   mrbc_define_method(vm, mrbc_class_SM, "exec", c_sm_exec);
+  mrbc_define_method(vm, mrbc_class_SM, "freq", c_sm_freq);
+  mrbc_define_method(vm, mrbc_class_SM, "freq=", c_sm_freq_eq);
 }


### PR DESCRIPTION
Expose runtime access to the state machine's clock divider so users can adjust the PIO frequency after construction without rebuilding the SM:

```ruby
sm = PIO::StateMachine.new(..., freq: 100_000_000)
sm.stop
sm.freq = 120_000_000
sm.start
sm.freq # => 120000000
```


