### PR TITLE
Redesign interoperability between Ruby and JS

### DIFF
--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -63,6 +63,7 @@
     <ul>
       <li><a href="dom.html">DOM manipulation</a></li>
       <li><a href="dom_apis.html">Advanced DOM manipulation</a></li>
+      <li><a href="js_types.html">JS type system (primitives, inspect, subclasses)</a></li>
       <li><a href="multitasks.html">Multi tasks</a></li>
       <li><a href="timeout.html">setTimeout and clearTimeout</a></li>
       <li><a href="prime_numbers.html">Prime numbers</a></li>

--- a/mrbgems/picoruby-wasm/demo/www/js_types.html
+++ b/mrbgems/picoruby-wasm/demo/www/js_types.html
@@ -183,6 +183,94 @@
       raise "then block did not run: got #{seen.inspect}" unless seen == 7
     end
 
+    # ----- Phase 4: DOM domain subclasses -----
+
+    test_case("JS::Element: dispatch and ancestry") do
+      div = doc.createElement('div')
+      raise "not a JS::Element: #{div.class}" unless div.is_a?(JS::Element)
+      raise "not a JS::Object" unless div.is_a?(JS::Object)
+    end
+
+    test_case("JS::Element: JS.document is detected") do
+      raise "document is not JS::Element: #{doc.class}" unless doc.is_a?(JS::Element)
+    end
+
+    test_case("JS::Element: setAttribute moved to subclass") do
+      div = doc.createElement('div')
+      div.setAttribute('data-foo', 'bar')
+      raise "setAttribute did not stick" unless div.getAttribute('data-foo') == 'bar'
+    end
+
+    test_case("JS::Element: appendChild on Document works") do
+      div = doc.createElement('div')
+      div.setAttribute('id', 'phase4-tmp')
+      doc.body.appendChild(div)
+      found = doc.getElementById('phase4-tmp')
+      raise "appended element not found" unless found
+      doc.body.removeChild(div)
+    end
+
+    test_case("JS::Event: dispatch via click handler") do
+      btn = doc.createElement('button')
+      btn.setAttribute('id', 'phase4-event-btn')
+      btn.textContent = 'tmp'
+      doc.body.appendChild(btn)
+      seen_class = nil #: Class?
+      btn.addEventListener('click') do |event|
+        seen_class = event.class
+        event.preventDefault
+      end
+      # Trigger the click from JS, then yield so the task scheduler can
+      # run the queued Ruby callback before we inspect seen_class.
+      JS.eval('document.getElementById("phase4-event-btn").click()')
+      sleep 0.05
+      doc.body.removeChild(btn)
+      raise "no click captured" unless seen_class
+      raise "event class is #{seen_class}" unless seen_class == JS::Event
+    end
+
+    test_case("JS::Event: preventDefault not on plain JS::Object") do
+      obj = JS.global.create_object
+      raise "should not respond to preventDefault" if obj.respond_to?(:preventDefault)
+    end
+
+    test_case("#typeof renamed from #type") do
+      arr = JS.global.create_array
+      raise "typeof: #{arr.typeof}" unless arr.typeof == :array
+      obj = JS.global.create_object
+      raise "typeof: #{obj.typeof}" unless obj.typeof == :object
+    end
+
+    test_case("JS::Event#target is JS::Element") do
+      btn = doc.createElement('button')
+      btn.setAttribute('id', 'phase4-target-btn')
+      doc.body.appendChild(btn)
+      target_class = nil #: Class?
+      btn.addEventListener('click') do |event|
+        target_class = event.target.class
+      end
+      JS.eval('document.getElementById("phase4-target-btn").click()')
+      sleep 0.05
+      doc.body.removeChild(btn)
+      raise "target class: #{target_class}" unless target_class == JS::Element
+    end
+
+    test_case("fetch block argument is JS::Response") do
+      seen_class = nil #: Class?
+      JS.global.fetch('data:text/plain,fetched') do |response|
+        seen_class = response.class
+      end
+      raise "response class: #{seen_class}" unless seen_class == JS::Response
+    end
+
+    test_case("JS::Response#to_binary returns the body") do
+      body = nil #: String?
+      JS.global.fetch('data:text/plain,hello-binary') do |response|
+        body = response.to_binary
+      end
+      raise "body: #{body.inspect}" unless body == 'hello-binary'
+    end
+
     # ----- Summary -----
 
     summary = doc.createElement('h2')

--- a/mrbgems/picoruby-wasm/demo/www/js_types.html
+++ b/mrbgems/picoruby-wasm/demo/www/js_types.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>JS type system - PicoRuby WASM</title>
+  <link rel="stylesheet" href="test.css">
+</head>
+<body>
+  <div><a href="index.html">Back</a></div>
+  <h1>JS::Object type system</h1>
+  <p>
+    Covers the JS wrapper redesign:
+    primitive auto-conversion, <code>#inspect</code>,
+    and the <code>JS::Array</code> / <code>JS::Function</code> /
+    <code>JS::Promise</code> subclasses.
+  </p>
+  <div id="test-results"></div>
+
+  <script type="text/ruby">
+    require 'js'
+
+    doc = JS.document
+    results = doc.getElementById('test-results')
+
+    def test_case(name, &block)
+      doc = JS.document
+      results = doc.getElementById('test-results')
+      div = doc.createElement('div')
+      div.className = 'test-case'
+
+      begin
+        block.call
+        div.className = 'test-case pass'
+        div.textContent = "PASS: #{name}"
+      rescue => e
+        div.className = 'test-case fail'
+        div.textContent = "FAIL: #{name} - #{e.message}"
+      end
+
+      results.appendChild(div)
+    end
+
+    # ----- Phase 2: primitive auto-conversion -----
+
+    test_case("property getter: string returns Ruby String") do
+      elem = doc.createElement('div')
+      elem.textContent = 'hello'
+      v = elem[:textContent]
+      raise "expected String, got #{v.class}" unless v.is_a?(String)
+      raise "unexpected value: #{v.inspect}" unless v == 'hello'
+    end
+
+    test_case("property getter: number returns Ruby Integer") do
+      elem = doc.createElement('div')
+      elem.tabIndex = 42
+      v = elem[:tabIndex]
+      raise "expected Integer, got #{v.class}" unless v.is_a?(Integer)
+      raise "unexpected value: #{v.inspect}" unless v == 42
+    end
+
+    test_case("property getter: boolean returns true/false") do
+      input = doc.createElement('input')
+      input.setAttribute('type', 'checkbox')
+      input.checked = true
+      v = input[:checked]
+      raise "expected true, got #{v.inspect}" unless v == true
+      raise "class should be TrueClass, got #{v.class}" unless v.is_a?(TrueClass)
+    end
+
+    test_case("property getter: missing returns nil") do
+      elem = doc.createElement('div')
+      raise "missing property should be nil" unless elem[:nonexistent].nil?
+    end
+
+    test_case("method return: native numeric comparison") do
+      elem = doc.createElement('div')
+      elem.tabIndex = 100
+      # No explicit .to_i; Integer operators just work
+      raise "comparison failed" unless elem[:tabIndex] > 50
+      raise "equality failed" unless elem[:tabIndex] == 100
+    end
+
+    # ----- Phase 1: #inspect -----
+
+    test_case("inspect: DOM element shows constructor and attributes") do
+      elem = doc.createElement('section')
+      elem.setAttribute('id', 'foo')
+      elem.setAttribute('class', 'bar')
+      s = elem.inspect
+      raise "no JS::Object prefix: #{s}" unless s.start_with?('#<JS::Object ref:')
+      raise "missing constructor name: #{s}" unless s.include?('HTMLElement') || s.include?('HTMLSectionElement')
+      raise "missing id: #{s}" unless s.include?('id="foo"')
+    end
+
+    test_case("inspect: array shows length and preview") do
+      arr = JS.global.create_array
+      arr.push('a')
+      arr.push(1)
+      arr.push(true)
+      s = arr.inspect
+      raise "no Array label: #{s}" unless s.include?('Array')
+      raise "no length: #{s}" unless s.include?('length=3')
+    end
+
+    test_case("inspect: plain JS object shows keys") do
+      obj = JS.global.create_object
+      obj[:name] = 'alice'
+      obj[:age] = 30
+      s = obj.inspect
+      raise "no name preview: #{s}" unless s.include?('name=')
+    end
+
+    # ----- Phase 3: composite-type subclasses -----
+
+    test_case("JS::Array: dispatch and ancestry") do
+      arr = JS.global.create_array
+      raise "not a JS::Array: #{arr.class}" unless arr.is_a?(JS::Array)
+      raise "not a JS::Object" unless arr.is_a?(JS::Object)
+      raise "Ruby Array conflict" if arr.is_a?(::Array)
+    end
+
+    test_case("JS::Array#size and #length") do
+      arr = JS.global.create_array
+      arr.push(10)
+      arr.push(20)
+      arr.push(30)
+      raise "size mismatch: #{arr.size}" unless arr.size == 3
+      raise "length mismatch: #{arr.length}" unless arr.length == 3
+    end
+
+    test_case("JS::Array#each yields primitives as Ruby values") do
+      arr = JS.global.create_array
+      arr.push(1)
+      arr.push(2)
+      arr.push(3)
+      collected = [] #: ::Array[Integer]
+      arr.each { |v| collected << v }
+      raise "unexpected: #{collected.inspect}" unless collected == [1, 2, 3]
+    end
+
+    test_case("JS::Array Enumerable: #map and #select") do
+      arr = JS.global.create_array
+      arr.push(1)
+      arr.push(2)
+      arr.push(3)
+      arr.push(4)
+      doubled = arr.map { |v| v.to_i * 2 }
+      raise "map: #{doubled.inspect}" unless doubled == [2, 4, 6, 8]
+      evens = arr.select { |v| v.to_i % 2 == 0 }
+      raise "select: #{evens.inspect}" unless evens == [2, 4]
+    end
+
+    test_case("JS::Function: dispatch and #call") do
+      fn = JS.eval('(function(x, y) { return x * y; })')
+      raise "not a JS::Function: #{fn.class}" unless fn.is_a?(JS::Function)
+      raise "not a JS::Object" unless fn.is_a?(JS::Object)
+      result = fn.call(6, 7)
+      raise "call result: #{result.inspect}" unless result == 42
+    end
+
+    test_case("JS::Function#call with string arg") do
+      fn = JS.eval('(function(s) { return s.toUpperCase(); })')
+      result = fn.call('hello')
+      raise "call result: #{result.inspect}" unless result == 'HELLO'
+    end
+
+    test_case("JS::Promise: dispatch via JS.eval") do
+      p = JS.eval('Promise.resolve(99)')
+      raise "not a JS::Promise: #{p.class}" unless p.is_a?(JS::Promise)
+      raise "not a JS::Object" unless p.is_a?(JS::Object)
+    end
+
+    test_case("JS::Promise#await resolves primitive") do
+      p = JS.eval('Promise.resolve("awaited")')
+      value = p.await
+      raise "await result: #{value.inspect}" unless value == 'awaited'
+    end
+
+    test_case("JS::Promise#then yields resolved value") do
+      p = JS.eval('Promise.resolve(7)')
+      seen = nil #: Integer?
+      p.then { |v| seen = v.to_i }
+      raise "then block did not run: got #{seen.inspect}" unless seen == 7
+    end
+
+    # ----- Summary -----
+
+    summary = doc.createElement('h2')
+    summary.textContent = 'All tests completed!'
+    summary.style = 'color: green; margin-top: 20px;'
+    results.appendChild(summary)
+  </script>
+  <script src="init.iife.js"></script>
+</body>
+</html>

