### PR TITLE
Add CYW43 AP-side IPv4 getters

### DIFF
--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -35,6 +35,17 @@ CYW43.disconnect
 CYW43.disable_sta_mode
 ```
 
+### Access Point Mode
+
+```ruby
+require "cyw43"
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+```
+
 ## API
 
 ### CYW43 Module Methods
@@ -43,6 +54,8 @@ CYW43.disable_sta_mode
 - `CYW43.initialized?()` - Check if initialized
 - `CYW43.enable_sta_mode()` - Enable station mode
 - `CYW43.disable_sta_mode()` - Disable station mode
+- `CYW43.enable_ap_mode(ssid, password, auth = CYW43::Auth::WPA2_AES_PSK)` - Enable access point mode
+- `CYW43.disable_ap_mode()` - Disable access point mode
 - `CYW43.connect_timeout(ssid, password, auth, timeout_ms)` - Connect to WiFi with timeout
 - `CYW43.disconnect()` - Disconnect from WiFi
 - `CYW43.link_connected?(print_status = false)` - Check connection status
@@ -80,3 +93,8 @@ CYW43.disable_sta_mode
 - Specific to Raspberry Pi Pico W and similar boards
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
+- `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
+- PicoRuby does not yet expose AP-side DHCP server, AP IP configuration, or connected client listing
+- Clients may associate to the SSID without receiving an IP address until DHCP/IP helpers are added
+- See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
+- TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample

--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -44,6 +44,7 @@ CYW43.init("JP")
 CYW43.enable_ap_mode("PICO-TIMER", "12345678")
 
 puts "AP started"
+puts "AP IP: #{CYW43.ap_ipv4_address}"
 ```
 
 ## API
@@ -62,6 +63,9 @@ puts "AP started"
 - `CYW43.tcpip_link_status()` - Get link status code
 - `CYW43.tcpip_link_status_name()` - Get link status name
 - `CYW43.dhcp_supplied?()` - Check if DHCP supplied IP
+- `CYW43.ap_ipv4_address()` - Get AP-side IPv4 address
+- `CYW43.ap_ipv4_netmask()` - Get AP-side IPv4 netmask
+- `CYW43.ap_ipv4_gateway()` - Get AP-side IPv4 gateway
 
 ### Authentication Types
 
@@ -94,7 +98,7 @@ puts "AP started"
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
 - `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
-- PicoRuby does not yet expose AP-side DHCP server, AP IP configuration, or connected client listing
-- Clients may associate to the SSID without receiving an IP address until DHCP/IP helpers are added
+- PicoRuby now exposes AP-side IPv4 information, but not AP-side DHCP control, custom AP IP configuration, or connected client listing
+- AP usability beyond SSID visibility still needs more hardware verification
 - See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
 - TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -1,0 +1,19 @@
+require "cyw43"
+
+# Minimal AP mode example for Pico W / Pico 2 W.
+# TODO: add AP-side DHCP/IP helpers before expanding this into a supported HTTP sample.
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+puts "Clients may need a static IP until DHCP support is added."
+
+led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
+
+loop do
+  led.write(1)
+  sleep 0.5
+  led.write(0)
+  sleep 0.5
+end

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -7,7 +7,7 @@ CYW43.init("JP")
 CYW43.enable_ap_mode("PICO-TIMER", "12345678")
 
 puts "AP started"
-puts "Clients may need a static IP until DHCP support is added."
+puts "AP IP: #{CYW43.ap_ipv4_address || 'unassigned'}"
 
 led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
 

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -33,6 +33,9 @@ extern void lwip_end(void);
 const char *CYW43_ipv4_address(char *buf, size_t buflen);
 const char *CYW43_ipv4_netmask(char *buf, size_t buflen);
 const char *CYW43_ipv4_gateway(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_address(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_netmask(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_gateway(char *buf, size_t buflen);
 #endif
 void CYW43_GPIO_write(uint8_t, uint8_t);
 uint8_t CYW43_GPIO_read(uint8_t pin);

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -14,10 +14,13 @@ void CYW43_arch_deinit(void);
 #ifdef USE_WIFI
 void CYW43_arch_enable_sta_mode(void);
 void CYW43_arch_disable_sta_mode(void);
+void CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth);
+void CYW43_arch_disable_ap_mode(void);
 int CYW43_wifi_connect_with_dhcp(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms);
 int CYW43_wifi_disconnect(void);
 int CYW43_tcpip_link_status(void);
 bool CYW43_dhcp_supplied(void);
+int CYW43_CONST_auth_wpa2_aes_psk(void);
 int CYW43_CONST_link_down(void);
 int CYW43_CONST_link_join(void);
 int CYW43_CONST_link_noip(void);
@@ -39,4 +42,3 @@ uint8_t CYW43_GPIO_read(uint8_t pin);
 #endif
 
 #endif /* CYW43_DEFINED_H_ */
-

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -60,6 +60,12 @@ CYW43_dhcp_supplied(void)
 }
 
 int
+CYW43_CONST_auth_wpa2_aes_psk(void)
+{
+  return CYW43_AUTH_WPA2_AES_PSK;
+}
+
+int
 CYW43_arch_init_with_country(const uint8_t *country)
 {
   int res;
@@ -97,6 +103,18 @@ void
 CYW43_arch_disable_sta_mode(void)
 {
   cyw43_arch_disable_sta_mode();
+}
+
+void
+CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth)
+{
+  cyw43_arch_enable_ap_mode(ssid, pw, auth);
+}
+
+void
+CYW43_arch_disable_ap_mode(void)
+{
+  cyw43_arch_disable_ap_mode();
 }
 
 int

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -153,46 +153,94 @@ CYW43_GPIO_read(uint8_t pin)
 }
 
 const char *
