### PR TITLE
Add minimal CYW43 AP mode API

### DIFF
--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -35,6 +35,17 @@ CYW43.disconnect
 CYW43.disable_sta_mode
 ```
 
+### Access Point Mode
+
+```ruby
+require "cyw43"
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+```
+
 ## API
 
 ### CYW43 Module Methods
@@ -43,6 +54,8 @@ CYW43.disable_sta_mode
 - `CYW43.initialized?()` - Check if initialized
 - `CYW43.enable_sta_mode()` - Enable station mode
 - `CYW43.disable_sta_mode()` - Disable station mode
+- `CYW43.enable_ap_mode(ssid, password, auth = CYW43::Auth::WPA2_AES_PSK)` - Enable access point mode
+- `CYW43.disable_ap_mode()` - Disable access point mode
 - `CYW43.connect_timeout(ssid, password, auth, timeout_ms)` - Connect to WiFi with timeout
 - `CYW43.disconnect()` - Disconnect from WiFi
 - `CYW43.link_connected?(print_status = false)` - Check connection status
@@ -80,3 +93,8 @@ CYW43.disable_sta_mode
 - Specific to Raspberry Pi Pico W and similar boards
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
+- `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
+- PicoRuby does not yet expose AP-side DHCP server, AP IP configuration, or connected client listing
+- Clients may associate to the SSID without receiving an IP address until DHCP/IP helpers are added
+- See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
+- TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -1,0 +1,19 @@
+require "cyw43"
+
+# Minimal AP mode example for Pico W / Pico 2 W.
+# TODO: add AP-side DHCP/IP helpers before expanding this into a supported HTTP sample.
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+puts "Clients may need a static IP until DHCP support is added."
+
+led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
+
+loop do
+  led.write(1)
+  sleep 0.5
+  led.write(0)
+  sleep 0.5
+end

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -14,10 +14,13 @@ void CYW43_arch_deinit(void);
 #ifdef USE_WIFI
 void CYW43_arch_enable_sta_mode(void);
 void CYW43_arch_disable_sta_mode(void);
+void CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth);
+void CYW43_arch_disable_ap_mode(void);
 int CYW43_wifi_connect_with_dhcp(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms);
 int CYW43_wifi_disconnect(void);
 int CYW43_tcpip_link_status(void);
 bool CYW43_dhcp_supplied(void);
+int CYW43_CONST_auth_wpa2_aes_psk(void);
 int CYW43_CONST_link_down(void);
 int CYW43_CONST_link_join(void);
 int CYW43_CONST_link_noip(void);
@@ -39,4 +42,3 @@ uint8_t CYW43_GPIO_read(uint8_t pin);
 #endif
 
 #endif /* CYW43_DEFINED_H_ */
-

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -60,6 +60,12 @@ CYW43_dhcp_supplied(void)
 }
 
 int
+CYW43_CONST_auth_wpa2_aes_psk(void)
+{
+  return CYW43_AUTH_WPA2_AES_PSK;
+}
+
+int
 CYW43_arch_init_with_country(const uint8_t *country)
 {
   int res;
@@ -97,6 +103,18 @@ void
 CYW43_arch_disable_sta_mode(void)
 {
   cyw43_arch_disable_sta_mode();
+}
+
+void
+CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth)
+{
+  cyw43_arch_enable_ap_mode(ssid, pw, auth);
+}
+
+void
+CYW43_arch_disable_ap_mode(void)
+{
+  cyw43_arch_disable_ap_mode();
 }
 
 int

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -19,6 +19,8 @@ class CYW43
   def self.disconnect: () -> bool
   def self.enable_sta_mode: () -> bool
   def self.disable_sta_mode: () -> bool
+  def self.enable_ap_mode: (String ssid, String password, ?Integer auth) -> bool
+  def self.disable_ap_mode: () -> bool
   def self.tcpip_link_status: () -> Integer
   def self.tcpip_link_status_name: () -> String
   def self.dhcp_supplied?: () -> bool

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -40,6 +40,7 @@ mrb_s_initialized_p(mrb_state *mrb, mrb_value klass)
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 
 static mrb_value
 mrb_s_enable_sta_mode(mrb_state *mrb, mrb_value klass)