--- a/mrbgems/picoruby-wasm/docs/interoperability_between_js_and_ruby.md
+++ b/mrbgems/picoruby-wasm/docs/interoperability_between_js_and_ruby.md
@@ -2,35 +2,46 @@
 
 `JS.global` (= `window`) and `JS.document` are the two entry points into the JavaScript world.
 
-**Reading** always returns a `JS::Object` wrapper (except `null`/`undefined` which become `nil`). **Writing** auto-converts Ruby primitives to JS equivalents.
+**Reading** auto-converts JS primitives (string, number, boolean, null, undefined) into Ruby native values. Composite JS values (object, array, function) are returned as `JS::Object` wrappers. **Writing** auto-converts Ruby primitives to JS equivalents.
 
 ## Reading from JS
 
-Use `[]` for property access, or call methods directly. Always returns `JS::Object`.
+Use `[]` for property access, or call methods directly.
 
 ```ruby
-element  = JS.document.getElementById('myElement')
-nav      = JS.global[:navigator]
-width    = element[:offsetWidth]   #=> JS::Object (JS number)
-text     = element[:textContent]   #=> JS::Object (JS string)
+element  = JS.document.getElementById('myElement')  # JS::Object (DOM element)
+nav      = JS.global[:navigator]                    # JS::Object
+width    = element[:offsetWidth]                    #=> Integer
+text     = element[:textContent]                    #=> String
+hidden   = element[:hidden]                         #=> true / false
+tag      = element[:tagName]                        #=> String
 ```
 
-Convert with explicit methods:
+### Type mapping (JS to Ruby, auto-converted)
 
-| Method | Ruby type |
-|--------|-----------|
-| `.to_s` | String |
-| `.to_i` | Integer |
-| `.to_f` | Float |
-| `.to_a` | Array of JS::Object |
+| JS type     | Ruby type |
+|-------------|-----------|
+| `string`    | `String`   |
+| `number` (integer) | `Integer` |
+| `number` (float)   | `Float`   |
+| `boolean`   | `true` / `false` |
+| `null` / `undefined` | `nil` |
+| `object`    | `JS::Object` |
+| `array`     | `JS::Object` (use `#to_a` to iterate) |
+| `function`  | `JS::Object` |
+| `symbol`    | `JS::Object` |
+| `bigint`    | `JS::Object` |
+
+### Iterating array-like values
+
+`querySelectorAll`, `HTMLCollection`, `NodeList` come back as `JS::Object`. Convert with `#to_a`:
 
 ```ruby
-text  = element[:textContent].to_s
-width = element[:offsetWidth].to_i
-items = doc.querySelectorAll('.item').to_a  # then .each, .map, etc.
+items = JS.document.querySelectorAll('.item').to_a
+items.each { |el| puts el[:textContent] }  # el is a JS::Object, [:textContent] is String
 ```
 
-Only `null` and `undefined` convert automatically to `nil`.
+`#to_a` recursively auto-converts primitives too, so an array of numbers becomes `Array[Integer]`.
 
 ## Writing to JS
 
@@ -82,12 +93,26 @@ JS.global[:Chart].new(canvas, config)
 
 ## Comparison
 
-`==` compares `JS::Object` with Ruby primitives directly. Numeric operators work on JS numbers:
+Primitives come back as Ruby native values, so `==` and numeric operators just work:
 
 ```ruby
-checkbox[:checked] == true          # boolean comparison
-element[:offsetWidth] > 100         # numeric comparison
-element[:id] == "myElement"         # string comparison
+checkbox[:checked] == true          # boolean == boolean
+element[:offsetWidth] > 100         # Integer > Integer
+element[:id] == "myElement"         # String == String
+```
+
+Between two `JS::Object` wrappers, `==` compares the underlying ref_id (identity). A `JS::Object` is never `==` to a Ruby primitive.
+
+## Debugging
+
+`#inspect` returns a readable preview that reflects the JS constructor and key properties:
+
+```ruby
+p JS.document.getElementById('app')
+#=> #<JS::Object ref:87 HTMLDivElement id="app" class="root">
+
+p some_fetch_response
+#=> #<JS::Object ref:42 Response status=200 url="https://...">
 ```
 
 ## See Also

--- a/mrbgems/picoruby-wasm/mrblib/js.rb
+++ b/mrbgems/picoruby-wasm/mrblib/js.rb
@@ -87,8 +87,43 @@ module JS
       success
     end
 
+  end
+
+  # Composite-type subclasses. wrap_ref_as_js_object in js.c picks the right
+  # class based on the JS runtime type of the wrapped value.
+
+  class Array < Object
+    include Enumerable
+
+    # Iterate over the wrapped JS array, yielding each element converted via
+    # js_ref_to_ruby_value (primitives become Ruby native values).
+    # Uses indexed access directly; calling #to_a here would infinite-loop
+    # via Enumerable#to_a -> #each.
+    def each(&block)
+      return self unless block
+      i = 0
+      n = length
+      while i < n
+        yield self[i]
+        i += 1
+      end
+      self
+    end
+
+    def size
+      length
+    end
+  end
+
+  class Function < Object
+    # #call is defined in C on class_JS_Function and invokes the wrapped JS
+    # function value directly (no `this` binding).
+  end
+
+  class Promise < Object
     # Await a JS Promise. Suspends the current Ruby task until the Promise
-    # resolves and returns the result as a JS::Object.
+    # resolves and returns the resolved value (auto-converted to a Ruby
+    # native value if it is a primitive, otherwise wrapped as JS::Object).
     def await
       callback_id = self.object_id
       _await_and_suspend(callback_id)
@@ -113,7 +148,7 @@ module JS
       case value
       when Hash
         hash_to_js_object(value)
-      when Array
+      when ::Array
         array_to_js_array(value)
       else
         value

--- a/mrbgems/picoruby-wasm/mrblib/js.rb
+++ b/mrbgems/picoruby-wasm/mrblib/js.rb
@@ -4,7 +4,7 @@ require 'json'
 module JS
   def self.document
     document = global[:document]
-    if document.is_a?(JS::Object)
+    if document.is_a?(JS::Element)
       document
     else
       raise 'Document object is not available'
@@ -65,14 +65,6 @@ module JS
       $promise_responses.delete(callback_id)
     end
 
-    def to_binary
-      callback_id = self.object_id
-      _to_binary_and_suspend(callback_id)
-      result = $promise_responses[callback_id]
-      $promise_responses.delete(callback_id)
-      result.to_s
-    end
-
     def setTimeout(delay_ms, &block)
       callback_id = block.object_id
       CALLBACKS[callback_id] = block
@@ -118,6 +110,27 @@ module JS
   class Function < Object
     # #call is defined in C on class_JS_Function and invokes the wrapped JS
     # function value directly (no `this` binding).
+  end
+
+  class Response < Object
+    # Read the response body as a binary String. Suspends the current Ruby
+    # task until the underlying ArrayBuffer is materialized.
+    def to_binary
+      callback_id = self.object_id
+      _to_binary_and_suspend(callback_id)
+      result = $promise_responses[callback_id]
+      $promise_responses.delete(callback_id)
+      result.to_s
+    end
+  end
+
+  class Event < Object
+    # #preventDefault and #stopPropagation are defined in C on class_JS_Event.
+  end
+
+  class Element < Object
+    # DOM element / Document. Methods (createElement, appendChild,
+    # setAttribute, etc.) are defined in C on class_JS_Element.
   end
 
   class Promise < Object

--- a/mrbgems/picoruby-wasm/mrblib/webserial.rb
+++ b/mrbgems/picoruby-wasm/mrblib/webserial.rb
@@ -2,8 +2,9 @@ module JS
   class WebSerial
     # Returns true if Web Serial API is available (Chrome / Edge).
     def self.supported?
-      nav = JS.global[:navigator] # steep:ignore
-      nav && (serial = nav[:serial]) && serial.type != "undefined"
+      nav = JS.global[:navigator]
+      return false unless nav.is_a?(JS::Object)
+      nav[:serial].is_a?(JS::Object)
     end
 
     # Request a serial port via the browser picker.

--- a/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
@@ -10,14 +10,14 @@ module JS
       def self.normalize_uuid: (String uuid) -> (Integer | String)
 
       # Build JS array from Ruby array of UUID strings
-      def self.uuids_to_js_array: (Array[String] uuids) -> JS::Object
+      def self.uuids_to_js_array: (::Array[String] uuids) -> JS::Object
 
       # Request a BLE device via browser picker (must be called from user gesture)
       def self.request_device: (
         ?name: String,
         ?name_prefix: String,
-        ?services: Array[String],
-        ?optional_services: Array[String]
+        ?services: ::Array[String],
+        ?optional_services: ::Array[String]
       ) -> JS::BLE::GATT::Device?
 
       class Device