-CYW43_ipv4_address(char *buf, size_t buflen)
+cyw43_ipv4_address_for_if(int itf, char *buf, size_t buflen)
 {
   const char *res;
   lwip_begin();
-  const ip4_addr_t *ip = netif_ip4_addr(netif_default);
-  if (ip && ip->addr != 0) {
-    res = ipaddr_ntoa_r(ip, buf, buflen);
-  } else {
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
     res = NULL;
+  } else {
+    const ip4_addr_t *ip = netif_ip4_addr(&cyw43_state.netif[itf]);
+    if (ip && ip->addr != 0) {
+      res = ipaddr_ntoa_r(ip, buf, buflen);
+    } else {
+      res = NULL;
+    }
   }
   lwip_end();
   return res;
+}
+
+const char *
+cyw43_ipv4_netmask_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *netmask = netif_ip4_netmask(&cyw43_state.netif[itf]);
+    if (netmask && netmask->addr != 0) {
+      res = ipaddr_ntoa_r(netmask, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+const char *
+cyw43_ipv4_gateway_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *gateway = netif_ip4_gw(&cyw43_state.netif[itf]);
+    if (gateway && gateway->addr != 0) {
+      res = ipaddr_ntoa_r(gateway, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+const char *
+CYW43_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_netmask(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *netmask = netif_ip4_netmask(netif_default);
-  if (netmask && netmask->addr != 0) {
-    res = ipaddr_ntoa_r(netmask, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_gateway(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *gateway = netif_ip4_gw(netif_default);
-  if (gateway && gateway->addr != 0) {
-    res = ipaddr_ntoa_r(gateway, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_gateway_for_if(CYW43_ITF_STA, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_AP, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_netmask(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_AP, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_gateway(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_gateway_for_if(CYW43_ITF_AP, buf, buflen);
 }

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -28,6 +28,9 @@ class CYW43
   def self.ipv4_address: () -> (String | nil)
   def self.ipv4_netmask: () -> (String | nil)
   def self.ipv4_gateway: () -> (String | nil)
+  def self.ap_ipv4_address: () -> (String | nil)
+  def self.ap_ipv4_netmask: () -> (String | nil)
+  def self.ap_ipv4_gateway: () -> (String | nil)
   private def self._init: (String | nil country, bool force) -> bool
 
   # @sidebar hardware_device

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -19,6 +19,8 @@ class CYW43
   def self.disconnect: () -> bool
   def self.enable_sta_mode: () -> bool
   def self.disable_sta_mode: () -> bool
+  def self.enable_ap_mode: (String ssid, String password, ?Integer auth) -> bool
+  def self.disable_ap_mode: () -> bool
   def self.tcpip_link_status: () -> Integer
   def self.tcpip_link_status_name: () -> String
   def self.dhcp_supplied?: () -> bool

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -40,6 +40,7 @@ mrb_s_initialized_p(mrb_state *mrb, mrb_value klass)
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 
 static mrb_value
 mrb_s_enable_sta_mode(mrb_state *mrb, mrb_value klass)
@@ -72,6 +73,40 @@ mrb_s_disable_sta_mode(mrb_state *mrb, mrb_value klass)
 }
 
 static bool cyw43_arch_connected = false;
+
+static mrb_value
+mrb_s_enable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  const char *ssid;
+  const char *pass;
+  mrb_int auth = CYW43_CONST_auth_wpa2_aes_psk();
+  mrb_get_args(mrb, "zz|i", &ssid, &pass, &auth);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
+
+static mrb_value
+mrb_s_disable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
 
 static mrb_value
 mrb_s_connect_timeout(mrb_state *mrb, mrb_value klass)
@@ -217,6 +252,8 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
 #ifdef USE_WIFI
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_sta_mode), mrb_s_enable_sta_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_sta_mode), mrb_s_disable_sta_mode, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_ap_mode), mrb_s_enable_ap_mode, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_ap_mode), mrb_s_disable_ap_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(connect_timeout), mrb_s_connect_timeout, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disconnect), mrb_s_disconnect, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(tcpip_link_status), mrb_s_tcpip_link_status, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -221,6 +221,48 @@ mrb_cyw43_s_ipv4_gateway(mrb_state *mrb, mrb_value self)
     return mrb_str_new_cstr(mrb, gateway_str);
   }
 }
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_address(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char addr_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(addr_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, addr_str);
+  }
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_netmask(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, netmask_str);
+  }
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_gateway(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char gateway_str[16] = {0};
+  if (!CYW43_ap_ipv4_gateway(gateway_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, gateway_str);
+  }
+}
 #endif
 
 static mrb_value
@@ -261,6 +303,9 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_address), mrb_cyw43_s_ipv4_address, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_netmask), mrb_cyw43_s_ipv4_netmask, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_gateway), mrb_cyw43_s_ipv4_gateway, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_address"), mrb_cyw43_s_ap_ipv4_address, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_netmask"), mrb_cyw43_s_ap_ipv4_netmask, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_gateway"), mrb_cyw43_s_ap_ipv4_gateway, MRB_ARGS_NONE());
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_DOWN), mrb_fixnum_value(CYW43_CONST_link_down()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_JOIN), mrb_fixnum_value(CYW43_CONST_link_join()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_NOIP), mrb_fixnum_value(CYW43_CONST_link_noip()));

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -225,6 +225,39 @@ c_CYW43_ipv4_gateway(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   SET_RETURN(mrbc_string_new_cstr(vm, gateway_str));
 }