@@ -72,6 +73,40 @@ mrb_s_disable_sta_mode(mrb_state *mrb, mrb_value klass)
 }
 
 static bool cyw43_arch_connected = false;
+
+static mrb_value
+mrb_s_enable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  const char *ssid;
+  const char *pass;
+  mrb_int auth = CYW43_CONST_auth_wpa2_aes_psk();
+  mrb_get_args(mrb, "zz|i", &ssid, &pass, &auth);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
+
+static mrb_value
+mrb_s_disable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
 
 static mrb_value
 mrb_s_connect_timeout(mrb_state *mrb, mrb_value klass)
@@ -217,6 +252,8 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
 #ifdef USE_WIFI
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_sta_mode), mrb_s_enable_sta_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_sta_mode), mrb_s_disable_sta_mode, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_ap_mode), mrb_s_enable_ap_mode, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_ap_mode), mrb_s_disable_ap_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(connect_timeout), mrb_s_connect_timeout, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disconnect), mrb_s_disconnect, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(tcpip_link_status), mrb_s_tcpip_link_status, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -8,6 +8,7 @@ static bool cyw43_arch_init_flag = false;
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 static bool cyw43_arch_connected = false;
 #endif
 
@@ -26,6 +27,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     cyw43_arch_init_flag = false;
 #ifdef USE_WIFI
     cyw43_arch_sta_mode_enabled = false;
+    cyw43_arch_ap_mode_enabled = false;
     cyw43_arch_connected = false;
 #endif
   }
@@ -105,6 +107,45 @@ c_CYW43_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
       return;
     }
     cyw43_arch_connected = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_enable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (argc < 2 || 3 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+  const char *ssid = (const char *)GET_STRING_ARG(1);
+  const char *pass = (const char *)GET_STRING_ARG(2);
+  int auth = argc < 3 ? CYW43_CONST_auth_wpa2_aes_psk() : GET_INT_ARG(3);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_disable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
@@ -210,6 +251,8 @@ mrbc_cyw43_init(mrbc_vm *vm)
 #ifdef USE_WIFI
   mrbc_define_method(vm, class_CYW43, "enable_sta_mode", c_CYW43_enable_sta_mode);
   mrbc_define_method(vm, class_CYW43, "disable_sta_mode", c_CYW43_disable_sta_mode);
+  mrbc_define_method(vm, class_CYW43, "enable_ap_mode", c_CYW43_enable_ap_mode);
+  mrbc_define_method(vm, class_CYW43, "disable_ap_mode", c_CYW43_disable_ap_mode);
   mrbc_define_method(vm, class_CYW43, "connect_timeout", c_CYW43_connect_timeout);
   mrbc_define_method(vm, class_CYW43, "disconnect", c_CYW43_disconnect);
   mrbc_define_method(vm, class_CYW43, "tcpip_link_status", c_CYW43_tcpip_link_status);


### PR DESCRIPTION
## Summary

This draft PR adds a minimal CYW43 AP mode API to PicoRuby for Pico W / Pico 2 W.

New Ruby APIs:

- `CYW43.enable_ap_mode(ssid, password, auth = CYW43::Auth::WPA2_AES_PSK) -> bool`
- `CYW43.disable_ap_mode() -> bool`

The intent here is to keep the first step small and consistent with the existing CYW43 API surface, before adding AP-side IP/DHCP support or a higher-level wrapper.

## What changed

- added `CYW43.enable_ap_mode` to the CYW43 bindings
- added `CYW43.disable_ap_mode` to the CYW43 bindings
- used `CYW43::Auth::WPA2_AES_PSK` as the default auth mode
- kept the behavior aligned with existing CYW43 APIs by returning `true` / `false`
- updated signatures
- added a minimal AP mode example
- documented current limitations in the CYW43 README

## Example

```ruby
CYW43.init("JP")
CYW43.enable_ap_mode("PICO-TIMER", "12345678")
puts "AP started"