--- a/mrbgems/picoruby-wasm/sig/js.rbs
+++ b/mrbgems/picoruby-wasm/sig/js.rbs
@@ -1,33 +1,28 @@
 module JS
   class Object
     # Global state (consider refactoring)
-    $promise_responses: Hash[Integer, JS::Object]
+    $promise_responses: Hash[Integer, untyped]
     $js_events: Hash[Integer, JS::Object]
     CALLBACKS: Hash[Integer, Proc]
 
     # Property Access
-    # Returns a JS::Object wrapper, or nil for null/undefined.
-    def []: (String | Symbol | Integer name) -> (JS::Object | nil)
+    # Primitive JS values (string, number, boolean, null, undefined) are
+    # auto-converted to the matching Ruby native value. Composite values
+    # (object, array, function, symbol, bigint) are returned as JS::Object.
+    def []: (String | Symbol | Integer name) -> (String | Integer | Float | bool | JS::Object | nil)
     # Setter automatically converts Ruby types to JS types.
     def []=: (String | Symbol name, untyped value) -> untyped
 
-    # Comparison operators
-    # == compares with Ruby native types (String, Integer, Float, true, false)
-    # or with other JS::Object (by ref_id)
+    # Equality.
+    # == compares ref_id to another JS::Object; returns false for any Ruby
+    # native value, which will never match a composite JS::Object anyway.
     def ==: (untyped other) -> bool
 
-    # Integer comparison operators (only work when JS type is number/bigint)
-    def <=>: (Integer | JS::Object other) -> Integer?
-    def >: (Integer | JS::Object other) -> bool
-    def >=: (Integer | JS::Object other) -> bool
-    def <: (Integer | JS::Object other) -> bool
-    def <=: (Integer | JS::Object other) -> bool
-
-    # Explicit Type Conversion Methods
+    # Explicit Type Conversion Methods (fallbacks for composite objects)
     def to_s: () -> String
     def to_i: () -> Integer
     def to_f: () -> Float
-    def to_a: () -> Array[JS::Object]
+    def to_a: () -> Array[untyped]
 
     # Event Handling
     def addEventListener: (String event_type) { (JS::Object event) -> void } -> Integer
@@ -36,8 +31,8 @@ module JS
 
     # Async operations
     def fetch: (String url, ?Hash[Symbol, untyped]? options) { (JS::Object response) -> void } -> void
-    def await: () -> JS::Object?
-    def then: () { (JS::Object? result) -> void } -> JS::Object?
+    def await: () -> untyped
+    def then: () { (untyped result) -> void } -> untyped
     def to_binary: () -> String
 
     # Timer operations
@@ -45,6 +40,7 @@ module JS
     def clearTimeout: (Integer callback_id) -> bool
 
     # Debugging
+    def inspect: () -> String
     def type: () -> Symbol
     def refcount: () -> Integer
 
@@ -61,49 +57,50 @@ module JS
     def stopPropagation: () -> nil
     def highlightAll: () -> void
 
-    # Common properties/methods (examples)
-    # Note: All of these now return a JS::Object wrapper that may need explicit conversion.
+    # Common properties/methods (examples).
+    # Return types reflect the Phase 2 auto-conversion: primitive JS values
+    # come back as Ruby native values; DOM nodes / collections stay wrapped.
     def getElementById: (String id) -> JS::Object?
     def querySelector: (String selector) -> JS::Object?
     def querySelectorAll: (String selector) -> JS::Object # Use .to_a to iterate
     def children: () -> JS::Object # Use .to_a to iterate
     def parentElement: () -> JS::Object?
-    def tagName: () -> JS::Object # Use .to_s
+    def tagName: () -> String
     def style: () -> JS::Object
     def item: (String | Integer num) -> JS::Object?
     def innerHTML=: (String html) -> String
     def textContent=: (String text) -> String
     def body: () -> JS::Object
-    def status: () -> JS::Object # Use .to_i
-    def push: (JS::Object item) -> JS::Object
-    def content: () -> JS::Object # Use .to_s
+    def status: () -> Integer
+    def push: (untyped item) -> Integer
+    def content: () -> String
     def classList: () -> JS::Object
     def add: (*String class_names) -> bool
     def remove: (*String class_names) -> bool
     def target: () -> JS::Object
-    def getAttribute: (String name) -> JS::Object? # Use .to_s
-    def length: () -> JS::Object # Use .to_i
-    def hostname: () -> JS::Object # Use .to_s
-    def href: () -> JS::Object # Use .to_s
+    def getAttribute: (String name) -> String?
+    def length: () -> Integer
+    def hostname: () -> String
+    def href: () -> String
 
     def URL: () -> JS::Object
     def history: () -> JS::Object
     def location: () -> JS::Object
-    def pathname: () -> JS::Object
+    def pathname: () -> String
     def pushState: (untyped data, String title, String url) -> void
     def replaceState: (untyped data, String title, String url) -> void
-    def createObjectURL: (JS::Object blob) -> JS::Object
+    def createObjectURL: (JS::Object blob) -> String
     def create_object: () -> JS::Object
     def create_array: () -> JS::Object
 
     # localStorage methods
     def setItem: (String key, String value) -> void
-    def getItem: (String key) -> JS::Object?
+    def getItem: (String key) -> String?
     def removeItem: (String key) -> void
 
     def _js_remove_event_listener_wrapper: (Integer callback_id) -> bool
 
-    private def method_missing: (Symbol method_name, *untyped args) -> (JS::Object | nil)
+    private def method_missing: (Symbol method_name, *untyped args) -> untyped
     private def _add_event_listener: (Integer callback_id, String event_type) -> nil
     private def self._register_callback: (Integer callback_id, String name) -> nil
     private def _removeEventListener: (Integer callback_id) -> bool
@@ -125,4 +122,3 @@ module JS
     def self.array_to_js_array: (Array[untyped] array) -> JS::Object
   end
 end
-

--- a/mrbgems/picoruby-wasm/sig/js.rbs
+++ b/mrbgems/picoruby-wasm/sig/js.rbs
@@ -25,13 +25,12 @@ module JS
     def to_a: () -> ::Array[untyped]
 
     # Event Handling
-    def addEventListener: (String event_type) { (JS::Object event) -> void } -> Integer
+    def addEventListener: (String event_type) { (JS::Event event) -> void } -> Integer
     def self.removeEventListener: (Integer callback_id) -> bool
     def self.register_callback: (String name) { (*untyped args) -> untyped } -> Integer
 
     # Async operations
-    def fetch: (String url, ?Hash[Symbol, untyped]? options) { (JS::Object response) -> void } -> void
-    def to_binary: () -> String
+    def fetch: (String url, ?Hash[Symbol, untyped]? options) { (JS::Response response) -> void } -> void
 
     # Timer operations
     def setTimeout: (Integer delay_ms) { () -> void } -> Integer
@@ -39,43 +38,31 @@ module JS
 
     # Debugging
     def inspect: () -> String
-    def type: () -> Symbol
+    def typeof: () -> Symbol
     def refcount: () -> Integer
 
-    # DOM manipulation methods defined in C
-    def createElement: (String tag_name) -> JS::Object
-    def createTextNode: (String text) -> JS::Object
-    def appendChild: (JS::Object child) -> bool
-    def removeChild: (JS::Object child) -> bool
-    def replaceChild: (JS::Object new_child, JS::Object old_child) -> bool
-    def insertBefore: (JS::Object new_child, ?JS::Object? ref_child) -> bool
-    def setAttribute: (String name, String value) -> bool
-    def removeAttribute: (String name) -> bool
-    def preventDefault: () -> nil
-    def stopPropagation: () -> nil
     def highlightAll: () -> void
 
     # Common properties/methods (examples).
     # Return types reflect the Phase 2 auto-conversion: primitive JS values
     # come back as Ruby native values; DOM nodes / collections stay wrapped.
-    def getElementById: (String id) -> JS::Object?
-    def querySelector: (String selector) -> JS::Object?
+    def querySelector: (String selector) -> JS::Element?
     def querySelectorAll: (String selector) -> JS::Object # Use .to_a to iterate
     def children: () -> JS::Object # Use .to_a to iterate
-    def parentElement: () -> JS::Object?
+    def parentElement: () -> JS::Element?
     def tagName: () -> String
     def style: () -> JS::Object
     def item: (String | Integer num) -> JS::Object?
     def innerHTML=: (String html) -> String
     def textContent=: (String text) -> String
-    def body: () -> JS::Object
+    def body: () -> JS::Element
     def status: () -> Integer
     def push: (untyped item) -> Integer
     def content: () -> String
     def classList: () -> JS::Object
     def add: (*String class_names) -> bool
     def remove: (*String class_names) -> bool
-    def target: () -> JS::Object
+    def target: () -> JS::Element
     def getAttribute: (String name) -> String?
     def length: () -> Integer
     def hostname: () -> String
@@ -89,7 +76,7 @@ module JS
     def replaceState: (untyped data, String title, String url) -> void
     def createObjectURL: (JS::Object blob) -> String
     def create_object: () -> JS::Object
-    def create_array: () -> JS::Object
+    def create_array: () -> JS::Array
 
     # localStorage methods
     def setItem: (String key, String value) -> void
@@ -104,7 +91,6 @@ module JS
     private def _removeEventListener: (Integer callback_id) -> bool
     private def _fetch_and_suspend: (String url, Integer callback_id) -> nil
     private def _fetch_with_options_and_suspend: (String url, String options_json, Integer callback_id) -> nil
-    private def _to_binary_and_suspend: (Integer callback_id) -> nil
     private def _await_and_suspend: (Integer callback_id) -> nil
     private def _set_timeout: (Integer callback_id, Integer delay_ms) -> Integer
     private def _clear_timeout: (Integer callback_id) -> bool
@@ -128,9 +114,34 @@ module JS
     def then: () { (untyped result) -> void } -> untyped
   end
 