+
+static void
+c_CYW43_ap_ipv4_address(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char ip_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(ip_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, ip_str));
+}
+
+static void
+c_CYW43_ap_ipv4_netmask(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, netmask_str));
+}
+
+static void
+c_CYW43_ap_ipv4_gateway(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char gateway_str[16] = {0};
+  if (!CYW43_ap_ipv4_gateway(gateway_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, gateway_str));
+}
 #endif
 
 static void
@@ -260,6 +293,9 @@ mrbc_cyw43_init(mrbc_vm *vm)
   mrbc_define_method(vm, class_CYW43, "ipv4_address", c_CYW43_ipv4_address);
   mrbc_define_method(vm, class_CYW43, "ipv4_netmask", c_CYW43_ipv4_netmask);
   mrbc_define_method(vm, class_CYW43, "ipv4_gateway", c_CYW43_ipv4_gateway);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_address", c_CYW43_ap_ipv4_address);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_netmask", c_CYW43_ap_ipv4_netmask);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_gateway", c_CYW43_ap_ipv4_gateway);
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_DOWN"), &mrbc_integer_value(CYW43_CONST_link_down()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_JOIN"), &mrbc_integer_value(CYW43_CONST_link_join()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_NOIP"), &mrbc_integer_value(CYW43_CONST_link_noip()));

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -8,6 +8,7 @@ static bool cyw43_arch_init_flag = false;
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 static bool cyw43_arch_connected = false;
 #endif
 
@@ -26,6 +27,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     cyw43_arch_init_flag = false;
 #ifdef USE_WIFI
     cyw43_arch_sta_mode_enabled = false;
+    cyw43_arch_ap_mode_enabled = false;
     cyw43_arch_connected = false;
 #endif
   }
