### PR TITLE
esp32: Add startup delay for USB Serial JTAG console connection

### DIFF
--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -122,6 +122,10 @@ machine_hal_init(void)
   esp_timer_start_periodic(periodic_timer, MRBC_TICK_UNIT * 1000);
 #endif
 
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  Machine_delay_ms(3000);
+#endif
+
   RingBuffer_init(stdin_rb, PICORB_STDIN_BUFFER_SIZE);
   xTaskCreate(stdin_reader_task, "stdin_reader", 2048, NULL, tskIDLE_PRIORITY + 1, NULL);
 }


### PR DESCRIPTION
## Background

When `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` is enabled, flashing the device and connecting a terminal emulator caused the "FemtoRuby" logo to take more than 30 seconds to appear. 
Investigation revealed that the USB Serial JTAG console requires some time to complete the connection after boot. Starting the shell before the connection is fully established delays all subsequent I/O responses. 

## Fix

Added a 3-second delay in `machine_hal_init()` when `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG` is enabled, ensuring the terminal connection is fully established before `IO.wait_terminal` is called.