+  # DOM-domain subclasses. Methods that only make sense on these types
+  # live here so type checkers can reject misuse on a plain JS::Object.
+
+  class Event < Object
+    def preventDefault: () -> nil
+    def stopPropagation: () -> nil
+  end
+
+  class Response < Object
+    def to_binary: () -> String
+    private def _to_binary_and_suspend: (Integer callback_id) -> nil
+  end
+
+  class Element < Object
+    def createElement: (String tag_name) -> JS::Element
+    def createTextNode: (String text) -> JS::Object
+    def appendChild: (JS::Object child) -> bool
+    def removeChild: (JS::Object child) -> bool
+    def replaceChild: (JS::Object new_child, JS::Object old_child) -> bool
+    def insertBefore: (JS::Object new_child, ?JS::Object? ref_child) -> bool
+    def setAttribute: (String name, String value) -> bool
+    def removeAttribute: (String name) -> bool
+    def getElementById: (String id) -> JS::Element?
+  end
+
   def self.global: () -> JS::Object
   def self.generic_callbacks: () -> JS::Object
-  def self.document: () -> JS::Object
+  def self.document: () -> JS::Element
 
   module Bridge
     def self.to_js: (untyped value) -> untyped

--- a/mrbgems/picoruby-wasm/sig/js.rbs
+++ b/mrbgems/picoruby-wasm/sig/js.rbs
@@ -22,7 +22,7 @@ module JS
     def to_s: () -> String
     def to_i: () -> Integer
     def to_f: () -> Float
-    def to_a: () -> Array[untyped]
+    def to_a: () -> ::Array[untyped]
 
     # Event Handling
     def addEventListener: (String event_type) { (JS::Object event) -> void } -> Integer
@@ -31,8 +31,6 @@ module JS
 
     # Async operations
     def fetch: (String url, ?Hash[Symbol, untyped]? options) { (JS::Object response) -> void } -> void
-    def await: () -> untyped
-    def then: () { (untyped result) -> void } -> untyped
     def to_binary: () -> String
 
     # Timer operations
@@ -112,6 +110,24 @@ module JS
     private def _clear_timeout: (Integer callback_id) -> bool
   end
 
+  # Composite-type subclasses. wrap_ref_as_js_object in js.c dispatches
+  # to these based on the JS runtime type.
+  class Array < Object
+    include Enumerable[untyped]
+    def each: () { (untyped) -> void } -> self
+    def size: () -> Integer
+    def length: () -> Integer
+  end
+
+  class Function < Object
+    def call: (*untyped) -> untyped
+  end
+
+  class Promise < Object
+    def await: () -> untyped
+    def then: () { (untyped result) -> void } -> untyped
+  end
+
   def self.global: () -> JS::Object
   def self.generic_callbacks: () -> JS::Object
   def self.document: () -> JS::Object
@@ -119,6 +135,6 @@ module JS
   module Bridge
     def self.to_js: (untyped value) -> untyped
     def self.hash_to_js_object: (Hash[untyped, untyped] hash) -> JS::Object
-    def self.array_to_js_array: (Array[untyped] array) -> JS::Object
+    def self.array_to_js_array: (::Array[untyped] array) -> JS::Object
   end
 end

--- a/mrbgems/picoruby-wasm/sig/webserial.rbs
+++ b/mrbgems/picoruby-wasm/sig/webserial.rbs
@@ -9,8 +9,8 @@ module JS
     # Show the browser's port picker and return a JS::WebSerial wrapping the
     # chosen port (or nil if the user cancelled).
     # Yields the result to the block when a block is given.
-    def self.request_port: (?filters: Array[untyped]) -> JS::WebSerial?
-                         | (?filters: Array[untyped]) { (JS::WebSerial?) -> void } -> JS::WebSerial?
+    def self.request_port: (?filters: ::Array[untyped]) -> JS::WebSerial?
+                         | (?filters: ::Array[untyped]) { (JS::WebSerial?) -> void } -> JS::WebSerial?
 
     # Request a serial port and open it with one call.
     # Yields the opened JS::WebSerial instance to the block.
@@ -33,9 +33,9 @@ module JS
     def close: () -> nil
     def opened?: () -> bool
     # Write bytes in chunks, returning a promise that resolves when flushed.
-    def write_bytes: (String bytes, ?chunk_size: Integer) -> JS::Object
+    def write_bytes: (String bytes, ?chunk_size: Integer) -> JS::Promise
     # Wait for pending writes to flush (returns a Promise).
-    def drain: () -> JS::Object
+    def drain: () -> JS::Promise
     # Pipe decoded serial text directly to an xterm.js terminal.
     def start_terminal_read: () -> nil
     # Start capturing serial output.
@@ -51,11 +51,11 @@ module JS
     # Class methods for internal use by the JavaScript glue code.
     def self._start_reading: (JS::Object js_port, Integer callback_id) -> nil
     def self._set_on_disconnect: (JS::Object js_port, Integer callback_id) -> nil
-    def self._open_port: (JS::Object js_port, JS::Object options) -> JS::Object
-    def self._request_port: () -> JS::Object
+    def self._open_port: (JS::Object js_port, JS::Object options) -> JS::Promise
+    def self._request_port: () -> JS::Promise
     def self._watch_connect_events: () -> nil
     def self._take_last_connected_port: () -> JS::Object?
     def self._close_port: (JS::Object js_port) -> nil
-    def self._close_port_promise: (JS::Object js_port) -> JS::Object
+    def self._close_port_promise: (JS::Object js_port) -> JS::Promise
   end
 end

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -2482,6 +2482,116 @@ mrb_js_eval(mrb_state *mrb, mrb_value klass)
   return js_ref_to_ruby_value(mrb, ref_id);
 }
 
+/*
+ * Build a short, human-readable preview of the JS value at ref_id
+ * and write it into buf (UTF-8, NUL-terminated).
+ * Used by JS::Object#inspect.
+ */
+EM_JS(void, js_inspect_to_buffer, (int ref_id, char* buf, int buf_size), {
+  function clip(s, max) {
+    if (s.length > max) return s.slice(0, max - 3) + '...';
+    return s;
+  }
+  function previewValue(val) {
+    if (val === null) return 'null';
+    if (val === undefined) return 'undefined';
+    const t = typeof val;
+    if (t === 'string') return JSON.stringify(val);
+    if (t === 'number' || t === 'boolean') return String(val);
+    if (t === 'bigint') return val.toString() + 'n';
+    if (t === 'symbol') return val.toString();
+    if (t === 'function') return 'function';
+    return '...';
+  }
+  let result;
+  try {
+    const v = globalThis.picorubyRefs[ref_id];
+    if (v === null) {
+      result = 'null';
+    } else if (v === undefined) {
+      result = 'undefined';
+    } else if (typeof v === 'string') {
+      result = 'String ' + clip(JSON.stringify(v), 120);
+    } else if (typeof v === 'number') {
+      result = 'Number ' + String(v);
+    } else if (typeof v === 'boolean') {
+      result = 'Boolean ' + (v ? 'true' : 'false');
+    } else if (typeof v === 'bigint') {
+      result = 'BigInt ' + v.toString() + 'n';
+    } else if (typeof v === 'symbol') {
+      result = 'Symbol ' + v.toString();
+    } else if (typeof v === 'function') {
+      const name = v.name && v.name.length > 0 ? v.name : '(anonymous)';
+      result = 'Function ' + name;
+    } else if (Array.isArray(v)) {
+      const len = v.length;
+      const sample = v.slice(0, 5).map(previewValue).join(',');
+      const preview = len > 5 ? '[' + sample + ',...]' : '[' + sample + ']';
+      result = 'Array length=' + len + ' ' + clip(preview, 120);
+    } else {
+      let ctor = 'Object';
+      try {
+        if (v.constructor && v.constructor.name) ctor = v.constructor.name;
+      } catch (e) {}
+      let extras = '';
+      try {
+        if (typeof Event !== 'undefined' && v instanceof Event) {
+          if (v.type) extras += ' type=' + JSON.stringify(String(v.type));
+        } else if (typeof Response !== 'undefined' && v instanceof Response) {
+          if (v.status !== undefined) extras += ' status=' + v.status;
+          if (v.url) extras += ' url=' + JSON.stringify(String(v.url));
+        } else if (typeof Element !== 'undefined' && v instanceof Element) {
+          if (v.id) extras += ' id=' + JSON.stringify(String(v.id));
+          const cls = v.getAttribute && v.getAttribute('class');
+          if (cls) extras += ' class=' + JSON.stringify(String(cls));
+        } else {
+          const keys = Object.keys(v).slice(0, 3);
+          if (keys.length > 0) {
+            const items = keys.map(function(k) {
+              return k + '=' + previewValue(v[k]);
+            });
+            extras = ' ' + items.join(' ');
+            if (Object.keys(v).length > 3) extras += ' ...';
+          }
+        }
+      } catch (e) {}
+      result = ctor + extras;
+    }
+  } catch (e) {
+    result = '<inspect error: ' + (e && e.message ? e.message : 'unknown') + '>';
+  }
+  if (buf_size > 0) {
+    if (result.length > buf_size - 1) {
+      result = result.slice(0, buf_size - 4) + '...';
+    }
+    stringToUTF8(result, buf, buf_size);
+  }
+});
+
+/*
+ * JS::Object#inspect
+ * Returns a readable representation such as:
+ *   #<JS::Object ref:87 HTMLDivElement id="foo" class="bar">
+ *   #<JS::Object ref:42 Array length=3 [1,2,"x"]>
+ *   #<JS::Object ref:8 Number 3.14>
+ */
+static mrb_value
+mrb_object_inspect(mrb_state *mrb, mrb_value self)
+{
+  picorb_js_obj *obj = (picorb_js_obj *)DATA_PTR(self);
+  char body[384];
+  body[0] = '\0';
+  js_inspect_to_buffer(obj->ref_id, body, sizeof(body));
+
+  char head[48];
+  snprintf(head, sizeof(head), "#<JS::Object ref:%d ", obj->ref_id);
+
+  mrb_value result = mrb_str_new_cstr(mrb, head);
+  mrb_str_cat_cstr(mrb, result, body);
+  mrb_str_cat_lit(mrb, result, ">");
+  return result;
+}
+
 
 void
 mrb_js_init(mrb_state *mrb)
@@ -2507,6 +2617,7 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(method_missing), mrb_object_method_missing, MRB_ARGS_ANY());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_a), mrb_object_to_a, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_s), mrb_object_to_s, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(inspect), mrb_object_inspect, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_f), mrb_object_to_f, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_i), mrb_object_to_i, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_add_event_listener), mrb_object__add_event_listener, MRB_ARGS_REQ(2));

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -251,12 +251,6 @@ EM_JS(void, copy_string_value, (int ref_id, char* buffer, int buffer_size), {
   stringToUTF8(str, buffer, buffer_size);
 });
 