@@ -105,6 +107,45 @@ c_CYW43_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
       return;
     }
     cyw43_arch_connected = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_enable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (argc < 2 || 3 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+  const char *ssid = (const char *)GET_STRING_ARG(1);
+  const char *pass = (const char *)GET_STRING_ARG(2);
+  int auth = argc < 3 ? CYW43_CONST_auth_wpa2_aes_psk() : GET_INT_ARG(3);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_disable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
@@ -210,6 +251,8 @@ mrbc_cyw43_init(mrbc_vm *vm)
 #ifdef USE_WIFI
   mrbc_define_method(vm, class_CYW43, "enable_sta_mode", c_CYW43_enable_sta_mode);
   mrbc_define_method(vm, class_CYW43, "disable_sta_mode", c_CYW43_disable_sta_mode);
+  mrbc_define_method(vm, class_CYW43, "enable_ap_mode", c_CYW43_enable_ap_mode);
+  mrbc_define_method(vm, class_CYW43, "disable_ap_mode", c_CYW43_disable_ap_mode);
   mrbc_define_method(vm, class_CYW43, "connect_timeout", c_CYW43_connect_timeout);
   mrbc_define_method(vm, class_CYW43, "disconnect", c_CYW43_disconnect);
   mrbc_define_method(vm, class_CYW43, "tcpip_link_status", c_CYW43_tcpip_link_status);

--- a/mrbgems/picoruby-network/sig/network.rbs
+++ b/mrbgems/picoruby-network/sig/network.rbs
@@ -15,6 +15,9 @@ module Network
     def self.ipv4_address: () -> (String | nil)
     def self.ipv4_netmask: () -> (String | nil)
     def self.ipv4_gateway: () -> (String | nil)
+    def self.ap_ipv4_address: () -> (String | nil)
+    def self.ap_ipv4_netmask: () -> (String | nil)
+    def self.ap_ipv4_gateway: () -> (String | nil)
     def self.dhcp_supplied?: () -> bool
   end
 end

--- a/mrbgems/picoruby-shell/shell_executables/ifconfig.rb
+++ b/mrbgems/picoruby-shell/shell_executables/ifconfig.rb
@@ -14,16 +14,30 @@ end
 
 puts "Link: WiFi"
 
+puts "  Station:"
 if Network::WiFi.link_connected?
-  puts "  Status: UP (#{Network::WiFi.tcpip_link_status_name})"
+  puts "    Status: UP (#{Network::WiFi.tcpip_link_status_name})"
   if Network::WiFi.dhcp_supplied?
-    puts "  DHCP: Active"
-    puts "  IP Address: #{Network::WiFi.ipv4_address || 'unassigned'}"
-    puts "  Netmask:    #{Network::WiFi.ipv4_netmask || 'unassigned'}"
-    puts "  Gateway:    #{Network::WiFi.ipv4_gateway || 'unassigned'}"
+    puts "    DHCP: Active"
+    puts "    IP Address: #{Network::WiFi.ipv4_address || 'unassigned'}"
+    puts "    Netmask:    #{Network::WiFi.ipv4_netmask || 'unassigned'}"
+    puts "    Gateway:    #{Network::WiFi.ipv4_gateway || 'unassigned'}"
   else
-    puts "  DHCP: Inactive"
+    puts "    DHCP: Inactive"
   end
 else
-  puts "  Status: DOWN"
+  puts "    Status: DOWN"
+end
+
+puts "  Access Point:"
+ap_ip = Network::WiFi.ap_ipv4_address
+ap_netmask = Network::WiFi.ap_ipv4_netmask
+ap_gateway = Network::WiFi.ap_ipv4_gateway
+if ap_ip || ap_netmask || ap_gateway
+  puts "    Status: UP"
+  puts "    IP Address: #{ap_ip || 'unassigned'}"
+  puts "    Netmask:    #{ap_netmask || 'unassigned'}"
+  puts "    Gateway:    #{ap_gateway || 'unassigned'}"
+else
+  puts "    Status: DOWN"
 end


### PR DESCRIPTION
## Summary

This draft PR adds minimal AP-side IPv4 observability for CYW43 AP mode.

New Ruby APIs:

- `CYW43.ap_ipv4_address -> String?`
- `CYW43.ap_ipv4_netmask -> String?`
- `CYW43.ap_ipv4_gateway -> String?`

It also updates `ifconfig` to show separate station and access-point sections, and updates the AP sample and README to print the AP-side address.

## Why this step

The previous AP-mode PR proves that PicoRuby can advertise an SSID from Ruby, but it is still hard to tell what AP-side network state is active at runtime.

This PR keeps the scope small and focuses on observability before moving on to a larger AP wrapper or DHCP/configuration work.

## What changed

- added `CYW43.ap_ipv4_address`
- added `CYW43.ap_ipv4_netmask`
- added `CYW43.ap_ipv4_gateway`
- kept the existing STA-side Ruby API unchanged
- updated internal IPv4 helpers to read explicitly from `CYW43_ITF_STA` and `CYW43_ITF_AP`
- made AP-side getters return `nil` when the AP interface is not active
- updated `ifconfig` to show separate `Station` and `Access Point` sections
- updated the AP sample and README to print the AP-side IP

## Example

```ruby
CYW43.init("JP")
CYW43.enable_ap_mode("PICO-TIMER", "12345678")

puts "AP IP: #{CYW43.ap_ipv4_address || 'unassigned'}"
puts "AP Netmask: #{CYW43.ap_ipv4_netmask || 'unassigned'}"
puts "AP Gateway: #{CYW43.ap_ipv4_gateway || 'unassigned'}"