-// String comparison for JS::Object#==
-EM_JS(bool, js_string_equals, (int ref_id, const char* ruby_str, int ruby_str_len), {
-  const js_str = globalThis.picorubyRefs[ref_id];
-  return js_str === UTF8ToString(ruby_str, ruby_str_len);
-});
-
 EM_JS(int, get_length, (int ref_id), {
   try {
     const obj = globalThis.picorubyRefs[ref_id];
@@ -1019,8 +1013,12 @@ wrap_ref_as_js_object(mrb_state *mrb, int ref_id)
 }
 
 /*
- * Helper: convert ref_id to Ruby value based on JS type
- * Returns nil for undefined/null, otherwise wraps as JS::Object
+ * Helper: convert ref_id to Ruby value based on JS type.
+ *
+ * Primitive JS values (string / number / boolean / null / undefined) are
+ * unwrapped to Ruby native values (String / Integer / Float / true / false / nil).
+ * Composite values (object / array / function / symbol / bigint) are wrapped
+ * as JS::Object.
  */
 static mrb_value
 js_ref_to_ruby_value(mrb_state *mrb, int ref_id)
@@ -1029,10 +1027,30 @@ js_ref_to_ruby_value(mrb_state *mrb, int ref_id)
     return mrb_nil_value();
   }
   int js_type = get_js_type(ref_id);
-  if (js_type == JS_TYPE_UNDEFINED || js_type == JS_TYPE_NULL) {
-    return mrb_nil_value();
+  switch (js_type) {
+    case JS_TYPE_UNDEFINED:
+    case JS_TYPE_NULL:
+      return mrb_nil_value();
+    case JS_TYPE_BOOLEAN:
+      return get_boolean_value(ref_id) ? mrb_true_value() : mrb_false_value();
+    case JS_TYPE_NUMBER: {
+      double num = get_number_value(ref_id);
+      if (num == (double)(mrb_int)num) {
+        return mrb_fixnum_value((mrb_int)num);
+      }
+      return mrb_float_value(mrb, num);
+    }
+    case JS_TYPE_STRING: {
+      int str_len = get_string_value_length(ref_id);
+      char *buffer = (char *)mrb_malloc(mrb, str_len + 1);
+      copy_string_value(ref_id, buffer, str_len + 1);
+      mrb_value str = mrb_str_new_cstr(mrb, buffer);
+      mrb_free(mrb, buffer);
+      return str;
+    }
+    default:
+      return wrap_ref_as_js_object(mrb, ref_id);
   }
-  return wrap_ref_as_js_object(mrb, ref_id);
 }
 
 /*
@@ -1247,7 +1265,7 @@ resume_promise_task(uintptr_t mrb_ptr, uintptr_t task_ptr, uintptr_t callback_id
     mrb_gv_set(mrb, MRB_GVSYM(promise_responses), responses);
   }
 
-  mrb_value response = wrap_ref_as_js_object(mrb, result_id);
+  mrb_value response = js_ref_to_ruby_value(mrb, result_id);
 
   mrb_hash_set(mrb, responses, mrb_fixnum_value(callback_id), response);
 
@@ -1303,38 +1321,7 @@ call_ruby_callback_sync_generic(uintptr_t callback_id, int *arg_ref_ids, int arg
   // Convert JavaScript arguments to Ruby array
   mrb_value args_array = mrb_ary_new_capa(global_mrb, argc);
   for (int i = 0; i < argc; i++) {
-    int ref_id = arg_ref_ids[i];
-    int js_type = get_js_type(ref_id);
-    mrb_value arg_value;
-
-    switch (js_type) {
-      case JS_TYPE_UNDEFINED:
-      case JS_TYPE_NULL:
-        arg_value = mrb_nil_value();
-        break;
-      case JS_TYPE_NUMBER:
-        {
-          double num = get_number_value(ref_id);
-          if (num == (int)num) {
-            arg_value = mrb_fixnum_value((mrb_int)num);
-          } else {
-            arg_value = mrb_float_value(global_mrb, num);
-          }
-        }
-        break;
-      case JS_TYPE_STRING:
-        {
-          int str_len = get_string_value_length(ref_id);
-          char *buffer = (char *)mrb_malloc(global_mrb, str_len + 1);
-          copy_string_value(ref_id, buffer, str_len + 1);
-          arg_value = mrb_str_new_cstr(global_mrb, buffer);
-          mrb_free(global_mrb, buffer);
-        }
-        break;
-      default:
-        arg_value = wrap_ref_as_js_object(global_mrb, ref_id);
-        break;
-    }
+    mrb_value arg_value = js_ref_to_ruby_value(global_mrb, arg_ref_ids[i]);
     mrb_ary_push(global_mrb, args_array, arg_value);
   }
 
@@ -1411,13 +1398,6 @@ get_js_property(mrb_state *mrb, int parent_ref_id, const char* property_name)
   int ref_id = get_property(parent_ref_id, property_name);
   return js_ref_to_ruby_value(mrb, ref_id);
 }
-
-// Function prototypes for explicit conversion methods
-static mrb_value mrb_object_to_a(mrb_state *mrb, mrb_value self);
-static mrb_value mrb_object_to_s(mrb_state *mrb, mrb_value self);
-static mrb_value mrb_object_to_i(mrb_state *mrb, mrb_value self);
-static mrb_value mrb_object_to_f(mrb_state *mrb, mrb_value self);
-
 
 /*
  * JS::Object#[]
@@ -1550,7 +1530,9 @@ mrb_object__await_and_suspend(mrb_state *mrb, mrb_value self)
 
 /*
  * JS::Object#==
- * Compares JS::Object with Ruby native types or other JS::Object
+ * Since Phase 2, primitive JS values are auto-converted to Ruby native
+ * values, so self here is always a composite JS::Object (object / array /
+ * function / symbol / bigint). Equality therefore reduces to ref_id match.
  */
 static mrb_value
 mrb_object_eq(mrb_state *mrb, mrb_value self)
@@ -1559,146 +1541,11 @@ mrb_object_eq(mrb_state *mrb, mrb_value self)
   mrb_value other;
   mrb_get_args(mrb, "o", &other);
 
-  int js_type = get_js_type(js_obj->ref_id);
-
-  switch (js_type) {
-    case JS_TYPE_STRING:
-      if (mrb_string_p(other)) {
-        const char *ruby_str = RSTRING_PTR(other);
-        int ruby_str_len = RSTRING_LEN(other);
-        return js_string_equals(js_obj->ref_id, ruby_str, ruby_str_len) ? mrb_true_value() : mrb_false_value();
-      }
-      break;
-
-    case JS_TYPE_NUMBER:
-    case JS_TYPE_BIGINT:
-      if (mrb_integer_p(other)) {
-        double js_num = get_number_value(js_obj->ref_id);
-        return js_num == (double)mrb_integer(other) ? mrb_true_value() : mrb_false_value();
-      }
-      if (mrb_float_p(other)) {
-        double js_num = get_number_value(js_obj->ref_id);
-        return js_num == mrb_float(other) ? mrb_true_value() : mrb_false_value();
-      }
-      break;
-
-    case JS_TYPE_BOOLEAN:
-      if (mrb_true_p(other)) {
-        return get_boolean_value(js_obj->ref_id) ? mrb_true_value() : mrb_false_value();
-      }
-      if (mrb_false_p(other)) {
-        return get_boolean_value(js_obj->ref_id) ? mrb_false_value() : mrb_true_value();
-      }
-      break;
-
-    default:
-      break;
-  }
-
-  // Compare ref_id if both are JS::Object
   if (mrb_obj_is_kind_of(mrb, other, class_JS_Object)) {
     picorb_js_obj *other_obj = (picorb_js_obj *)DATA_PTR(other);
-    return js_obj->ref_id == other_obj->ref_id ? mrb_true_value() : mrb_false_value();
+    return mrb_bool_value(js_obj->ref_id == other_obj->ref_id);
   }
-
   return mrb_false_value();
-}
-
-/*
- * JS::Object#<=>
- * Comparison operator for numeric JS::Object
- * Returns -1, 0, 1, or nil
- */
-static mrb_value
-mrb_object_cmp(mrb_state *mrb, mrb_value self)
-{
-  picorb_js_obj *js_obj = (picorb_js_obj *)DATA_PTR(self);
-  mrb_value other;
-  mrb_get_args(mrb, "o", &other);
-
-  int js_type = get_js_type(js_obj->ref_id);
-
-  if (js_type != JS_TYPE_NUMBER && js_type != JS_TYPE_BIGINT) {
-    return mrb_nil_value();
-  }
-
-  double js_num = get_number_value(js_obj->ref_id);
-  double other_num;
-
-  if (mrb_integer_p(other)) {
-    other_num = (double)mrb_integer(other);
-  } else if (mrb_float_p(other)) {
-    other_num = mrb_float(other);
-  } else if (mrb_obj_is_kind_of(mrb, other, class_JS_Object)) {
-    picorb_js_obj *other_obj = (picorb_js_obj *)DATA_PTR(other);
-    int other_type = get_js_type(other_obj->ref_id);
-    if (other_type != JS_TYPE_NUMBER && other_type != JS_TYPE_BIGINT) {
-      return mrb_nil_value();
-    }
-    other_num = get_number_value(other_obj->ref_id);
-  } else {
-    return mrb_nil_value();
-  }
-
-  if (js_num < other_num) {
-    return mrb_fixnum_value(-1);
-  } else if (js_num > other_num) {
-    return mrb_fixnum_value(1);
-  } else {
-    return mrb_fixnum_value(0);
-  }
-}
-
-/*
- * JS::Object#>
- */
-static mrb_value
-mrb_object_gt(mrb_state *mrb, mrb_value self)
-{
-  mrb_value cmp_result = mrb_object_cmp(mrb, self);
-  if (mrb_nil_p(cmp_result)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "comparison failed");
-  }
-  return mrb_integer(cmp_result) > 0 ? mrb_true_value() : mrb_false_value();
-}
-
-/*
- * JS::Object#>=
- */
-static mrb_value
-mrb_object_ge(mrb_state *mrb, mrb_value self)
-{
-  mrb_value cmp_result = mrb_object_cmp(mrb, self);
-  if (mrb_nil_p(cmp_result)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "comparison failed");
-  }
-  return mrb_integer(cmp_result) >= 0 ? mrb_true_value() : mrb_false_value();
-}
-
-/*
- * JS::Object#<
- */
-static mrb_value
-mrb_object_lt(mrb_state *mrb, mrb_value self)
-{
-  mrb_value cmp_result = mrb_object_cmp(mrb, self);
-  if (mrb_nil_p(cmp_result)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "comparison failed");
-  }
-  return mrb_integer(cmp_result) < 0 ? mrb_true_value() : mrb_false_value();
-}
-
-/*
- * JS::Object#<=
- */
-static mrb_value
-mrb_object_le(mrb_state *mrb, mrb_value self)
-{
-  mrb_value cmp_result = mrb_object_cmp(mrb, self);
-  if (mrb_nil_p(cmp_result)) {
-    mrb_raise(mrb, E_TYPE_ERROR, "comparison failed");
-  }
-  return mrb_integer(cmp_result) <= 0 ? mrb_true_value() : mrb_false_value();
 }
 
 /*
@@ -2030,41 +1877,7 @@ mrb_object_to_a(mrb_state *mrb, mrb_value self)
   mrb_value array = mrb_ary_new_capa(mrb, length);
   for (int i = 0; i < length; i++) {
     int element_ref_id = get_element(ref_id, i);
-    mrb_value element;
-
-    if (element_ref_id < 0) {
-      element = mrb_nil_value();
-    } else {
-      int element_type = get_js_type(element_ref_id);
-      switch (element_type) {
-        case JS_TYPE_UNDEFINED:
-        case JS_TYPE_NULL:
-          element = mrb_nil_value();
-          break;
-        case JS_TYPE_NUMBER:
-          {
-            double num = get_number_value(element_ref_id);
-            if (num == (int)num) {
-              element = mrb_fixnum_value((mrb_int)num);
-            } else {
-              element = mrb_float_value(mrb, num);
-            }
-          }
-          break;
-        case JS_TYPE_STRING:
-          {
-            int str_len = get_string_value_length(element_ref_id);
-            char *buffer = (char *)mrb_malloc(mrb, str_len + 1);
-            copy_string_value(element_ref_id, buffer, str_len + 1);
-            element = mrb_str_new_cstr(mrb, buffer);
-            mrb_free(mrb, buffer);
-          }
-          break;
-        default:
-          element = wrap_ref_as_js_object(mrb, element_ref_id);
-          break;
-      }
-    }
+    mrb_value element = js_ref_to_ruby_value(mrb, element_ref_id);
     mrb_ary_push(mrb, array, element);
   }
   return array;
@@ -2072,83 +1885,43 @@ mrb_object_to_a(mrb_state *mrb, mrb_value self)
 
 /*
  * JS::Object#to_s
+ * Since Phase 2, primitive JS values are auto-converted to Ruby native
+ * strings/numbers at the C boundary. This fallback runs only for composite
+ * JS::Object (object / array / function / symbol / bigint) and returns a
+ * short identifier; use #inspect for the human-readable preview.
  */
 static mrb_value
 mrb_object_to_s(mrb_state *mrb, mrb_value self)
 {
   picorb_js_obj *js_obj = (picorb_js_obj *)DATA_PTR(self);
-  int ref_id = js_obj->ref_id;
-  int js_type = get_js_type(ref_id);
-
-  switch (js_type) {
-    case JS_TYPE_UNDEFINED:
-    case JS_TYPE_NULL:
-      return mrb_str_new_cstr(mrb, "");
-    case JS_TYPE_BOOLEAN:
-      return get_boolean_value(ref_id) ? mrb_str_new_cstr(mrb, "true") : mrb_str_new_cstr(mrb, "false");
-    case JS_TYPE_NUMBER:
-      {
-        mrb_value ruby_int_obj = mrb_object_to_i(mrb, self);
-        return mrb_funcall_id(mrb, ruby_int_obj, MRB_SYM(to_s), 0);
-      }
-    case JS_TYPE_STRING:
-      {
-        int str_len = get_string_value_length(ref_id);
-        char *buffer = (char *)mrb_malloc(mrb, str_len + 1);
-        copy_string_value(ref_id, buffer, str_len + 1);
-        mrb_value str = mrb_str_new_cstr(mrb, buffer);
-        mrb_free(mrb, buffer);
-        return str;
-      }
-    default:
-      {
-        char buffer[64];
-        snprintf(buffer, sizeof(buffer), "#<JS::Object:0x%x(ref:%d)>", (unsigned int)js_obj, ref_id);
-        return mrb_str_new_cstr(mrb, buffer);
-      }
-  }
+  char buffer[64];
+  snprintf(buffer, sizeof(buffer), "#<JS::Object:0x%x(ref:%d)>",
+           (unsigned int)js_obj, js_obj->ref_id);
+  return mrb_str_new_cstr(mrb, buffer);
 }
 
 /*
  * JS::Object#to_f
+ * Fallback for composite JS::Object; numeric JS values are already
+ * converted to Ruby Float/Integer and never reach this method.
  */
 static mrb_value
 mrb_object_to_f(mrb_state *mrb, mrb_value self)
 {
-  picorb_js_obj *js_obj = (picorb_js_obj *)DATA_PTR(self);
-  int ref_id = js_obj->ref_id;
-  int js_type = get_js_type(ref_id);
-
-  if (js_type == JS_TYPE_NUMBER) {
-    double value = get_number_value(ref_id);
-    return mrb_float_value(mrb, value);
-  } else if (js_type == JS_TYPE_STRING) {
-    mrb_value str_obj = mrb_object_to_s(mrb, self);
-    return mrb_funcall_id(mrb, str_obj, MRB_SYM(to_f), 0);
-  } else {
-    return mrb_float_value(mrb, 0.0);
-  }
+  (void)self;
+  return mrb_float_value(mrb, 0.0);
 }
 
 /*
  * JS::Object#to_i
+ * Fallback for composite JS::Object; numeric JS values are already
+ * converted to Ruby Integer and never reach this method.
  */
 static mrb_value
 mrb_object_to_i(mrb_state *mrb, mrb_value self)
 {
-  picorb_js_obj *js_obj = (picorb_js_obj *)DATA_PTR(self);
-  int ref_id = js_obj->ref_id;
-  int js_type = get_js_type(ref_id);
-
-  if (js_type == JS_TYPE_NUMBER) {
-    double value = get_number_value(ref_id);
-    return mrb_fixnum_value((mrb_int)value);
-  } else if (js_type == JS_TYPE_STRING) {
-    mrb_value str_obj = mrb_object_to_s(mrb, self);
-    return mrb_funcall_id(mrb, str_obj, MRB_SYM(to_i), 0);
-  } else {
-    return mrb_fixnum_value(0);
-  }
+  (void)self;
+  return mrb_fixnum_value(0);
 }
 
 
@@ -2609,11 +2382,6 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(aref), mrb_object_get_property, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(aset), mrb_object_set_property, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(eq), mrb_object_eq, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(cmp), mrb_object_cmp, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(gt), mrb_object_gt, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(ge), mrb_object_ge, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(lt), mrb_object_lt, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_OPSYM(le), mrb_object_le, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(method_missing), mrb_object_method_missing, MRB_ARGS_ANY());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_a), mrb_object_to_a, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_s), mrb_object_to_s, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -39,6 +39,16 @@ typedef enum {
 } js_value_type;
 
 struct RClass *class_JS_Object;
+struct RClass *class_JS_Array;
+struct RClass *class_JS_Function;
+struct RClass *class_JS_Promise;
+
+typedef enum {
+  JS_COMPOSITE_PLAIN = 0,
+  JS_COMPOSITE_ARRAY = 1,
+  JS_COMPOSITE_FUNCTION = 2,
+  JS_COMPOSITE_PROMISE = 3
+} js_composite_kind;
 
 static void
 picorb_js_obj_free(mrb_state *mrb, void *ptr)
@@ -235,6 +245,21 @@ EM_JS(int, get_js_property_type, (int ref_id, const char* property_name), {
 
 EM_JS(bool, get_boolean_value, (int ref_id), {
   return globalThis.picorubyRefs[ref_id] ? true : false;
+});
+
+// Classify a composite JS value into an enum used to pick the Ruby class
+// (JS::Object / JS::Array / JS::Function / JS::Promise) when wrapping.
+// Only meaningful for values that get_js_type returned as composite.
+EM_JS(int, js_classify_composite, (int ref_id), {
+  try {
+    const v = globalThis.picorubyRefs[ref_id];
+    if (Array.isArray(v)) return 1;
+    if (typeof v === 'function') return 2;
+    if (typeof Promise !== 'undefined' && v instanceof Promise) return 3;
+    return 0;
+  } catch(e) {
+    return 0;
+  }
 });
 
 EM_JS(double, get_number_value, (int ref_id), {
@@ -559,6 +584,46 @@ EM_JS(int, call_constructor_with_args, (int ref_id, const char* args_json, int a
     return newRefId;
   } catch(e) {
     console.error('Error in call_constructor_with_args:', e);
+    return -1;
+  }
+});
+
+// Invoke a JS function value directly (no `this` binding). The caller passes
+// arguments as a JSON array encoded with the same tagged-value format used by
+// call_method_with_args. Used by JS::Function#call.
+EM_JS(int, js_function_apply_args, (int func_ref_id, const char* args_json, int args_json_len), {
+  try {
+    const fn = globalThis.picorubyRefs[func_ref_id];
+    if (typeof fn !== 'function') {
+      console.error('js_function_apply_args: not a function');
+      return -1;
+    }
+    const argsData = JSON.parse(UTF8ToString(args_json, args_json_len));
+    if (!Array.isArray(argsData)) {
+      console.error('js_function_apply_args: args_json must be a JSON array');
+      return -1;
+    }
+    const args = argsData.map(arg => {
+      switch (arg.type) {
+        case 'string':
+        case 'integer':
+        case 'float':
+        case 'boolean':
+          return arg.value;
+        case 'ref':
+          return globalThis.picorubyRefs[arg.value];
+        case 'nil':
+          return null;
+        default:
+          return null;
+      }
+    });
+    const result = fn(...args);
+    const newRefId = globalThis.picorubyRefs.length;
+    globalThis.picorubyRefs.push(result);
+    return newRefId;
+  } catch(e) {
+    console.error('Error in js_function_apply_args:', e);
     return -1;
   }
 });
@@ -1002,14 +1067,23 @@ EM_JS(void, js_get_type_info, (int ref_id, js_type_info* info), {
  *****************************************************/
 
 /*
- * Helper: wrap ref_id as JS::Object
+ * Helper: wrap ref_id as the most specific JS::* subclass.
+ * Picks JS::Array / JS::Function / JS::Promise for array-like / function /
+ * Promise values, otherwise falls back to JS::Object.
  */
 mrb_value
 wrap_ref_as_js_object(mrb_state *mrb, int ref_id)
 {
+  struct RClass *klass = class_JS_Object;
+  switch (js_classify_composite(ref_id)) {
+    case JS_COMPOSITE_ARRAY:    klass = class_JS_Array; break;
+    case JS_COMPOSITE_FUNCTION: klass = class_JS_Function; break;
+    case JS_COMPOSITE_PROMISE:  klass = class_JS_Promise; break;
+    default: break;
+  }
   picorb_js_obj *data = (picorb_js_obj *)mrb_malloc(mrb, sizeof(picorb_js_obj));
   data->ref_id = ref_id;
-  return mrb_obj_value(Data_Wrap_Struct(mrb, class_JS_Object, &picorb_js_obj_type, data));
+  return mrb_obj_value(Data_Wrap_Struct(mrb, klass, &picorb_js_obj_type, data));
 }
 
 /*
@@ -1602,8 +1676,15 @@ mrb_object_type(mrb_state *mrb, mrb_value self)
  * Handles any combination of String, Integer, Float, nil, bool, JS::Object.
  * Returns the ref_id of the result, or -1 on error.
  */
-static int
-call_method_with_ruby_args(mrb_state *mrb, int ref_id, const char *method_name, mrb_value *argv, mrb_int argc, int extra_ref_id)
+/*
+ * Build a JSON-encoded tagged-value argument array for the EM_JS call helpers.
+ * `context` is a human-readable label used in error messages (e.g. the method
+ * name or "constructor"). Passing a non-negative `extra_ref_id` appends one
+ * more argument of type "ref" after argv[].
+ * Raises on unsupported argument types; does not return in that case.
+ */
+static mrb_value
+build_args_json(mrb_state *mrb, mrb_value *argv, mrb_int argc, int extra_ref_id, const char *context)
 {
   mrb_value json_array = mrb_str_new_lit(mrb, "[");
   mrb_int total = argc + (extra_ref_id >= 0 ? 1 : 0);
@@ -1651,75 +1732,35 @@ call_method_with_ruby_args(mrb_state *mrb, int ref_id, const char *method_name, 
       snprintf(ref_buf, sizeof(ref_buf), "%d", arg_obj->ref_id);
       mrb_str_cat_cstr(mrb, json_array, ref_buf);
     } else {
-      mrb_raisef(mrb, E_TYPE_ERROR, "Unsupported argument type for method: %s at position: %d", method_name, (int)i);
-      return -1;
+      mrb_raisef(mrb, E_TYPE_ERROR, "Unsupported argument type for %s at position: %d", context, (int)i);
     }
 
     mrb_str_cat_lit(mrb, json_array, "}");
   }
 
   mrb_str_cat_lit(mrb, json_array, "]");
-  return call_method_with_args(ref_id, method_name, RSTRING_PTR(json_array), RSTRING_LEN(json_array));
+  return json_array;
+}
+
+static int
+call_method_with_ruby_args(mrb_state *mrb, int ref_id, const char *method_name, mrb_value *argv, mrb_int argc, int extra_ref_id)
+{
+  mrb_value json = build_args_json(mrb, argv, argc, extra_ref_id, method_name);
+  return call_method_with_args(ref_id, method_name, RSTRING_PTR(json), RSTRING_LEN(json));
 }
 
 static int
 call_constructor_with_ruby_args(mrb_state *mrb, int ref_id, mrb_value *argv, mrb_int argc, int extra_ref_id)
 {
-  mrb_value json_array = mrb_str_new_lit(mrb, "[");
-  mrb_int total = argc + (extra_ref_id >= 0 ? 1 : 0);
+  mrb_value json = build_args_json(mrb, argv, argc, extra_ref_id, "constructor");
+  return call_constructor_with_args(ref_id, RSTRING_PTR(json), RSTRING_LEN(json));
+}
 
-  for (mrb_int i = 0; i < total; i++) {
-    if (i > 0) mrb_str_cat_lit(mrb, json_array, ",");
-    mrb_str_cat_lit(mrb, json_array, "{\"type\":");
-
-    if (i == argc && extra_ref_id >= 0) {
-      mrb_str_cat_lit(mrb, json_array, "\"ref\",\"value\":");
-      char ref_buf[32];
-      snprintf(ref_buf, sizeof(ref_buf), "%d", extra_ref_id);
-      mrb_str_cat_cstr(mrb, json_array, ref_buf);
-    } else if (mrb_string_p(argv[i])) {
-      mrb_str_cat_lit(mrb, json_array, "\"string\",\"value\":\"");
-      const char *str = mrb_string_value_cstr(mrb, &argv[i]);
-      for (const char *p = str; *p; p++) {
-        if (*p == '"' || *p == '\\') {
-          char escaped[3] = {'\\', *p, '\0'};
-          mrb_str_cat(mrb, json_array, escaped, 2);
-        } else {
-          mrb_str_cat(mrb, json_array, p, 1);
-        }
-      }
-      mrb_str_cat_lit(mrb, json_array, "\"");
-    } else if (mrb_integer_p(argv[i])) {
-      mrb_str_cat_lit(mrb, json_array, "\"integer\",\"value\":");
-      char num_buf[32];
-      snprintf(num_buf, sizeof(num_buf), "%d", (int)mrb_integer(argv[i]));
-      mrb_str_cat_cstr(mrb, json_array, num_buf);
-    } else if (mrb_float_p(argv[i])) {
-      mrb_str_cat_lit(mrb, json_array, "\"float\",\"value\":");
-      char num_buf[64];
-      snprintf(num_buf, sizeof(num_buf), "%f", mrb_float(argv[i]));
-      mrb_str_cat_cstr(mrb, json_array, num_buf);
-    } else if (mrb_nil_p(argv[i])) {
-      mrb_str_cat_lit(mrb, json_array, "\"nil\",\"value\":null");
-    } else if (mrb_true_p(argv[i]) || mrb_false_p(argv[i])) {
-      mrb_str_cat_lit(mrb, json_array, "\"boolean\",\"value\":");
-      mrb_str_cat_cstr(mrb, json_array, mrb_true_p(argv[i]) ? "true" : "false");
-    } else if (mrb_obj_is_kind_of(mrb, argv[i], class_JS_Object)) {
-      picorb_js_obj *arg_obj = (picorb_js_obj *)DATA_PTR(argv[i]);
-      mrb_str_cat_lit(mrb, json_array, "\"ref\",\"value\":");
-      char ref_buf[32];
-      snprintf(ref_buf, sizeof(ref_buf), "%d", arg_obj->ref_id);
-      mrb_str_cat_cstr(mrb, json_array, ref_buf);
-    } else {
-      mrb_raisef(mrb, E_TYPE_ERROR, "Unsupported constructor argument type at position: %d", (int)i);
-      return -1;
-    }
-
-    mrb_str_cat_lit(mrb, json_array, "}");
-  }
-
-  mrb_str_cat_lit(mrb, json_array, "]");
-  return call_constructor_with_args(ref_id, RSTRING_PTR(json_array), RSTRING_LEN(json_array));
+static int
+apply_function_with_ruby_args(mrb_state *mrb, int func_ref_id, mrb_value *argv, mrb_int argc)
+{
+  mrb_value json = build_args_json(mrb, argv, argc, -1, "function call");
+  return js_function_apply_args(func_ref_id, RSTRING_PTR(json), RSTRING_LEN(json));
 }
 
 static int
@@ -1823,8 +1864,9 @@ mrb_object_method_missing(mrb_state *mrb, mrb_value self)
       picorb_js_obj *arg_obj = (picorb_js_obj *)DATA_PTR(argv[0]);
       new_ref_id = call_method_with_ref(js_obj->ref_id, method_name, arg_obj->ref_id);
     } else {
-      mrb_raise(mrb, E_TYPE_ERROR, "argument must be a String, Integer, or JS::Object");
-      return mrb_nil_value();
+      // Fall back to the generic JSON dispatch so boolean / nil / Float
+      // (and any other supported Ruby type) are forwarded correctly.
+      new_ref_id = call_method_with_ruby_args(mrb, js_obj->ref_id, method_name, argv, argc, -1);
     }
     return js_ref_to_ruby_value(mrb, new_ref_id);
   } else if (argc == 2) {
@@ -1881,6 +1923,21 @@ mrb_object_to_a(mrb_state *mrb, mrb_value self)
     mrb_ary_push(mrb, array, element);
   }
   return array;
+}
+
+/*
+ * JS::Function#call(*args)
+ * Invokes the wrapped JS function value directly with no `this` binding.
+ */
+static mrb_value
+mrb_function_call(mrb_state *mrb, mrb_value self)
+{
+  picorb_js_obj *js_obj = (picorb_js_obj *)DATA_PTR(self);
+  mrb_value *argv;
+  mrb_int argc;
+  mrb_get_args(mrb, "*", &argv, &argc);
+  int result_ref_id = apply_function_with_ruby_args(mrb, js_obj->ref_id, argv, argc);
+  return js_ref_to_ruby_value(mrb, result_ref_id);
 }
 
 /*
@@ -2411,4 +2468,16 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(removeAttribute), mrb_object_remove_attribute, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(preventDefault), mrb_object_prevent_default, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(stopPropagation), mrb_object_stop_propagation, MRB_ARGS_NONE());
+
+  // Composite-type subclasses. wrap_ref_as_js_object dispatches to these
+  // based on the JS runtime type of the wrapped value.
+  class_JS_Array = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Array), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Array, MRB_TT_DATA);
+
+  class_JS_Function = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Function), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Function, MRB_TT_DATA);
+  mrb_define_method_id(mrb, class_JS_Function, MRB_SYM(call), mrb_function_call, MRB_ARGS_ANY());
+
+  class_JS_Promise = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Promise), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Promise, MRB_TT_DATA);
 }

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -42,6 +42,9 @@ struct RClass *class_JS_Object;
 struct RClass *class_JS_Array;
 struct RClass *class_JS_Function;
 struct RClass *class_JS_Promise;
+struct RClass *class_JS_Event;
+struct RClass *class_JS_Response;
+struct RClass *class_JS_Element;
 
 typedef enum {
   JS_COMPOSITE_PLAIN = 0,
@@ -49,6 +52,13 @@ typedef enum {
   JS_COMPOSITE_FUNCTION = 2,
   JS_COMPOSITE_PROMISE = 3
 } js_composite_kind;
+
+typedef enum {
+  JS_DOM_PLAIN = 0,
+  JS_DOM_EVENT = 1,
+  JS_DOM_RESPONSE = 2,
+  JS_DOM_ELEMENT = 3
+} js_dom_kind;
 
 static void
 picorb_js_obj_free(mrb_state *mrb, void *ptr)
@@ -256,6 +266,23 @@ EM_JS(int, js_classify_composite, (int ref_id), {
     if (Array.isArray(v)) return 1;
     if (typeof v === 'function') return 2;
     if (typeof Promise !== 'undefined' && v instanceof Promise) return 3;
+    return 0;
+  } catch(e) {
+    return 0;
+  }
+});
+
+// Classify a plain-object JS value into a DOM-related Ruby subclass.
+// Document is treated as Element-like so that doc.createElement /
+// doc.appendChild dispatch to JS::Element methods (Document is a Node but
+// not technically an Element in the DOM standard).
+EM_JS(int, js_classify_dom, (int ref_id), {
+  try {
+    const v = globalThis.picorubyRefs[ref_id];
+    if (typeof Event !== 'undefined' && v instanceof Event) return 1;
+    if (typeof Response !== 'undefined' && v instanceof Response) return 2;
+    if (typeof Element !== 'undefined' && (v instanceof Element ||
+        (typeof Document !== 'undefined' && v instanceof Document))) return 3;
     return 0;
   } catch(e) {
     return 0;
@@ -1069,7 +1096,9 @@ EM_JS(void, js_get_type_info, (int ref_id, js_type_info* info), {
 /*
  * Helper: wrap ref_id as the most specific JS::* subclass.
  * Picks JS::Array / JS::Function / JS::Promise for array-like / function /
- * Promise values, otherwise falls back to JS::Object.
+ * Promise values; for plain objects, picks JS::Event / JS::Response /
+ * JS::Element when the underlying value is a DOM Event / Response / Element
+ * (or Document, treated as Element-like). Falls back to JS::Object.
  */
 mrb_value
 wrap_ref_as_js_object(mrb_state *mrb, int ref_id)
@@ -1079,7 +1108,14 @@ wrap_ref_as_js_object(mrb_state *mrb, int ref_id)
     case JS_COMPOSITE_ARRAY:    klass = class_JS_Array; break;
     case JS_COMPOSITE_FUNCTION: klass = class_JS_Function; break;
     case JS_COMPOSITE_PROMISE:  klass = class_JS_Promise; break;
-    default: break;
+    case JS_COMPOSITE_PLAIN:
+      switch (js_classify_dom(ref_id)) {
+        case JS_DOM_EVENT:    klass = class_JS_Event; break;
+        case JS_DOM_RESPONSE: klass = class_JS_Response; break;
+        case JS_DOM_ELEMENT:  klass = class_JS_Element; break;
+        default: break;
+      }
+      break;
   }
   picorb_js_obj *data = (picorb_js_obj *)mrb_malloc(mrb, sizeof(picorb_js_obj));
   data->ref_id = ref_id;
@@ -2449,25 +2485,14 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_class_method_id(mrb, class_JS_Object, MRB_SYM(_register_callback), mrb_object_s__register_callback, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_and_suspend), mrb_object__fetch_and_suspend, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_with_options_and_suspend), mrb_object__fetch_with_options_and_suspend, MRB_ARGS_REQ(3));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_to_binary_and_suspend), mrb_object__to_binary_and_suspend, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_await_and_suspend), mrb_object__await_and_suspend, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_set_timeout), mrb_object__set_timeout, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_clear_timeout), mrb_object__clear_timeout, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(type), mrb_object_type, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(typeof), mrb_object_type, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(refcount), mrb_js_refcount, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_removeEventListener), mrb_object__remove_event_listener, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(createElement), mrb_object_create_element, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(createTextNode), mrb_object_create_text_node, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(create_object), mrb_object_create_object, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(create_array), mrb_object_create_array, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(appendChild), mrb_object_append_child, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(removeChild), mrb_object_remove_child, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(replaceChild), mrb_object_replace_child, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(insertBefore), mrb_object_insert_before, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(setAttribute), mrb_object_set_attribute, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(removeAttribute), mrb_object_remove_attribute, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(preventDefault), mrb_object_prevent_default, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(stopPropagation), mrb_object_stop_propagation, MRB_ARGS_NONE());
 
   // Composite-type subclasses. wrap_ref_as_js_object dispatches to these
   // based on the JS runtime type of the wrapped value.
@@ -2480,4 +2505,27 @@ mrb_js_init(mrb_state *mrb)
 
   class_JS_Promise = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Promise), class_JS_Object);
   MRB_SET_INSTANCE_TT(class_JS_Promise, MRB_TT_DATA);
+
+  // DOM-domain subclasses for Event / Response / Element. Methods that only
+  // make sense on these types live here so type checkers can reject misuse
+  // (e.g. calling preventDefault on a plain JS::Object).
+  class_JS_Event = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Event), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Event, MRB_TT_DATA);
+  mrb_define_method_id(mrb, class_JS_Event, MRB_SYM(preventDefault), mrb_object_prevent_default, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_JS_Event, MRB_SYM(stopPropagation), mrb_object_stop_propagation, MRB_ARGS_NONE());
+
+  class_JS_Response = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Response), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Response, MRB_TT_DATA);
+  mrb_define_method_id(mrb, class_JS_Response, MRB_SYM(_to_binary_and_suspend), mrb_object__to_binary_and_suspend, MRB_ARGS_REQ(1));
+
+  class_JS_Element = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Element), class_JS_Object);
+  MRB_SET_INSTANCE_TT(class_JS_Element, MRB_TT_DATA);
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(createElement), mrb_object_create_element, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(createTextNode), mrb_object_create_text_node, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(appendChild), mrb_object_append_child, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(removeChild), mrb_object_remove_child, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(replaceChild), mrb_object_replace_child, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(insertBefore), mrb_object_insert_before, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(setAttribute), mrb_object_set_attribute, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, class_JS_Element, MRB_SYM(removeAttribute), mrb_object_remove_attribute, MRB_ARGS_REQ(1));
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the JavaScript interop layer in PicoRuby WASM, focusing on automatic conversion between JS and Ruby types, new composite-type Ruby subclasses for JS objects, and enhanced documentation and testing. These changes make working with JS objects from Ruby more natural, especially regarding primitive values, array handling, and DOM interaction.

**JS-Ruby Interop Improvements:**

* JS primitives (string, number, boolean, null, undefined) are now auto-converted to Ruby native types on property access and method return; composite JS values (object, array, function, etc.) are wrapped as `JS::Object` or a subclass. [[1]](diffhunk://#diff-7dfccb5bd6f0c81ce5b124be125a09051318eaa8357d480f4ac8b0915b5144ceL5-R44) [[2]](diffhunk://#diff-0f860f60d184f6dfcfc77d6fc8974da3c651569af02a12a5aaafc84e6f2cebe6L116-R164)
* Added new Ruby subclasses for JS composite types: `JS::Array`, `JS::Function`, `JS::Promise`, `JS::Response`, `JS::Event`, and `JS::Element`, each with specialized behavior (e.g., `JS::Array` includes `Enumerable`, `JS::Promise#await` auto-converts primitives).

**Documentation and Testing:**

* Updated interoperability documentation to reflect the new type conversion behavior, array handling, comparison semantics, and improved `#inspect` output for JS objects. [[1]](diffhunk://#diff-7dfccb5bd6f0c81ce5b124be125a09051318eaa8357d480f4ac8b0915b5144ceL5-R44) [[2]](diffhunk://#diff-7dfccb5bd6f0c81ce5b124be125a09051318eaa8357d480f4ac8b0915b5144ceL85-R115)
* Added a comprehensive new test/demo page (`js_types.html`) that exercises and demonstrates all aspects of the new type system, including primitives, array iteration, subclass dispatch, and DOM/event integration. [[1]](diffhunk://#diff-a25c73384d227f5f25553173123ee0af932433c4a91aed7873087d0140491aedR1-R283) [[2]](diffhunk://#diff-9d1cdf8189c973b644043c06a7936b17dfb30414c3b4dc2a0b995d0ecab31086R66)

**API Consistency and Type Signatures:**

* Standardized use of `::Array` in method signatures and type annotations for improved type safety and clarity in both Ruby and RBS files. [[1]](diffhunk://#diff-0f860f60d184f6dfcfc77d6fc8974da3c651569af02a12a5aaafc84e6f2cebe6L116-R164) [[2]](diffhunk://#diff-e889f6ee3958cf175871b8b820025e841808b5a0b623200ca01a5d6e7f4d003eL13-R20)

**Bugfixes and Minor Improvements:**

* Improved feature detection for Web Serial API to use new type system checks.
* Fixed `JS.document` to require a `JS::Element` rather than a generic `JS::Object`.
* Moved `JS::Response#to_binary` to the correct subclass and improved its documentation. [[1]](diffhunk://#diff-0f860f60d184f6dfcfc77d6fc8974da3c651569af02a12a5aaafc84e6f2cebe6L68-L75) [[2]](diffhunk://#diff-0f860f60d184f6dfcfc77d6fc8974da3c651569af02a12a5aaafc84e6f2cebe6R82-R139)

**Submodule Update:**

* Updated the `picoruby-funicular` submodule to the latest commit.