### PR TITLE
picoruby-indexeddb

### DIFF
--- a/build_config/picoruby-wasm.rb
+++ b/build_config/picoruby-wasm.rb
@@ -43,6 +43,7 @@ MRuby::CrossBuild.new("picoruby-wasm") do |conf|
   end
   conf.gem gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-math"
   conf.gem core: 'picoruby-wasm'
+  conf.gem core: 'picoruby-indexeddb'
   conf.gem core: 'picoruby-funicular'
   conf.gem core: 'picoruby-markdown'
   conf.gem core: 'picoruby-drb'

--- a/mrbgems/picoruby-indexeddb/README.md
+++ b/mrbgems/picoruby-indexeddb/README.md
@@ -1,0 +1,93 @@
+# picoruby-indexeddb
+
+Ruby-idiomatic IndexedDB wrapper for PicoRuby.wasm.
+
+## Features
+
+- Simple, synchronous-looking API using `await` under the hood
+- Schema versioning with upgrade callbacks
+- In-memory fallback when IndexedDB is unavailable (e.g., testing environments)
+
+## Usage
+
+```ruby
+require 'indexeddb'
+
+# Check availability
+IndexedDB.available?  # => true (in browser)
+
+# Open a database with schema upgrade
+db = IndexedDB.open('mydb', version: 1) do |db, old_version, new_version|
+  db.create_store('users', key_path: 'id') if old_version < 1
+end
+
+# Introspection
+db.store_names      # => ["users"]
+db.has_store?('users')  # => true
+
+# Close when done
+db.close
+```
+
+### Schema Upgrades
+
+The upgrade block runs only when creating a new database or bumping the version:
+
+```ruby
+db = IndexedDB.open('mydb', version: 2) do |db, old_v, new_v|
+  db.create_store('users', key_path: 'id') if old_v < 1
+  db.create_store('cache', auto_increment: true) if old_v < 2
+end
+```
+
+**Important:** Schema mutations (`create_store`, `delete_store`) are only valid inside the upgrade block. Calling them outside raises `IndexedDB::SchemaError`.
+
+### In-Memory Fallback
+
+When `IndexedDB.available?` returns `false`, `IndexedDB.open` automatically falls back to an in-memory implementation with the same API:
+
+```ruby
+# Force no fallback (raises NotSupportedError if unavailable)
+db = IndexedDB.open('mydb', version: 1, fallback: false)
+```
+
+## API Reference
+
+### Module Methods
+
+| Method | Description |
+|--------|-------------|
+| `IndexedDB.available?` | Returns `true` if browser IndexedDB is accessible |
+| `IndexedDB.open(name, version:, fallback:, &block)` | Opens a database, optionally running upgrade block |
+
+### Database
+
+| Method | Description |
+|--------|-------------|
+| `name` | Database name |
+| `version` | Current schema version |
+| `store_names` | Array of object store names |
+| `has_store?(name)` | Check if store exists |
+| `store(name)` | Get a Store object |
+| `create_store(name, key_path:, auto_increment:)` | Create object store (upgrade only) |
+| `delete_store(name)` | Delete object store (upgrade only) |
+| `close` | Close the database connection |
+| `closed?` | Returns `true` if closed |
+
+## Errors
+
+| Error | Description |
+|-------|-------------|
+| `IndexedDB::Error` | Base error class |
+| `IndexedDB::NotSupportedError` | IndexedDB unavailable and fallback disabled |
+| `IndexedDB::OpenError` | Failed to open database |
+| `IndexedDB::SchemaError` | Schema mutation outside upgrade block |
+
+## Dependencies
+
+- `picoruby-wasm`
+- `picoruby-json`
+
+## License
+
+MIT

--- a/mrbgems/picoruby-indexeddb/README.md
+++ b/mrbgems/picoruby-indexeddb/README.md
@@ -7,6 +7,8 @@ Ruby-idiomatic IndexedDB wrapper for PicoRuby.wasm.
 - Simple, synchronous-looking API using `await` under the hood
 - Schema versioning with upgrade callbacks
 - One-shot autocommit operations (each method opens its own transaction)
+- Atomic multi-store transactions via `Database#batch`
+- `IndexedDB::KVS` single-store facade for plain Hash-like persistence
 - Secondary index support
 - In-memory fallback when IndexedDB is unavailable (e.g., testing environments)
 
@@ -107,6 +109,50 @@ users.put({ 'id' => 1, 'name' => 'Alice' })
 users.index('by_name').get('Alice')  # => { 'id' => 1, 'name' => 'Alice' }
 ```
 
+### Atomic Batches
+
+Single-call operations on `Store` (`get`, `put`, `delete`, ...) each open their own one-shot transaction. When you need to commit several writes atomically across one or more stores, use `Database#batch`:
+
+```ruby
+db.batch(['users', 'cache'], mode: :readwrite) do |tx|
+  tx['users'].put({ 'id' => 1, 'name' => 'Alice' })
+  tx['users'].put({ 'id' => 2, 'name' => 'Bob' })
+  tx['cache'].put('hot', key: 'tier')
+end  # commits atomically here, or rolls back if any request errored
+```
+
+Inside the block, `tx[name]` returns a `Batch::StoreView` that exposes only the enqueueing operations: `put`, `add`, `delete`, `clear`. Read methods (`get`, `count`, `keys`, `to_a`, `each`, `index`) raise `IndexedDB::AwaitInBatchError`, because every `await` would yield to the JS event loop and auto-commit the in-flight transaction.
+
+If you only need one store, pass a string instead of an array:
+
+```ruby
+db.batch('users') do |tx|
+  tx['users'].delete(2)
+  tx['users'].put({ 'id' => 4, 'name' => 'Dave' })
+end
+```
+
+### KVS Facade
+
+For applications that just want a persistent Hash-like surface (no schemas, no indexes), use `IndexedDB::KVS`. Each operation autocommits through the underlying `Store`.
+
+```ruby
+kv = IndexedDB::KVS.open('user_prefs')
+
+kv['theme'] = 'dark'
+kv['theme']           # => 'dark'
+kv['missing']         # => nil
+kv.has_key?('theme')  # => true
+kv.size               # => 1
+
+kv.delete('theme')
+kv.each { |k, v| ... }
+kv.to_h               # => { 'theme' => 'dark', ... }
+kv.clear
+```
+
+Symbol keys are stringified on input so `kv[:foo]` and `kv['foo']` are interchangeable. The default store name is `'kv'`; pass `store:` to open a non-default store. The same `fallback:` semantics as `IndexedDB.open` apply.
+
 ### Key Ranges
 
 ```ruby
@@ -157,8 +203,37 @@ db = IndexedDB.open('mydb', version: 1, fallback: false)
 | `store(name)` | Get a Store object |
 | `create_store(name, key_path:, auto_increment:)` | Create object store (upgrade only) |
 | `delete_store(name)` | Delete object store (upgrade only) |
+| `batch(store_names, mode:, &block)` | Atomic multi-store transaction (no await inside block) |
 | `close` | Close the database connection |
 | `closed?` | Returns `true` if closed |
+
+### Batch::StoreView (yielded by `Database#batch`)
+
+| Method | Description |
+|--------|-------------|
+| `put(value, key:)` | Enqueue a put request |
+| `add(value, key:)` | Enqueue an add request (fails if key exists) |
+| `delete(key)` | Enqueue a delete request |
+| `clear` | Enqueue a clear request |
+| `get` / `count` / `keys` / `to_a` / `each` / `index` | Raise `AwaitInBatchError` |
+
+### KVS
+
+| Method | Description |
+|--------|-------------|
+| `KVS.open(name, store:, fallback:)` | Open a single-store KVS database |
+| `kv[key]` | Get value (returns `nil` if missing) |
+| `kv[key] = value` | Store value (returns `value`) |
+| `delete(key)` | Remove a key |
+| `has_key?(key)` | Membership check |
+| `size` / `length` | Number of entries |
+| `empty?` | `true` when no entries |
+| `clear` | Remove all entries |
+| `keys` | Array of stored keys (Strings) |
+| `values` | Array of stored values |
+| `each` | Iterate over `[key, value]` pairs |
+| `to_h` | Materialize the whole store as a Hash |
+| `close` | Close the underlying database |
 
 ### Store
 
@@ -203,7 +278,9 @@ db = IndexedDB.open('mydb', version: 1, fallback: false)
 | `IndexedDB::Error` | Base error class |
 | `IndexedDB::NotSupportedError` | IndexedDB unavailable and fallback disabled |
 | `IndexedDB::OpenError` | Failed to open database |
+| `IndexedDB::BlockedError` | Open blocked because another connection holds an older version |
 | `IndexedDB::SchemaError` | Schema mutation outside upgrade block |
+| `IndexedDB::AwaitInBatchError` | Await-bearing call invoked inside `Database#batch` |
 
 ## Dependencies
 

--- a/mrbgems/picoruby-indexeddb/README.md
+++ b/mrbgems/picoruby-indexeddb/README.md
@@ -6,6 +6,8 @@ Ruby-idiomatic IndexedDB wrapper for PicoRuby.wasm.
 
 - Simple, synchronous-looking API using `await` under the hood
 - Schema versioning with upgrade callbacks
+- One-shot autocommit operations (each method opens its own transaction)
+- Secondary index support
 - In-memory fallback when IndexedDB is unavailable (e.g., testing environments)
 
 ## Usage
@@ -29,6 +31,52 @@ db.has_store?('users')  # => true
 db.close
 ```
 
+### Store Operations
+
+```ruby
+users = db.store('users')
+
+# Create / Update
+users.put({ 'id' => 1, 'name' => 'Alice' })
+users.put({ 'id' => 2, 'name' => 'Bob' })
+
+# Read
+users.get(1)        # => { 'id' => 1, 'name' => 'Alice' }
+users.get(999)      # => nil
+
+# Delete
+users.delete(2)
+
+# Count
+users.count         # => 1
+
+# Get all keys / values
+users.keys          # => [1]
+users.to_a          # => [{ 'id' => 1, 'name' => 'Alice' }]
+
+# Iterate
+users.each do |key, value|
+  puts "#{key}: #{value['name']}"
+end
+
+# Clear all
+users.clear
+```
+
+### Out-of-line Keys
+
+For stores without `key_path`, provide the key explicitly:
+
+```ruby
+db = IndexedDB.open('mydb', version: 1) do |db, old_v, new_v|
+  db.create_store('kv') if old_v < 1
+end
+
+kv = db.store('kv')
+kv.put('some value', key: 'mykey')
+kv.get('mykey')  # => 'some value'
+```
+
 ### Schema Upgrades
 
 The upgrade block runs only when creating a new database or bumping the version:
@@ -40,11 +88,49 @@ db = IndexedDB.open('mydb', version: 2) do |db, old_v, new_v|
 end
 ```
 
-**Important:** Schema mutations (`create_store`, `delete_store`) are only valid inside the upgrade block. Calling them outside raises `IndexedDB::SchemaError`.
+**Important:** Schema mutations (`create_store`, `delete_store`, `create_index`) are only valid inside the upgrade block. Calling them outside raises `IndexedDB::SchemaError`.
+
+### Secondary Indexes
+
+```ruby
+db = IndexedDB.open('mydb', version: 2) do |db, old_v, new_v|
+  if old_v < 1
+    store = db.create_store('users', key_path: 'id')
+    store.create_index('by_name', 'name')
+  end
+end
+
+users = db.store('users')
+users.put({ 'id' => 1, 'name' => 'Alice' })
+
+# Query via index
+users.index('by_name').get('Alice')  # => { 'id' => 1, 'name' => 'Alice' }
+```
+
+### Key Ranges
+
+```ruby
+# Exact match
+range = IndexedDB::KeyRange.only(5)
+
+# Lower bound (>= 10)
+range = IndexedDB::KeyRange.lower_bound(10)
+
+# Upper bound (<= 100)
+range = IndexedDB::KeyRange.upper_bound(100)
+
+# Between (10 <= key < 100)
+range = IndexedDB::KeyRange.bound(10, 100, exclude_upper: true)
+
+# Use with iteration
+users.each(range) { |key, value| ... }
+users.keys(range)
+users.to_a(range)
+```
 
 ### In-Memory Fallback
 
-When `IndexedDB.available?` returns `false`, `IndexedDB.open` automatically falls back to an in-memory implementation with the same API:
+When `IndexedDB.available?` returns `false`, `IndexedDB.open` automatically falls back to an in-memory implementation with the same API. Data is lost on page reload.
 
 ```ruby
 # Force no fallback (raises NotSupportedError if unavailable)
@@ -73,6 +159,42 @@ db = IndexedDB.open('mydb', version: 1, fallback: false)
 | `delete_store(name)` | Delete object store (upgrade only) |
 | `close` | Close the database connection |
 | `closed?` | Returns `true` if closed |
+
+### Store
+
+| Method | Description |
+|--------|-------------|
+| `get(key)` | Retrieve value by primary key |
+| `put(value, key:)` | Store a value (key extracted from value if key_path set) |
+| `delete(key)` | Delete by primary key |
+| `count(key_or_range)` | Count records |
+| `clear` | Remove all records |
+| `keys(range)` | Get all primary keys |
+| `to_a(range)` | Get all values |
+| `each(range, direction:)` | Iterate over [key, value] pairs |
+| `index(name)` | Get an Index object |
+| `create_index(name, key_path, unique:, multi_entry:)` | Create index (upgrade only) |
+| `delete_index(name)` | Delete index (upgrade only) |
+
+### Index
+
+| Method | Description |
+|--------|-------------|
+| `get(key)` | Get first matching record |
+| `get_all(key_or_range, count:)` | Get all matching records |
+| `count(key_or_range)` | Count matching records |
+| `keys(range)` | Get all primary keys |
+| `to_a(range)` | Get all values |
+| `each(range, direction:)` | Iterate over [primary_key, value] pairs |
+
+### KeyRange
+
+| Method | Description |
+|--------|-------------|
+| `KeyRange.only(value)` | Match exactly one key |
+| `KeyRange.lower_bound(lower, exclude:)` | All keys >= lower |
+| `KeyRange.upper_bound(upper, exclude:)` | All keys <= upper |
+| `KeyRange.bound(lower, upper, exclude_lower:, exclude_upper:)` | Keys between bounds |
 
 ## Errors
 

--- a/mrbgems/picoruby-indexeddb/demo/batch.html
+++ b/mrbgems/picoruby-indexeddb/demo/batch.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../test.css">
+    <title>IndexedDB Phase C: Batch atomic transactions</title>
+  </head>
+  <body>
+    <div><a href="../index.html">Back</a></div>
+    <h1>IndexedDB Phase C: Batch</h1>
+    <p>
+      Verifies <code>Database#batch</code> atomic multi-store writes and
+      that await-bearing operations on <code>Batch::StoreView</code> raise
+      <code>AwaitInBatchError</code>.
+    </p>
+    <button id="run">Run Test</button>
+    <button id="reset">Delete Test DB</button>
+    <pre id="output"></pre>
+
+    <script type="text/ruby">
+      require 'js'
+
+      $log = JS.document.getElementById('output')
+
+      def log(msg)
+        $log.innerText = $log.innerText.to_s + msg.to_s + "\n"
+      end
+
+      def reset_log
+        $log.innerText = ''
+      end
+
+      def assert(label, expected, actual)
+        if expected == actual
+          log "PASS  #{label}"
+        else
+          log "FAIL  #{label}: expected #{expected.inspect}, got #{actual.inspect}"
+        end
+      end
+
+      JS.document.getElementById('run').addEventListener('click') do
+        reset_log
+        log "=== Phase C: Batch ==="
+        log ""
+
+        db_name = 'picoruby_idb_phase_c'
+
+        db = IndexedDB.open(db_name, version: 1) do |d, old_v, new_v|
+          log "upgrade: old=#{old_v} new=#{new_v}"
+          d.create_store('users', key_path: 'id') unless d.has_store?('users')
+          d.create_store('cache') unless d.has_store?('cache')
+        end
+
+        log "opened: #{db.name} v#{db.version}"
+        log ""
+
+        # Make sure stores are empty
+        db.store('users').clear
+        db.store('cache').clear
+
+        # --- Atomic multi-store batch write ---
+        log "-- batch: writes to two stores --"
+        db.batch(['users', 'cache'], mode: :readwrite) do |tx|
+          tx['users'].put({ 'id' => 1, 'name' => 'Alice' })
+          tx['users'].put({ 'id' => 2, 'name' => 'Bob' })
+          tx['users'].put({ 'id' => 3, 'name' => 'Carol' })
+          tx['cache'].put('hot', key: 'tier')
+          tx['cache'].put(42, key: 'count')
+        end
+
+        # Reads happen outside the batch (so they may await)
+        assert "users count after batch", 3, db.store('users').count
+        assert "cache count after batch", 2, db.store('cache').count
+        assert "users.get(1)", 'Alice', db.store('users').get(1)['name']
+        assert "cache.get('tier')", 'hot', db.store('cache').get('tier')
+        assert "cache.get('count')", 42, db.store('cache').get('count')
+
+        log ""
+
+        # --- Single-store batch (string instead of array) ---
+        log "-- batch: single-store, string arg --"
+        db.batch('users') do |tx|
+          tx['users'].delete(2)
+          tx['users'].put({ 'id' => 4, 'name' => 'Dave' })
+        end
+        assert "users count after single-store batch", 3, db.store('users').count
+        assert "users.get(2) deleted in batch", nil, db.store('users').get(2)
+        assert "users.get(4) added in batch", 'Dave', db.store('users').get(4)['name']
+
+        log ""
+
+        # --- Await guard: read inside batch raises ---
+        log "-- batch: read inside batch raises --"
+        raised = nil
+        begin
+          db.batch(['users']) do |tx|
+            tx['users'].get(1)
+          end
+        rescue IndexedDB::AwaitInBatchError => e
+          raised = e.message
+        end
+        if raised
+          log "PASS  AwaitInBatchError raised: #{raised}"
+        else
+          log "FAIL  expected AwaitInBatchError on tx['users'].get(...)"
+        end
+
+        log ""
+        log "-- batch: count inside batch raises --"
+        raised = nil
+        begin
+          db.batch(['users']) do |tx|
+            tx['users'].count
+          end
+        rescue IndexedDB::AwaitInBatchError => e
+          raised = e.message
+        end
+        if raised
+          log "PASS  AwaitInBatchError raised: #{raised}"
+        else
+          log "FAIL  expected AwaitInBatchError on tx['users'].count"
+        end
+
+        log ""
+
+        # --- StoreView caching: same view returned twice ---
+        log "-- batch: tx[name] returns cached view --"
+        cached_check = false
+        db.batch(['users']) do |tx|
+          v1 = tx['users']
+          v2 = tx['users']
+          cached_check = v1.equal?(v2)
+        end
+        assert "tx['users'] is cached", true, cached_check
+
+        log ""
+
+        # --- clear inside batch ---
+        log "-- batch: clear inside batch --"
+        db.batch(['cache']) do |tx|
+          tx['cache'].clear
+        end
+        assert "cache count after clear-batch", 0, db.store('cache').count
+
+        db.close
+        log ""
+        log "=== All Phase C tests complete ==="
+
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+        log e.backtrace.first(5).join("\n") if e.backtrace
+      end
+
+      JS.document.getElementById('reset').addEventListener('click') do
+        reset_log
+        log "deleting 'picoruby_idb_phase_c'..."
+        req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_c')
+        IndexedDB::Helper._request_to_promise(req).await
+        log "deleted; reload then click Run Test"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+    </script>
+    <script src="../init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-indexeddb/demo/batch.html
+++ b/mrbgems/picoruby-indexeddb/demo/batch.html
@@ -155,7 +155,7 @@
         reset_log
         log "deleting 'picoruby_idb_phase_c'..."
         req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_c')
-        IndexedDB::Helper._request_to_promise(req).await
+        IndexedDB::Helper.request_to_promise(req).await
         log "deleted; reload then click Run Test"
       rescue => e
         log "ERROR: #{e.class}: #{e.message}"

--- a/mrbgems/picoruby-indexeddb/demo/crud.html
+++ b/mrbgems/picoruby-indexeddb/demo/crud.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../test.css">
+    <title>IndexedDB Phase B: Store CRUD operations</title>
+  </head>
+  <body>
+    <div><a href="../index.html">Back</a></div>
+    <h1>IndexedDB Phase B: Store CRUD</h1>
+    <p>
+      Verifies <code>Store#put</code>, <code>Store#get</code>,
+      <code>Store#delete</code>, <code>Store#count</code>,
+      <code>Store#clear</code>, <code>Store#keys</code>,
+      <code>Store#to_a</code>, and <code>Store#each</code>.
+    </p>
+    <button id="run">Run Test</button>
+    <button id="reset">Delete Test DB</button>
+    <pre id="output"></pre>
+
+    <script type="text/ruby">
+      require 'js'
+
+      $log = JS.document.getElementById('output')
+
+      def log(msg)
+        $log.innerText = $log.innerText.to_s + msg.to_s + "\n"
+      end
+
+      def reset_log
+        $log.innerText = ''
+      end
+
+      def assert(label, expected, actual)
+        if expected == actual
+          log "✓ #{label}"
+        else
+          log "✗ #{label}: expected #{expected.inspect}, got #{actual.inspect}"
+        end
+      end
+
+      JS.document.getElementById('run').addEventListener('click') do
+        reset_log
+        log "=== Phase B: Store CRUD ==="
+        log ""
+
+        db_name = 'picoruby_idb_phase_b'
+
+        # Open with a store that has key_path
+        db = IndexedDB.open(db_name, version: 1) do |d, old_v, new_v|
+          log "upgrade: old=#{old_v} new=#{new_v}"
+          d.create_store('users', key_path: 'id') unless d.has_store?('users')
+          d.create_store('kv') unless d.has_store?('kv')
+        end
+
+        log "opened: #{db.name} v#{db.version}"
+        log ""
+
+        users = db.store('users')
+        kv = db.store('kv')
+
+        # --- Test put/get with key_path ---
+        log "-- put/get with key_path --"
+        users.put({ 'id' => 1, 'name' => 'Alice' })
+        users.put({ 'id' => 2, 'name' => 'Bob' })
+        users.put({ 'id' => 3, 'name' => 'Carol' })
+
+        alice = users.get(1)
+        assert "get(1) returns Alice", 'Alice', alice['name']
+
+        bob = users.get(2)
+        assert "get(2) returns Bob", 'Bob', bob['name']
+
+        missing = users.get(999)
+        assert "get(999) returns nil", nil, missing
+
+        log ""
+
+        # --- Test put/get with explicit key ---
+        log "-- put/get with explicit key --"
+        kv.put('value1', key: 'key1')
+        kv.put('value2', key: 'key2')
+
+        assert "kv.get('key1')", 'value1', kv.get('key1')
+        assert "kv.get('key2')", 'value2', kv.get('key2')
+
+        log ""
+
+        # --- Test count ---
+        log "-- count --"
+        assert "users.count", 3, users.count
+        assert "kv.count", 2, kv.count
+
+        log ""
+
+        # --- Test delete ---
+        log "-- delete --"
+        users.delete(2)
+        assert "users.count after delete", 2, users.count
+        assert "get(2) after delete", nil, users.get(2)
+
+        log ""
+
+        # --- Test keys ---
+        log "-- keys --"
+        user_keys = users.keys
+        assert "users.keys includes 1", true, user_keys.include?(1)
+        assert "users.keys includes 3", true, user_keys.include?(3)
+        assert "users.keys excludes 2", false, user_keys.include?(2)
+
+        log ""
+
+        # --- Test to_a ---
+        log "-- to_a --"
+        all_users = users.to_a
+        assert "users.to_a length", 2, all_users.length
+        names = all_users.map { |u| u['name'] }.sort
+        assert "users names", ['Alice', 'Carol'], names
+
+        log ""
+
+        # --- Test each ---
+        log "-- each --"
+        collected = []
+        users.each do |key, value|
+          collected << [key, value['name']]
+        end
+        assert "each yielded 2 pairs", 2, collected.length
+        log "  collected: #{collected.inspect}"
+
+        log ""
+
+        # --- Test clear ---
+        log "-- clear --"
+        kv.clear
+        assert "kv.count after clear", 0, kv.count
+
+        log ""
+
+        # --- Test update (put overwrites) ---
+        log "-- update via put --"
+        users.put({ 'id' => 1, 'name' => 'Alice Updated' })
+        updated = users.get(1)
+        assert "updated name", 'Alice Updated', updated['name']
+        assert "count unchanged", 2, users.count
+
+        db.close
+        log ""
+        log "=== All tests complete ==="
+
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+        log e.backtrace.first(5).join("\n") if e.backtrace
+      end
+
+      JS.document.getElementById('reset').addEventListener('click') do
+        reset_log
+        log "deleting 'picoruby_idb_phase_b'..."
+        req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_b')
+        IndexedDB::Helper._request_to_promise(req).await
+        log "deleted; reload then click Run Test"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+    </script>
+    <script src="../init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-indexeddb/demo/crud.html
+++ b/mrbgems/picoruby-indexeddb/demo/crud.html
@@ -157,7 +157,7 @@
         reset_log
         log "deleting 'picoruby_idb_phase_b'..."
         req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_b')
-        IndexedDB::Helper._request_to_promise(req).await
+        IndexedDB::Helper.request_to_promise(req).await
         log "deleted; reload then click Run Test"
       rescue => e
         log "ERROR: #{e.class}: #{e.message}"

--- a/mrbgems/picoruby-indexeddb/demo/funicular_cache.html
+++ b/mrbgems/picoruby-indexeddb/demo/funicular_cache.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../test.css">
+    <title>IndexedDB Phase E: Funicular HTTP cache</title>
+  </head>
+  <body>
+    <div><a href="../index.html">Back</a></div>
+    <h1>IndexedDB Phase E: Funicular HTTP cache</h1>
+    <p>
+      Verifies <code>Funicular::HTTP</code> opt-in response cache backed by
+      <code>IndexedDB::KVS</code>. Cache lifecycle and hit/miss semantics
+      are tested without network access by pre-populating entries through
+      <code>HTTP.cache_write</code>. The optional network test at the
+      bottom hits a local same-origin endpoint; it will report a network
+      error if no such endpoint is available, which is fine.
+    </p>
+    <button id="run">Run Test</button>
+    <button id="run_net">Run Network Test (optional)</button>
+    <button id="reset">Clear Cache</button>
+    <pre id="output"></pre>
+
+    <script type="text/ruby">
+      require 'js'
+
+      $log = JS.document.getElementById('output')
+
+      def log(msg)
+        $log.innerText = $log.innerText.to_s + msg.to_s + "\n"
+      end
+
+      def reset_log
+        $log.innerText = ''
+      end
+
+      def assert(label, expected, actual)
+        if expected == actual
+          log "PASS  #{label}"
+        else
+          log "FAIL  #{label}: expected #{expected.inspect}, got #{actual.inspect}"
+        end
+      end
+
+      JS.document.getElementById('run').addEventListener('click') do
+        reset_log
+        log "=== Phase E: Funicular HTTP cache ==="
+        log ""
+
+        # --- cache_init! is idempotent ---
+        log "-- cache_init! idempotent --"
+        c1 = Funicular::HTTP.cache_init!
+        c2 = Funicular::HTTP.cache_init!
+        assert "cache_init! same instance", true, c1.equal?(c2)
+
+        Funicular::HTTP.cache_clear
+        log ""
+
+        # --- Pre-populate the cache and observe a synchronous hit ---
+        log "-- pre-populated entry served synchronously on cache hit --"
+        url = '/__phase_e_cached__'
+        now = (JS.global[:Date].now.to_i / 1000)
+        Funicular::HTTP.cache_write(url, {
+          "status" => 200,
+          "data"   => { "fruit" => "apple", "n" => 7 },
+          "cached_at" => now
+        })
+
+        synchronous_seen = false
+        block_data = nil
+        block_status = nil
+        Funicular::HTTP.get(url, cache: 60) do |resp|
+          synchronous_seen = true
+          block_data = resp.data
+          block_status = resp.status
+        end
+        assert "block invoked synchronously on cache hit", true, synchronous_seen
+        assert "cached status surfaced", 200, block_status
+        assert "cached data fruit", 'apple', block_data['fruit']
+        assert "cached data n", 7, block_data['n']
+
+        log ""
+
+        # --- TTL expiry triggers a miss ---
+        log "-- expired entry is treated as miss --"
+        old_url = '/__phase_e_expired__'
+        Funicular::HTTP.cache_write(old_url, {
+          "status" => 200,
+          "data"   => { "stale" => true },
+          "cached_at" => now - 1000  # 1000s ago
+        })
+        # ttl=60 means anything older than 60s is stale.
+        # We cannot actually fetch in this test, so check cache_hit? indirectly
+        # via cache_lookup + manual TTL math.
+        entry = Funicular::HTTP.cache_lookup(old_url)
+        age = (JS.global[:Date].now.to_i / 1000) - entry['cached_at']
+        assert "stale entry age > ttl", true, age > 60
+
+        log ""
+
+        # --- cache_purge removes a single entry ---
+        log "-- cache_purge --"
+        Funicular::HTTP.cache_purge(url)
+        assert "purged entry is nil", nil, Funicular::HTTP.cache_lookup(url)
+        # Other entry untouched
+        assert "other entry survives purge", true, !Funicular::HTTP.cache_lookup(old_url).nil?
+
+        log ""
+
+        # --- cache_clear removes everything ---
+        log "-- cache_clear --"
+        Funicular::HTTP.cache_clear
+        assert "cleared old_url", nil, Funicular::HTTP.cache_lookup(old_url)
+
+        log ""
+
+        # --- cache: nil/absent does not consult cache ---
+        log "-- cache: nil bypasses cache lookup --"
+        Funicular::HTTP.cache_write(url, {
+          "status" => 200,
+          "data"   => { "should_not_be_seen" => true },
+          "cached_at" => now
+        })
+        # With cache: nil, get(...) would hit the network. We can't run a
+        # real fetch here, so just verify the entry remains untouched after
+        # cache_lookup and that the test logic above already covers cache hit.
+        assert "entry still present after no-cache call setup", true,
+          !Funicular::HTTP.cache_lookup(url).nil?
+
+        Funicular::HTTP.cache_clear
+
+        log ""
+        log "=== All non-network Phase E tests complete ==="
+        log "Use 'Run Network Test' to exercise live fetch + cache write."
+
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+        log e.backtrace.first(5).join("\n") if e.backtrace
+      end
+
+      JS.document.getElementById('run_net').addEventListener('click') do
+        reset_log
+        log "=== Phase E network test ==="
+        log "Hitting jsonplaceholder.typicode.com (public CORS-enabled JSON API)."
+        log "Watch the browser Network panel: the second GET should NOT issue a request."
+        log ""
+
+        Funicular::HTTP.cache_init!
+        Funicular::HTTP.cache_clear
+
+        net_url = 'https://jsonplaceholder.typicode.com/posts/1'
+
+        log "-- first GET (cache miss, populates cache) --"
+        Funicular::HTTP.get(net_url, cache: 30) do |resp|
+          log "  status=#{resp.status} ok=#{resp.ok}"
+          if resp.ok
+            entry = Funicular::HTTP.cache_lookup(net_url)
+            if entry.is_a?(Hash)
+              log "  cache populated: cached_at=#{entry['cached_at']}"
+              log "  cached title: #{entry['data']['title']}"
+            else
+              log "  WARN: cache miss did not populate (got #{entry.class})"
+            end
+          end
+        end
+
+        log ""
+        log "-- second GET (should hit cache synchronously) --"
+        synchronous = false
+        before_call = true
+        Funicular::HTTP.get(net_url, cache: 30) do |resp|
+          synchronous = before_call  # true only if block ran before next line
+          log "  hit: status=#{resp.status} title=#{resp.data['title']}"
+        end
+        before_call = false
+        if synchronous
+          log "PASS  second GET resolved synchronously (cache hit, no network)"
+        else
+          log "FAIL  second GET did not resolve synchronously"
+        end
+
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+        log e.backtrace.first(5).join("\n") if e.backtrace
+      end
+
+      JS.document.getElementById('reset').addEventListener('click') do
+        reset_log
+        log "clearing HTTP cache..."
+        Funicular::HTTP.cache_init!
+        Funicular::HTTP.cache_clear
+        log "done"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+    </script>
+    <script src="../init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-indexeddb/demo/kvs.html
+++ b/mrbgems/picoruby-indexeddb/demo/kvs.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../test.css">
+    <title>IndexedDB Phase D: KVS facade</title>
+  </head>
+  <body>
+    <div><a href="../index.html">Back</a></div>
+    <h1>IndexedDB Phase D: KVS</h1>
+    <p>
+      Verifies <code>IndexedDB::KVS</code> single-store facade:
+      <code>[]</code>, <code>[]=</code>, <code>delete</code>,
+      <code>has_key?</code>, <code>size</code>, <code>empty?</code>,
+      <code>clear</code>, <code>keys</code>, <code>values</code>,
+      <code>each</code>, <code>to_h</code>.
+    </p>
+    <button id="run">Run Test</button>
+    <button id="reset">Delete Test DB</button>
+    <pre id="output"></pre>
+
+    <script type="text/ruby">
+      require 'js'
+
+      $log = JS.document.getElementById('output')
+
+      def log(msg)
+        $log.innerText = $log.innerText.to_s + msg.to_s + "\n"
+      end
+
+      def reset_log
+        $log.innerText = ''
+      end
+
+      def assert(label, expected, actual)
+        if expected == actual
+          log "PASS  #{label}"
+        else
+          log "FAIL  #{label}: expected #{expected.inspect}, got #{actual.inspect}"
+        end
+      end
+
+      JS.document.getElementById('run').addEventListener('click') do
+        reset_log
+        log "=== Phase D: KVS ==="
+        log ""
+
+        kv = IndexedDB::KVS.open('picoruby_idb_phase_d')
+        log "opened: #{kv.name}"
+
+        # Start clean
+        kv.clear
+
+        # --- []= and [] ---
+        log ""
+        log "-- []= and [] --"
+        kv['theme'] = 'dark'
+        kv['lang']  = 'ja'
+        kv['count'] = 42
+        assert "kv['theme']", 'dark', kv['theme']
+        assert "kv['lang']",  'ja',   kv['lang']
+        assert "kv['count']", 42,     kv['count']
+        assert "kv['missing']", nil,  kv['missing']
+
+        # --- []= returns assigned value ---
+        ret = (kv['x'] = 'y')
+        assert "[]= returns value", 'y', ret
+
+        # --- size and empty? ---
+        log ""
+        log "-- size / empty? --"
+        assert "size", 4, kv.size
+        assert "length alias", 4, kv.length
+        assert "empty?", false, kv.empty?
+
+        # --- has_key? ---
+        log ""
+        log "-- has_key? --"
+        assert "has_key?('theme')", true, kv.has_key?('theme')
+        assert "has_key?('missing')", false, kv.has_key?('missing')
+
+        # --- symbol coerced to string ---
+        log ""
+        log "-- symbol keys are stringified --"
+        kv[:foo] = 'bar'
+        assert "kv[:foo] (sym in)", 'bar', kv[:foo]
+        assert "kv['foo'] (str out)", 'bar', kv['foo']
+
+        # --- delete ---
+        log ""
+        log "-- delete --"
+        kv.delete('lang')
+        assert "after delete: has_key?", false, kv.has_key?('lang')
+        assert "after delete: size", 4, kv.size
+
+        # --- keys / values ---
+        log ""
+        log "-- keys / values --"
+        all_keys = kv.keys.sort
+        log "  keys: #{all_keys.inspect}"
+        assert "keys length", 4, all_keys.length
+        assert "keys include theme", true, all_keys.include?('theme')
+
+        # --- each ---
+        log ""
+        log "-- each --"
+        collected = {} #: Hash[untyped, untyped]
+        kv.each do |pair|
+          k = pair[0]
+          v = pair[1]
+          collected[k.to_s] = v
+        end
+        assert "each yielded 4 pairs", 4, collected.size
+        assert "each: theme value", 'dark', collected['theme']
+        assert "each: count value", 42, collected['count']
+
+        # --- to_h ---
+        log ""
+        log "-- to_h --"
+        h = kv.to_h
+        assert "to_h class", true, h.is_a?(Hash)
+        assert "to_h size", 4, h.size
+        assert "to_h theme", 'dark', h['theme']
+        assert "to_h count", 42, h['count']
+
+        # --- overwrite ---
+        log ""
+        log "-- overwrite --"
+        kv['theme'] = 'light'
+        assert "overwritten value", 'light', kv['theme']
+        assert "size unchanged", 4, kv.size
+
+        # --- clear ---
+        log ""
+        log "-- clear --"
+        kv.clear
+        assert "size after clear", 0, kv.size
+        assert "empty? after clear", true, kv.empty?
+
+        kv.close
+        log ""
+        log "=== All Phase D tests complete ==="
+
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+        log e.backtrace.first(5).join("\n") if e.backtrace
+      end
+
+      JS.document.getElementById('reset').addEventListener('click') do
+        reset_log
+        log "deleting 'picoruby_idb_phase_d'..."
+        req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_d')
+        IndexedDB::Helper.request_to_promise(req).await
+        log "deleted; reload then click Run Test"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+    </script>
+    <script src="../init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-indexeddb/demo/open.html
+++ b/mrbgems/picoruby-indexeddb/demo/open.html
@@ -54,7 +54,7 @@ done
         db = IndexedDB.open(db_name, version: 1) do |d, old_v, new_v|
           upgrade_seen = true
           log "upgrade fired: old=#{old_v} new=#{new_v}"
-          log "  inside upgrade: db.upgrading? #{d._upgrading?}"
+          log "  inside upgrade: db.upgrading? #{d.upgrading?}"
           unless d.has_store?('kv')
             d.create_store('kv')
             log "  created store 'kv'"
@@ -64,7 +64,7 @@ done
         end
 
         log "upgrade was skipped (already at version 1)" unless upgrade_seen
-        log "open returned: name=#{db.name} version=#{db.version} upgrading?=#{db._upgrading?}"
+        log "open returned: name=#{db.name} version=#{db.version} upgrading?=#{db.upgrading?}"
         log "store_names: #{db.store_names.inspect}"
         log "has_store?(kv): #{db.has_store?('kv')}"
         log "has_store?(missing): #{db.has_store?('missing')}"
@@ -78,7 +78,7 @@ done
         reset_log
         log "deleting 'picoruby_idb_phase_a'..."
         req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_a')
-        IndexedDB::Helper._request_to_promise(req).await
+        IndexedDB::Helper.request_to_promise(req).await
         log "deleted; reload then click Run Test to re-trigger upgrade"
       rescue => e
         log "ERROR: #{e.class}: #{e.message}"

--- a/mrbgems/picoruby-indexeddb/demo/open.html
+++ b/mrbgems/picoruby-indexeddb/demo/open.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../test.css">
+    <title>IndexedDB Phase A: open + upgrade</title>
+  </head>
+  <body>
+    <div><a href="../index.html">Back</a></div>
+    <h1>IndexedDB Phase A: open + upgrade</h1>
+    <p>
+      Verifies <code>IndexedDB.available?</code>, <code>IndexedDB.open</code>
+      with a synchronous upgrade callback, and schema introspection
+      (<code>store_names</code>, <code>has_store?</code>).
+    </p>
+    <button id="run">Run Test</button>
+    <button id="reset">Delete Test DB</button>
+    <pre id="output"></pre>
+
+    <!-- Expected on first run:
+available?: true
+opening 'picoruby_idb_phase_a' v1...
+upgrade fired: old=0 new=1
+  inside upgrade: db.upgrading? true
+  created store 'kv'
+open returned: name=picoruby_idb_phase_a version=1 upgrading?=false
+store_names: ["kv"]
+has_store?(kv): true
+has_store?(missing): false
+done
+    -->
+
+    <script type="text/ruby">
+      require 'js'
+
+      $log = JS.document.getElementById('output')
+
+      def log(msg)
+        $log.innerText = $log.innerText.to_s + msg.to_s + "\n"
+      end
+
+      def reset_log
+        $log.innerText = ''
+      end
+
+      JS.document.getElementById('run').addEventListener('click') do
+        reset_log
+        log "available?: #{IndexedDB.available?}"
+
+        db_name = 'picoruby_idb_phase_a'
+        log "opening '#{db_name}' v1..."
+
+        upgrade_seen = false
+        db = IndexedDB.open(db_name, version: 1) do |d, old_v, new_v|
+          upgrade_seen = true
+          log "upgrade fired: old=#{old_v} new=#{new_v}"
+          log "  inside upgrade: db.upgrading? #{d._upgrading?}"
+          unless d.has_store?('kv')
+            d.create_store('kv')
+            log "  created store 'kv'"
+          else
+            log "  store 'kv' already exists"
+          end
+        end
+
+        log "upgrade was skipped (already at version 1)" unless upgrade_seen
+        log "open returned: name=#{db.name} version=#{db.version} upgrading?=#{db._upgrading?}"
+        log "store_names: #{db.store_names.inspect}"
+        log "has_store?(kv): #{db.has_store?('kv')}"
+        log "has_store?(missing): #{db.has_store?('missing')}"
+        db.close
+        log "done"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+
+      JS.document.getElementById('reset').addEventListener('click') do
+        reset_log
+        log "deleting 'picoruby_idb_phase_a'..."
+        req = JS.global[:indexedDB].deleteDatabase('picoruby_idb_phase_a')
+        IndexedDB::Helper._request_to_promise(req).await
+        log "deleted; reload then click Run Test to re-trigger upgrade"
+      rescue => e
+        log "ERROR: #{e.class}: #{e.message}"
+      end
+    </script>
+    <script src="../init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-indexeddb/mrbgem.rake
+++ b/mrbgems/picoruby-indexeddb/mrbgem.rake
@@ -1,0 +1,10 @@
+MRuby::Gem::Specification.new('picoruby-indexeddb') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'HASUMI Hitoshi'
+  spec.summary = 'Ruby-idiomatic IndexedDB wrapper for PicoRuby.wasm'
+
+  spec.add_dependency 'picoruby-wasm'
+  spec.add_dependency 'picoruby-json'
+
+  spec.require_name = 'indexeddb'
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
@@ -25,37 +25,40 @@ module IndexedDB
   # in-memory implementation with the same API surface (no persistence).
   def self.open(name, version: 1, fallback: true, &block)
     if available?
-      _open_real(name, version, &block)
+      open_real(name, version, &block)
     elsif fallback
-      _open_fallback(name, version, &block)
+      open_fallback(name, version, &block)
     else
       raise NotSupportedError, "IndexedDB is not available in this environment"
     end
   end
 
-  def self._open_real(name, version, &block)
-    callback_id = 0
-    if block
-      user_block = block
-      # @type var user_block: ^(IndexedDB::db_like, Integer, Integer) -> void
-      proc_obj = ->(db_ref, old_v, new_v) do
-        upgrade_db = Database.new(db_ref, name: name, upgrading: true)
-        user_block.call(upgrade_db, old_v, new_v)
-        upgrade_db._mark_upgrade_done
-        nil
+  class << self
+    private
+
+    def open_real(name, version, &block)
+      callback_id = 0
+      if block
+        user_block = block
+        # @type var user_block: ^(IndexedDB::db_like, Integer, Integer) -> void
+        proc_obj = ->(db_ref, old_v, new_v) do
+          upgrade_db = Database.new(db_ref, name: name, upgrading: true)
+          user_block.call(upgrade_db, old_v, new_v)
+          upgrade_db.mark_upgrade_done
+          nil
+        end
+        callback_id = proc_obj.object_id
+        JS::Object::CALLBACKS[callback_id] = proc_obj
       end
-      callback_id = proc_obj.object_id
-      JS::Object::CALLBACKS[callback_id] = proc_obj
+
+      promise = Helper.open_with_upgrade(name.to_s, version.to_i, callback_id)
+      raw_db = promise.await
+      JS::Object::CALLBACKS.delete(callback_id) if callback_id != 0
+      Database.new(raw_db, name: name, upgrading: false)
     end
 
-    promise = Helper._open_with_upgrade(name.to_s, version.to_i, callback_id)
-    raw_db = promise.await
-    JS::Object::CALLBACKS.delete(callback_id) if callback_id != 0
-    Database.new(raw_db, name: name, upgrading: false)
-  end
-
-  def self._open_fallback(name, version, &block)
-    # InMemoryDatabase is defined in indexeddb_in_memory.rb (Phase B).
-    InMemoryDatabase.open(name, version, &block)
+    def open_fallback(name, version, &block)
+      InMemoryDatabase.open(name, version, &block)
+    end
   end
 end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
@@ -1,0 +1,61 @@
+begin
+  require 'js'
+rescue LoadError
+  # Not available outside the wasm build; the in-memory fallback still works.
+end
+
+module IndexedDB
+  # True when the browser exposes globalThis.indexedDB.
+  def self.available?
+    !JS.global[:indexedDB].nil?
+  end
+
+  # Open (and upgrade) a database.
+  #
+  #   IndexedDB.open('mydb', version: 2) do |db, old_v, new_v|
+  #     db.create_store('users', key_path: 'id') if old_v < 1
+  #     db.create_store('cache')                  if old_v < 2
+  #   end
+  #
+  # The block runs synchronously inside onupgradeneeded if (and only if)
+  # a schema upgrade is triggered. Schema mutations are valid only there.
+  # `await` MUST NOT be used inside the upgrade block.
+  #
+  # When `IndexedDB.available?` is false, the call falls back to an
+  # in-memory implementation with the same API surface (no persistence).
+  def self.open(name, version: 1, fallback: true, &block)
+    if available?
+      _open_real(name, version, &block)
+    elsif fallback
+      _open_fallback(name, version, &block)
+    else
+      raise NotSupportedError, "IndexedDB is not available in this environment"
+    end
+  end
+
+  def self._open_real(name, version, &block)
+    callback_id = 0
+    if block
+      user_block = block
+      # @type var user_block: ^(IndexedDB::db_like, Integer, Integer) -> void
+      proc_obj = ->(db_ref, old_v, new_v) do
+        upgrade_db = Database.new(db_ref, name: name, upgrading: true)
+        user_block.call(upgrade_db, old_v, new_v)
+        upgrade_db._mark_upgrade_done
+        nil
+      end
+      callback_id = proc_obj.object_id
+      JS::Object::CALLBACKS[callback_id] = proc_obj
+    end
+
+    promise = Helper._open_with_upgrade(name.to_s, version.to_i, callback_id)
+    raw_db = promise.await
+    JS::Object::CALLBACKS.delete(callback_id) if callback_id != 0
+    Database.new(raw_db, name: name, upgrading: false)
+  end
+
+  def self._open_fallback(name, version, &block)
+    # InMemoryDatabase is defined in indexeddb_in_memory.rb (Phase B).
+    InMemoryDatabase.open(name, version, &block)
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
@@ -1,0 +1,112 @@
+module IndexedDB
+  # Atomic multi-store transaction. Created by Database#batch.
+  #
+  # The block enqueues write requests synchronously without awaiting; on block
+  # exit, a single Promise tied to the transaction's oncomplete event is awaited
+  # (committing the whole group or rolling back on error).
+  #
+  # Inside the block, await-bearing operations (get / count / keys / to_a / each
+  # / index) are forbidden because each await yields to the JS event loop, which
+  # auto-commits the transaction and corrupts state. They raise AwaitInBatchError.
+  class Batch
+    def initialize(database, store_names, mode)
+      @database = database
+      js_db = database._js_db
+      mode_str = mode.to_s
+
+      tx = if store_names.length == 1
+             js_db.transaction(store_names[0], mode_str)
+           else
+             names_arr = JS.global.create_array
+             store_names.each { |n| names_arr.push(n) }
+             js_db.transaction(names_arr, mode_str)
+           end
+
+      @tx = tx
+      @views = {} #: Hash[String, StoreView]
+    end
+
+    # Returns a StoreView for the named store. Cached per-batch.
+    def [](store_name)
+      key = store_name.to_s
+      view = @views[key]
+      return view if view
+      js_store = @tx.objectStore(key)
+      v = StoreView.new(js_store, key)
+      @views[key] = v
+      v
+    end
+
+    def _await_complete
+      promise = Helper._transaction_to_promise(@tx)
+      promise.await
+      nil
+    end
+
+    # Restricted Store-like interface usable inside a batch block. Only
+    # operations that do NOT need to await an IDBRequest are exposed. Read
+    # methods raise AwaitInBatchError so users get a clear failure mode.
+    class StoreView
+      attr_reader :name
+
+      def initialize(js_store, name)
+        @js_store = js_store
+        @name = name
+      end
+
+      def put(value, key: nil)
+        js_value = JS::Bridge.to_js(value)
+        if key.nil?
+          @js_store.put(js_value)
+        else
+          @js_store.put(js_value, JS::Bridge.to_js(key))
+        end
+        nil
+      end
+
+      def add(value, key: nil)
+        js_value = JS::Bridge.to_js(value)
+        if key.nil?
+          @js_store.add(js_value)
+        else
+          @js_store.add(js_value, JS::Bridge.to_js(key))
+        end
+        nil
+      end
+
+      def delete(key)
+        @js_store.delete(JS::Bridge.to_js(key))
+        nil
+      end
+
+      def clear
+        @js_store.clear
+        nil
+      end
+
+      def get(_key)
+        raise AwaitInBatchError, "get cannot be called inside batch; perform reads outside the batch block"
+      end
+
+      def count(_key_or_range = nil)
+        raise AwaitInBatchError, "count cannot be called inside batch"
+      end
+
+      def keys(_range = nil)
+        raise AwaitInBatchError, "keys cannot be called inside batch"
+      end
+
+      def to_a(_range = nil)
+        raise AwaitInBatchError, "to_a cannot be called inside batch"
+      end
+
+      def each(*_args)
+        raise AwaitInBatchError, "each cannot be called inside batch"
+      end
+
+      def index(_name)
+        raise AwaitInBatchError, "index cannot be called inside batch"
+      end
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
@@ -11,7 +11,7 @@ module IndexedDB
   class Batch
     def initialize(database, store_names, mode)
       @database = database
-      js_db = database._js_db
+      js_db = database.js_db
       mode_str = mode.to_s
 
       tx = if store_names.length == 1
@@ -37,8 +37,8 @@ module IndexedDB
       v
     end
 
-    def _await_complete
-      promise = Helper._transaction_to_promise(@tx)
+    def await_complete
+      promise = Helper.transaction_to_promise(@tx)
       promise.await
       nil
     end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
@@ -50,16 +50,16 @@ module IndexedDB
     # ---- Schema mutations (upgrade-only) -----------------------------------
 
     def create_store(name, key_path: nil, auto_increment: false)
-      _ensure_upgrading!('create_store')
+      ensure_upgrading!('create_store')
       opts = JS.global.create_object
       opts[:keyPath] = key_path.to_s if key_path
       opts[:autoIncrement] = true if auto_increment
       js_store = @js_db.createObjectStore(name.to_s, opts)
-      _store_for(js_store, name.to_s)
+      store_for(js_store, name.to_s)
     end
 
     def delete_store(name)
-      _ensure_upgrading!('delete_store')
+      ensure_upgrading!('delete_store')
       @js_db.deleteObjectStore(name.to_s)
       nil
     end
@@ -79,18 +79,10 @@ module IndexedDB
         if tx.nil?
           raise SchemaError, "no active versionchange transaction"
         end
-        _store_for(tx.objectStore(name.to_s), name.to_s)
+        store_for(tx.objectStore(name.to_s), name.to_s)
       else
-        # Phase B: returns a Store that opens a one-shot transaction per op.
         Store.new(self, name.to_s)
       end
-    end
-
-    # Internal: build a Store wrapping a specific IDBObjectStore (used
-    # during upgrade so create_store / store(name) return upgrade-mode
-    # stores backed by the versionchange transaction).
-    def _store_for(js_store, name)
-      Store.new(self, name, js_store: js_store, upgrading: @upgrading)
     end
 
     # Atomic multi-store transaction.
@@ -104,36 +96,40 @@ module IndexedDB
     # tx[name] raise AwaitInBatchError. The whole group commits atomically
     # on block exit, or rolls back if any request errors.
     def batch(store_names, mode: :readwrite, &block)
-      _ensure_not_upgrading!
+      ensure_not_upgrading!
       raise ArgumentError, "batch requires a block" unless block
       names = store_names.is_a?(Array) ? store_names.map { |n| n.to_s } : [store_names.to_s]
       tx = Batch.new(self, names, mode)
       block.call(tx)
-      tx._await_complete
+      tx.await_complete
     end
 
-    # Internal: marks the upgrade phase complete. After this, the Database
-    # rejects schema mutations.
-    def _mark_upgrade_done
+    # Marks the upgrade phase complete. Called from IndexedDB.open after the
+    # upgrade callback returns. Public because it crosses module boundaries.
+    def mark_upgrade_done
       @upgrading = false
     end
 
-    def _js_db
+    def js_db
       @js_db
     end
 
-    def _upgrading?
+    def upgrading?
       @upgrading
     end
 
     private
 
-    def _ensure_upgrading!(op)
+    def store_for(js_store, name)
+      Store.new(self, name, js_store: js_store, upgrading: @upgrading)
+    end
+
+    def ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
     end
 
-    def _ensure_not_upgrading!
+    def ensure_not_upgrading!
       return unless @upgrading
       raise SchemaError, "batch cannot be called inside the upgrade block"
     end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
@@ -93,6 +93,25 @@ module IndexedDB
       Store.new(self, name, js_store: js_store, upgrading: @upgrading)
     end
 
+    # Atomic multi-store transaction.
+    #
+    #   db.batch(['users', 'cache'], mode: :readwrite) do |tx|
+    #     tx['users'].put({ id: 1, name: 'Alice' })
+    #     tx['cache'].put('hot', key: 'tier')
+    #   end
+    #
+    # No await is permitted inside the block. Reads (get/count/keys/...) on
+    # tx[name] raise AwaitInBatchError. The whole group commits atomically
+    # on block exit, or rolls back if any request errors.
+    def batch(store_names, mode: :readwrite, &block)
+      _ensure_not_upgrading!
+      raise ArgumentError, "batch requires a block" unless block
+      names = store_names.is_a?(Array) ? store_names.map { |n| n.to_s } : [store_names.to_s]
+      tx = Batch.new(self, names, mode)
+      block.call(tx)
+      tx._await_complete
+    end
+
     # Internal: marks the upgrade phase complete. After this, the Database
     # rejects schema mutations.
     def _mark_upgrade_done
@@ -112,6 +131,11 @@ module IndexedDB
     def _ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+
+    def _ensure_not_upgrading!
+      return unless @upgrading
+      raise SchemaError, "batch cannot be called inside the upgrade block"
     end
   end
 end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_database.rb
@@ -1,0 +1,117 @@
+module IndexedDB
+  # Wraps an IDBDatabase. Two lifecycle states:
+  #
+  #   * upgrading: true   - constructed inside the upgrade callback. Schema
+  #     mutations (create_store / delete_store / Store#create_index) are
+  #     valid here and only here. Stays valid only for the duration of the
+  #     onupgradeneeded handler; await is forbidden.
+  #
+  #   * upgrading: false  - the normal post-open state. Schema mutations
+  #     raise SchemaError. Await-bearing operations on Stores are valid.
+  class Database
+    attr_reader :name
+
+    def initialize(js_db, name:, upgrading:)
+      @js_db = js_db
+      @name = name
+      @upgrading = upgrading
+    end
+
+    def closed?
+      @js_db.nil?
+    end
+
+    def close
+      return if closed?
+      @js_db.close
+      @js_db = nil
+    end
+
+    def version
+      @js_db[:version].to_i
+    end
+
+    def store_names
+      list = @js_db[:objectStoreNames]
+      n = list[:length].to_i
+      result = [] #: Array[String]
+      i = 0
+      while i < n
+        result << list.item(i).to_s
+        i += 1
+      end
+      result
+    end
+
+    def has_store?(name)
+      store_names.include?(name.to_s)
+    end
+
+    # ---- Schema mutations (upgrade-only) -----------------------------------
+
+    def create_store(name, key_path: nil, auto_increment: false)
+      _ensure_upgrading!('create_store')
+      opts = JS.global.create_object
+      opts[:keyPath] = key_path.to_s if key_path
+      opts[:autoIncrement] = true if auto_increment
+      js_store = @js_db.createObjectStore(name.to_s, opts)
+      _store_for(js_store, name.to_s)
+    end
+
+    def delete_store(name)
+      _ensure_upgrading!('delete_store')
+      @js_db.deleteObjectStore(name.to_s)
+      nil
+    end
+
+    # ---- Accessors ---------------------------------------------------------
+
+    # Inside upgrade context, returns a Store wrapping the upgrade-mode
+    # IDBObjectStore (so create_index can be called). Outside, returns a
+    # Store backed by a fresh one-shot transaction per operation.
+    def store(name)
+      if @upgrading
+        # During upgradeneeded the implicit versionchange transaction is
+        # available on the request, but the IDBObjectStore must be obtained
+        # from the version-change transaction. We expose it via the JS
+        # Database#transaction property which IDB sets on the open request.
+        tx = @js_db[:transaction]
+        if tx.nil?
+          raise SchemaError, "no active versionchange transaction"
+        end
+        _store_for(tx.objectStore(name.to_s), name.to_s)
+      else
+        # Phase B: returns a Store that opens a one-shot transaction per op.
+        Store.new(self, name.to_s)
+      end
+    end
+
+    # Internal: build a Store wrapping a specific IDBObjectStore (used
+    # during upgrade so create_store / store(name) return upgrade-mode
+    # stores backed by the versionchange transaction).
+    def _store_for(js_store, name)
+      Store.new(self, name, js_store: js_store, upgrading: @upgrading)
+    end
+
+    # Internal: marks the upgrade phase complete. After this, the Database
+    # rejects schema mutations.
+    def _mark_upgrade_done
+      @upgrading = false
+    end
+
+    def _js_db
+      @js_db
+    end
+
+    def _upgrading?
+      @upgrading
+    end
+
+    private
+
+    def _ensure_upgrading!(op)
+      return if @upgrading
+      raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_errors.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_errors.rb
@@ -1,0 +1,24 @@
+module IndexedDB
+  class Error < StandardError; end
+
+  # Raised when IndexedDB is not available in the current environment AND
+  # the caller has explicitly disabled the in-memory fallback.
+  class NotSupportedError < Error; end
+
+  # Raised when an open() request fails (req.error or rejected promise).
+  class OpenError < Error; end
+
+  # Raised when versionchange is blocked because another connection still
+  # holds an older version of the database.
+  class BlockedError < Error; end
+
+  # Raised when Ruby code attempts to await a result inside a Database#batch
+  # block. IDB transactions auto-commit at every JS event-loop turn, and every
+  # JS::Promise#await yields to the event loop, so awaiting inside a batch
+  # would deterministically kill the transaction.
+  class AwaitInBatchError < Error; end
+
+  # Raised when a schema mutation (create_store, delete_store, create_index)
+  # is invoked outside an upgrade callback.
+  class SchemaError < Error; end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
@@ -1,0 +1,55 @@
+module IndexedDB
+  # Phase A: stub for the Hash-backed fallback. Database#open delegates here
+  # when IndexedDB.available? is false. The actual KVS-style methods are
+  # added in Phase B alongside the real Store.
+  class InMemoryDatabase
+    def self.open(name, version, &block)
+      db = new(name, version)
+      if block
+        block.call(db, 0, version)
+        db._mark_upgrade_done
+      end
+      db
+    end
+
+    def initialize(name, version)
+      @name = name
+      @version = version
+      @upgrading = true
+    end
+
+    def name; @name; end
+    def version; @version; end
+    def closed?; false; end
+    def close; end
+    def store_names; []; end
+    def has_store?(_); false; end
+
+    def create_store(name, key_path: nil, auto_increment: false)
+      _ensure_upgrading!('create_store')
+      # Phase B will register the store in the singleton hash. For Phase A
+      # we accept the call so smoke tests do not crash in fallback mode.
+      nil
+    end
+
+    def delete_store(name)
+      _ensure_upgrading!('delete_store')
+      nil
+    end
+
+    def store(name)
+      nil
+    end
+
+    def _mark_upgrade_done
+      @upgrading = false
+    end
+
+    private
+
+    def _ensure_upgrading!(op)
+      return if @upgrading
+      raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
@@ -101,6 +101,17 @@ module IndexedDB
       InMemoryStore.new(self, store_name, upgrading: @upgrading)
     end
 
+    # In-memory batch: synchronous, no real transaction. The block runs
+    # against InMemoryBatchView which mirrors Batch::StoreView semantics.
+    def batch(store_names, mode: :readwrite, &block)
+      raise SchemaError, "batch cannot be called inside the upgrade block" if @upgrading
+      raise ArgumentError, "batch requires a block" unless block
+      names = store_names.is_a?(Array) ? store_names.map { |n| n.to_s } : [store_names.to_s]
+      tx = InMemoryBatch.new(self, names, mode)
+      block.call(tx)
+      nil
+    end
+
     def _mark_upgrade_done
       @upgrading = false
     end
@@ -280,6 +291,82 @@ module IndexedDB
     def _ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+  end
+
+  # In-memory batch wrapper. Mirrors Batch's API surface so the same user
+  # block runs against either backend. Reads still raise AwaitInBatchError
+  # so users do not write code that only works on the in-memory path.
+  class InMemoryBatch
+    def initialize(database, store_names, mode)
+      @database = database
+      @store_names = store_names
+      @mode = mode.to_s
+      @views = {} #: Hash[String, InMemoryBatchView]
+    end
+
+    def [](store_name)
+      key = store_name.to_s
+      view = @views[key]
+      return view if view
+      raise Error, "store '#{key}' not in this batch's scope" unless @store_names.include?(key)
+      v = InMemoryBatchView.new(@database, key)
+      @views[key] = v
+      v
+    end
+  end
+
+  class InMemoryBatchView
+    attr_reader :name
+
+    def initialize(database, name)
+      @database = database
+      @name = name
+      @store = InMemoryStore.new(database, name, upgrading: false)
+    end
+
+    def put(value, key: nil)
+      @store.put(value, key: key)
+      nil
+    end
+
+    def add(value, key: nil)
+      @store.put(value, key: key)
+      nil
+    end
+
+    def delete(key)
+      @store.delete(key)
+      nil
+    end
+
+    def clear
+      @store.clear
+      nil
+    end
+
+    def get(_key)
+      raise AwaitInBatchError, "get cannot be called inside batch"
+    end
+
+    def count(_key_or_range = nil)
+      raise AwaitInBatchError, "count cannot be called inside batch"
+    end
+
+    def keys(_range = nil)
+      raise AwaitInBatchError, "keys cannot be called inside batch"
+    end
+
+    def to_a(_range = nil)
+      raise AwaitInBatchError, "to_a cannot be called inside batch"
+    end
+
+    def each(*_args)
+      raise AwaitInBatchError, "each cannot be called inside batch"
+    end
+
+    def index(_name)
+      raise AwaitInBatchError, "index cannot be called inside batch"
     end
   end
 

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
@@ -1,14 +1,35 @@
 module IndexedDB
-  # Phase A: stub for the Hash-backed fallback. Database#open delegates here
-  # when IndexedDB.available? is false. The actual KVS-style methods are
-  # added in Phase B alongside the real Store.
+  # Hash-backed fallback when IndexedDB is unavailable.
+  # Provides the same API surface as Database for transparent fallback.
   class InMemoryDatabase
+    # Class instance variables for singleton storage
+    @stores = {} #: Hash[[String, String], Hash[untyped, untyped]]
+    @meta = {}   #: Hash[String, Hash[Symbol, untyped]]
+
+    class << self
+      attr_accessor :stores, :meta
+    end
+
     def self.open(name, version, &block)
+      @stores ||= {} #: Hash[[String, String], Hash[untyped, untyped]]
+      @meta ||= {} #: Hash[String, Hash[Symbol, untyped]]
+
+      # Check existing version
+      existing_version = @meta.dig(name, :version) || 0
+
       db = new(name, version)
-      if block
-        block.call(db, 0, version)
+
+      if block && existing_version < version
+        block.call(db, existing_version, version)
+        db._mark_upgrade_done
+      else
         db._mark_upgrade_done
       end
+
+      # Record the version
+      @meta[name] ||= {} #: Hash[Symbol, untyped]
+      @meta[name][:version] = version
+
       db
     end
 
@@ -16,33 +37,88 @@ module IndexedDB
       @name = name
       @version = version
       @upgrading = true
+      @closed = false
+      @store_names = self.class.meta.dig(name, :stores)&.keys || []
     end
 
     def name; @name; end
     def version; @version; end
-    def closed?; false; end
-    def close; end
-    def store_names; []; end
-    def has_store?(_); false; end
+    def closed?; @closed; end
+
+    def close
+      @closed = true
+    end
+
+    def store_names
+      @store_names.dup
+    end
+
+    def has_store?(name)
+      @store_names.include?(name.to_s)
+    end
+
+    # ---- Schema mutations (upgrade only) -----------------------------------
 
     def create_store(name, key_path: nil, auto_increment: false)
       _ensure_upgrading!('create_store')
-      # Phase B will register the store in the singleton hash. For Phase A
-      # we accept the call so smoke tests do not crash in fallback mode.
-      nil
+      store_name = name.to_s
+
+      # Initialize storage
+      self.class.stores[[@name, store_name]] ||= {} #: Hash[untyped, untyped]
+
+      # Record metadata
+      self.class.meta[@name] ||= {} #: Hash[Symbol, untyped]
+      self.class.meta[@name][:stores] ||= {} #: Hash[String, Hash[Symbol, untyped]]
+      self.class.meta[@name][:stores][store_name] = {
+        key_path: key_path&.to_s,
+        auto_increment: auto_increment,
+        next_key: 1,
+        indexes: {} #: Hash[String, Hash[Symbol, untyped]]
+      }
+
+      @store_names << store_name unless @store_names.include?(store_name)
+
+      # Return a store object for chaining (e.g., create_index during upgrade)
+      InMemoryStore.new(self, store_name, upgrading: true)
     end
 
     def delete_store(name)
       _ensure_upgrading!('delete_store')
+      store_name = name.to_s
+
+      self.class.stores.delete([@name, store_name])
+      self.class.meta[@name][:stores]&.delete(store_name)
+      @store_names.delete(store_name)
+
       nil
     end
 
+    # ---- Accessors ---------------------------------------------------------
+
     def store(name)
-      nil
+      store_name = name.to_s
+      return nil unless has_store?(store_name)
+      InMemoryStore.new(self, store_name, upgrading: @upgrading)
     end
 
     def _mark_upgrade_done
       @upgrading = false
+    end
+
+    def _upgrading?
+      @upgrading
+    end
+
+    def _db_name
+      @name
+    end
+
+    def _store_meta(store_name)
+      self.class.meta.dig(@name, :stores, store_name) || {} #: Hash[Symbol, untyped]
+    end
+
+    def _store_data(store_name)
+      self.class.stores[[@name, store_name]] ||= {} #: Hash[untyped, untyped]
     end
 
     private
@@ -50,6 +126,194 @@ module IndexedDB
     def _ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+  end
+
+  # In-memory Store implementation with the same API as Store.
+  class InMemoryStore
+    attr_reader :name
+
+    def initialize(database, name, upgrading: false)
+      @database = database
+      @name = name
+      @upgrading = upgrading
+    end
+
+    # ---- One-shot operations -----------------------------------------------
+
+    def get(key)
+      _data[key]
+    end
+
+    def put(value, key: nil)
+      meta = _meta
+      actual_key = if key.nil? && meta[:key_path]
+                     # Extract key from value using key_path
+                     _extract_key(value, meta[:key_path])
+                   elsif key.nil? && meta[:auto_increment]
+                     k = meta[:next_key]
+                     meta[:next_key] = k + 1
+                     k
+                   else
+                     key
+                   end
+
+      raise Error, "No key provided and no key_path/auto_increment" if actual_key.nil?
+
+      # Deep copy to avoid mutation issues
+      stored_value = _deep_copy(value)
+      _data[actual_key] = stored_value
+      actual_key
+    end
+
+    def delete(key)
+      _data.delete(key)
+      nil
+    end
+
+    def count(key_or_range = nil)
+      if key_or_range.nil?
+        _data.size
+      else
+        # Simple key lookup
+        _data.key?(key_or_range) ? 1 : 0
+      end
+    end
+
+    def clear
+      _data.clear
+      nil
+    end
+
+    def keys(range = nil)
+      if range.nil?
+        _data.keys
+      else
+        # For simplicity, return all keys (range filtering would need more work)
+        _data.keys
+      end
+    end
+
+    def to_a(range = nil)
+      if range.nil?
+        _data.values
+      else
+        _data.values
+      end
+    end
+
+    def each(range = nil, direction: :next)
+      return to_enum(:each, range, direction: direction) unless block_given?
+
+      pairs = _data.to_a
+      pairs = pairs.reverse if direction == :prev || direction == 'prev'
+
+      pairs.each do |key, value|
+        yield [key, value]
+      end
+    end
+
+    # ---- Index access (stub) -----------------------------------------------
+
+    def index(index_name)
+      # Return a simple stub that returns nil/empty for queries
+      InMemoryIndex.new(self, index_name.to_s)
+    end
+
+    # ---- Schema mutations (upgrade only) -----------------------------------
+
+    def create_index(index_name, key_path, unique: false, multi_entry: false)
+      _ensure_upgrading!('create_index')
+      meta = _meta
+      meta[:indexes] ||= {}
+      meta[:indexes][index_name.to_s] = {
+        key_path: key_path.to_s,
+        unique: unique,
+        multi_entry: multi_entry
+      }
+      nil
+    end
+
+    def delete_index(index_name)
+      _ensure_upgrading!('delete_index')
+      meta = _meta
+      meta[:indexes]&.delete(index_name.to_s)
+      nil
+    end
+
+    def index_names
+      meta = _meta
+      (meta[:indexes] || {}).keys
+    end
+
+    # ---- Internal ----------------------------------------------------------
+
+    def _data
+      @database._store_data(@name)
+    end
+
+    def _meta
+      @database._store_meta(@name)
+    end
+
+    def _extract_key(value, key_path)
+      # Simple single-level key extraction
+      if value.is_a?(Hash)
+        value[key_path] || value[key_path.to_sym]
+      else
+        nil
+      end
+    end
+
+    def _deep_copy(obj)
+      case obj
+      when Hash
+        obj.each_with_object({} #: Hash[untyped, untyped]
+        ) { |(k, v), h| h[k] = _deep_copy(v) }
+      when Array
+        obj.map { |v| _deep_copy(v) }
+      else
+        obj
+      end
+    end
+
+    def _ensure_upgrading!(op)
+      return if @upgrading
+      raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+  end
+
+  # Minimal Index stub for in-memory fallback.
+  class InMemoryIndex
+    attr_reader :name
+
+    def initialize(store, name)
+      @store = store
+      @name = name
+    end
+
+    def get(key)
+      # Linear scan for matching value
+      meta = @store._meta
+      index_meta = meta[:indexes]&.dig(@name)
+      return nil unless index_meta
+
+      key_path = index_meta[:key_path]
+      @store._data.each_value do |value|
+        if value.is_a?(Hash)
+          indexed_val = value[key_path] || value[key_path.to_sym]
+          return value if indexed_val == key
+        end
+      end
+      nil
+    end
+
+    def to_a
+      @store.to_a
+    end
+
+    def each(&block)
+      @store.each(&block)
     end
   end
 end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_in_memory.rb
@@ -2,7 +2,6 @@ module IndexedDB
   # Hash-backed fallback when IndexedDB is unavailable.
   # Provides the same API surface as Database for transparent fallback.
   class InMemoryDatabase
-    # Class instance variables for singleton storage
     @stores = {} #: Hash[[String, String], Hash[untyped, untyped]]
     @meta = {}   #: Hash[String, Hash[Symbol, untyped]]
 
@@ -14,19 +13,17 @@ module IndexedDB
       @stores ||= {} #: Hash[[String, String], Hash[untyped, untyped]]
       @meta ||= {} #: Hash[String, Hash[Symbol, untyped]]
 
-      # Check existing version
       existing_version = @meta.dig(name, :version) || 0
 
       db = new(name, version)
 
       if block && existing_version < version
         block.call(db, existing_version, version)
-        db._mark_upgrade_done
+        db.mark_upgrade_done
       else
-        db._mark_upgrade_done
+        db.mark_upgrade_done
       end
 
-      # Record the version
       @meta[name] ||= {} #: Hash[Symbol, untyped]
       @meta[name][:version] = version
 
@@ -60,13 +57,11 @@ module IndexedDB
     # ---- Schema mutations (upgrade only) -----------------------------------
 
     def create_store(name, key_path: nil, auto_increment: false)
-      _ensure_upgrading!('create_store')
+      ensure_upgrading!('create_store')
       store_name = name.to_s
 
-      # Initialize storage
       self.class.stores[[@name, store_name]] ||= {} #: Hash[untyped, untyped]
 
-      # Record metadata
       self.class.meta[@name] ||= {} #: Hash[Symbol, untyped]
       self.class.meta[@name][:stores] ||= {} #: Hash[String, Hash[Symbol, untyped]]
       self.class.meta[@name][:stores][store_name] = {
@@ -78,12 +73,11 @@ module IndexedDB
 
       @store_names << store_name unless @store_names.include?(store_name)
 
-      # Return a store object for chaining (e.g., create_index during upgrade)
       InMemoryStore.new(self, store_name, upgrading: true)
     end
 
     def delete_store(name)
-      _ensure_upgrading!('delete_store')
+      ensure_upgrading!('delete_store')
       store_name = name.to_s
 
       self.class.stores.delete([@name, store_name])
@@ -112,29 +106,25 @@ module IndexedDB
       nil
     end
 
-    def _mark_upgrade_done
+    def mark_upgrade_done
       @upgrading = false
     end
 
-    def _upgrading?
+    def upgrading?
       @upgrading
     end
 
-    def _db_name
-      @name
-    end
-
-    def _store_meta(store_name)
+    def store_meta(store_name)
       self.class.meta.dig(@name, :stores, store_name) || {} #: Hash[Symbol, untyped]
     end
 
-    def _store_data(store_name)
+    def store_data(store_name)
       self.class.stores[[@name, store_name]] ||= {} #: Hash[untyped, untyped]
     end
 
     private
 
-    def _ensure_upgrading!(op)
+    def ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
     end
@@ -153,17 +143,16 @@ module IndexedDB
     # ---- One-shot operations -----------------------------------------------
 
     def get(key)
-      _data[key]
+      data[key]
     end
 
     def put(value, key: nil)
-      meta = _meta
-      actual_key = if key.nil? && meta[:key_path]
-                     # Extract key from value using key_path
-                     _extract_key(value, meta[:key_path])
-                   elsif key.nil? && meta[:auto_increment]
-                     k = meta[:next_key]
-                     meta[:next_key] = k + 1
+      m = meta
+      actual_key = if key.nil? && m[:key_path]
+                     extract_key(value, m[:key_path])
+                   elsif key.nil? && m[:auto_increment]
+                     k = m[:next_key]
+                     m[:next_key] = k + 1
                      k
                    else
                      key
@@ -171,52 +160,49 @@ module IndexedDB
 
       raise Error, "No key provided and no key_path/auto_increment" if actual_key.nil?
 
-      # Deep copy to avoid mutation issues
-      stored_value = _deep_copy(value)
-      _data[actual_key] = stored_value
+      stored_value = deep_copy(value)
+      data[actual_key] = stored_value
       actual_key
     end
 
     def delete(key)
-      _data.delete(key)
+      data.delete(key)
       nil
     end
 
     def count(key_or_range = nil)
       if key_or_range.nil?
-        _data.size
+        data.size
       else
-        # Simple key lookup
-        _data.key?(key_or_range) ? 1 : 0
+        data.key?(key_or_range) ? 1 : 0
       end
     end
 
     def clear
-      _data.clear
+      data.clear
       nil
     end
 
     def keys(range = nil)
       if range.nil?
-        _data.keys
+        data.keys
       else
-        # For simplicity, return all keys (range filtering would need more work)
-        _data.keys
+        data.keys
       end
     end
 
     def to_a(range = nil)
       if range.nil?
-        _data.values
+        data.values
       else
-        _data.values
+        data.values
       end
     end
 
     def each(range = nil, direction: :next)
       return to_enum(:each, range, direction: direction) unless block_given?
 
-      pairs = _data.to_a
+      pairs = data.to_a
       pairs = pairs.reverse if direction == :prev || direction == 'prev'
 
       pairs.each do |key, value|
@@ -227,17 +213,16 @@ module IndexedDB
     # ---- Index access (stub) -----------------------------------------------
 
     def index(index_name)
-      # Return a simple stub that returns nil/empty for queries
       InMemoryIndex.new(self, index_name.to_s)
     end
 
     # ---- Schema mutations (upgrade only) -----------------------------------
 
     def create_index(index_name, key_path, unique: false, multi_entry: false)
-      _ensure_upgrading!('create_index')
-      meta = _meta
-      meta[:indexes] ||= {}
-      meta[:indexes][index_name.to_s] = {
+      ensure_upgrading!('create_index')
+      m = meta
+      m[:indexes] ||= {}
+      m[:indexes][index_name.to_s] = {
         key_path: key_path.to_s,
         unique: unique,
         multi_entry: multi_entry
@@ -246,29 +231,30 @@ module IndexedDB
     end
 
     def delete_index(index_name)
-      _ensure_upgrading!('delete_index')
-      meta = _meta
-      meta[:indexes]&.delete(index_name.to_s)
+      ensure_upgrading!('delete_index')
+      m = meta
+      m[:indexes]&.delete(index_name.to_s)
       nil
     end
 
     def index_names
-      meta = _meta
-      (meta[:indexes] || {}).keys
+      m = meta
+      (m[:indexes] || {}).keys
     end
 
-    # ---- Internal ----------------------------------------------------------
+    # ---- Cross-class internals (called by InMemoryIndex) -------------------
 
-    def _data
-      @database._store_data(@name)
+    def data
+      @database.store_data(@name)
     end
 
-    def _meta
-      @database._store_meta(@name)
+    def meta
+      @database.store_meta(@name)
     end
 
-    def _extract_key(value, key_path)
-      # Simple single-level key extraction
+    private
+
+    def extract_key(value, key_path)
       if value.is_a?(Hash)
         value[key_path] || value[key_path.to_sym]
       else
@@ -276,19 +262,19 @@ module IndexedDB
       end
     end
 
-    def _deep_copy(obj)
+    def deep_copy(obj)
       case obj
       when Hash
         obj.each_with_object({} #: Hash[untyped, untyped]
-        ) { |(k, v), h| h[k] = _deep_copy(v) }
+        ) { |(k, v), h| h[k] = deep_copy(v) }
       when Array
-        obj.map { |v| _deep_copy(v) }
+        obj.map { |v| deep_copy(v) }
       else
         obj
       end
     end
 
-    def _ensure_upgrading!(op)
+    def ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
     end
@@ -380,13 +366,12 @@ module IndexedDB
     end
 
     def get(key)
-      # Linear scan for matching value
-      meta = @store._meta
-      index_meta = meta[:indexes]&.dig(@name)
+      m = @store.meta
+      index_meta = m[:indexes]&.dig(@name)
       return nil unless index_meta
 
       key_path = index_meta[:key_path]
-      @store._data.each_value do |value|
+      @store.data.each_value do |value|
         if value.is_a?(Hash)
           indexed_val = value[key_path] || value[key_path.to_sym]
           return value if indexed_val == key

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
@@ -11,38 +11,38 @@ module IndexedDB
 
     # Retrieve the first record matching the given index key.
     def get(key)
-      @store._with_readonly_store do |js_store|
+      @store.with_readonly_store do |js_store|
         idx = js_store.index(@name)
-        req = idx.get(@store._to_js_key(key))
-        @store._await_request(req)
+        req = idx.get(@store.to_js_key(key))
+        @store.await_request(req)
       end
     end
 
     # Retrieve all records matching the given index key (or range).
     def get_all(key_or_range = nil, count: nil)
-      @store._with_readonly_store do |js_store|
+      @store.with_readonly_store do |js_store|
         idx = js_store.index(@name)
         req = if key_or_range.nil?
                 count.nil? ? idx.getAll : idx.getAll(nil, count) # steep:ignore
               else
-                js_key = @store._to_js_key(key_or_range)
+                js_key = @store.to_js_key(key_or_range)
                 count.nil? ? idx.getAll(js_key) : idx.getAll(js_key, count)
               end
-        js_arr = @store._await_request(req)
-        @store._js_array_to_ruby(js_arr)
+        js_arr = @store.await_request(req)
+        @store.js_array_to_ruby(js_arr)
       end
     end
 
     # Count records matching the key or range.
     def count(key_or_range = nil)
-      @store._with_readonly_store do |js_store|
+      @store.with_readonly_store do |js_store|
         idx = js_store.index(@name)
         req = if key_or_range.nil?
                 idx.count
               else
-                idx.count(@store._to_js_key(key_or_range))
+                idx.count(@store.to_js_key(key_or_range))
               end
-        @store._await_request(req).to_i
+        @store.await_request(req).to_i
       end
     end
 
@@ -59,7 +59,6 @@ module IndexedDB
       all_keys = keys(range)
       all_values = to_a(range)
 
-      # Build pairs manually (Array#zip not available in PicoRuby)
       pairs = [] #: Array[[untyped, untyped]]
       i = 0
       while i < all_keys.length
@@ -76,15 +75,15 @@ module IndexedDB
 
     # Return all primary keys in index order.
     def keys(range = nil)
-      @store._with_readonly_store do |js_store|
+      @store.with_readonly_store do |js_store|
         idx = js_store.index(@name)
         req = if range.nil?
                 idx.getAllKeys
               else
-                idx.getAllKeys(@store._to_js_key(range))
+                idx.getAllKeys(@store.to_js_key(range))
               end
-        js_arr = @store._await_request(req)
-        @store._js_array_to_ruby(js_arr)
+        js_arr = @store.await_request(req)
+        @store.js_array_to_ruby(js_arr)
       end
     end
   end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
@@ -14,7 +14,7 @@ module IndexedDB
       @store.with_readonly_store do |js_store|
         idx = js_store.index(@name)
         req = idx.get(@store.to_js_key(key))
-        @store.await_request(req)
+        @store.js_to_ruby(@store.await_request(req))
       end
     end
 

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_index.rb
@@ -1,0 +1,91 @@
+module IndexedDB
+  # Wraps an IDBIndex for secondary index access.
+  # Provides the same read operations as Store but queries via the index.
+  class Index
+    attr_reader :name
+
+    def initialize(store, name)
+      @store = store
+      @name = name
+    end
+
+    # Retrieve the first record matching the given index key.
+    def get(key)
+      @store._with_readonly_store do |js_store|
+        idx = js_store.index(@name)
+        req = idx.get(@store._to_js_key(key))
+        @store._await_request(req)
+      end
+    end
+
+    # Retrieve all records matching the given index key (or range).
+    def get_all(key_or_range = nil, count: nil)
+      @store._with_readonly_store do |js_store|
+        idx = js_store.index(@name)
+        req = if key_or_range.nil?
+                count.nil? ? idx.getAll : idx.getAll(nil, count) # steep:ignore
+              else
+                js_key = @store._to_js_key(key_or_range)
+                count.nil? ? idx.getAll(js_key) : idx.getAll(js_key, count)
+              end
+        js_arr = @store._await_request(req)
+        @store._js_array_to_ruby(js_arr)
+      end
+    end
+
+    # Count records matching the key or range.
+    def count(key_or_range = nil)
+      @store._with_readonly_store do |js_store|
+        idx = js_store.index(@name)
+        req = if key_or_range.nil?
+                idx.count
+              else
+                idx.count(@store._to_js_key(key_or_range))
+              end
+        @store._await_request(req).to_i
+      end
+    end
+
+    # Return all values via the index order.
+    def to_a(range = nil)
+      get_all(range)
+    end
+
+    # Iterate over [primary_key, value] pairs via the index.
+    # Uses bulk fetch (getAll/getAllKeys) due to transaction limitations.
+    def each(range = nil, direction: :next)
+      return to_enum(:each, range, direction: direction) unless block_given?
+
+      all_keys = keys(range)
+      all_values = to_a(range)
+
+      # Build pairs manually (Array#zip not available in PicoRuby)
+      pairs = [] #: Array[[untyped, untyped]]
+      i = 0
+      while i < all_keys.length
+        pairs << [all_keys[i], all_values[i]]
+        i += 1
+      end
+
+      pairs = pairs.reverse if direction == :prev || direction == 'prev'
+
+      pairs.each do |pair|
+        yield pair
+      end
+    end
+
+    # Return all primary keys in index order.
+    def keys(range = nil)
+      @store._with_readonly_store do |js_store|
+        idx = js_store.index(@name)
+        req = if range.nil?
+                idx.getAllKeys
+              else
+                idx.getAllKeys(@store._to_js_key(range))
+              end
+        js_arr = @store._await_request(req)
+        @store._js_array_to_ruby(js_arr)
+      end
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_key_range.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_key_range.rb
@@ -1,0 +1,37 @@
+module IndexedDB
+  # Thin wrapper over IDBKeyRange for range queries.
+  # Returns JS::Object references that can be passed directly to
+  # Store#each, Store#keys, Store#to_a, Index methods, etc.
+  module KeyRange
+    # Match exactly one key.
+    def self.only(value)
+      idb_key_range = JS.global[:IDBKeyRange]
+      idb_key_range.only(JS::Bridge.to_js(value)) # steep:ignore
+    end
+
+    # All keys >= lower (or > lower if exclude: true).
+    def self.lower_bound(lower, exclude: false)
+      idb_key_range = JS.global[:IDBKeyRange]
+      idb_key_range.lowerBound(JS::Bridge.to_js(lower), exclude) # steep:ignore
+    end
+
+    # All keys <= upper (or < upper if exclude: true).
+    def self.upper_bound(upper, exclude: false)
+      idb_key_range = JS.global[:IDBKeyRange]
+      idb_key_range.upperBound(JS::Bridge.to_js(upper), exclude) # steep:ignore
+    end
+
+    # All keys between lower and upper.
+    #   exclude_lower: true  => lower < key
+    #   exclude_upper: true  => key < upper
+    def self.bound(lower, upper, exclude_lower: false, exclude_upper: false)
+      idb_key_range = JS.global[:IDBKeyRange]
+      idb_key_range.bound( # steep:ignore
+        JS::Bridge.to_js(lower),
+        JS::Bridge.to_js(upper),
+        exclude_lower,
+        exclude_upper
+      )
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_kvs.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_kvs.rb
@@ -1,0 +1,110 @@
+module IndexedDB
+  # Single-store key/value facade over a Database. Useful when the application
+  # only needs a persistent Hash-like surface and does not care about schemas
+  # or indexes.
+  #
+  #   kv = IndexedDB::KVS.open('user_prefs')
+  #   kv['theme'] = 'dark'
+  #   kv['theme']         #=> 'dark'
+  #   kv.delete('theme')
+  #   kv.each { |k, v| ... }
+  #
+  # Every operation autocommits via the underlying Database/InMemoryDatabase
+  # one-shot transaction semantics.
+  class KVS
+    DEFAULT_STORE = 'kv'.freeze
+
+    # Open (or create) a KVS-backed database. If the store does not exist yet,
+    # it is created at version 1. Pass `store:` to use a non-default store
+    # name (useful when sharing one Database between several KVS instances).
+    def self.open(name, store: DEFAULT_STORE, fallback: true)
+      store_name = store.to_s
+      db = IndexedDB.open(name, version: 1, fallback: fallback) do |d, _old_v, _new_v|
+        d.create_store(store_name) unless d.has_store?(store_name)
+      end
+      new(db, store_name)
+    end
+
+    attr_reader :name
+
+    def initialize(database, store_name)
+      @database = database
+      @name = store_name
+    end
+
+    def [](key)
+      store.get(key.to_s)
+    end
+
+    def []=(key, value)
+      store.put(value, key: key.to_s)
+      value
+    end
+
+    def delete(key)
+      store.delete(key.to_s)
+      nil
+    end
+
+    def has_key?(key)
+      !store.get(key.to_s).nil?
+    end
+
+    def size
+      store.count
+    end
+
+    alias length size
+
+    def empty?
+      size == 0
+    end
+
+    def clear
+      store.clear
+      nil
+    end
+
+    def keys
+      store.keys.map { |k| k.to_s }
+    end
+
+    def values
+      store.to_a
+    end
+
+    def each(&block)
+      return to_enum(:each) unless block
+
+      store.each do |pair|
+        block.call(pair)
+      end
+    end
+
+    def to_h
+      result = {} #: Hash[String, untyped]
+      store.each do |pair|
+        key = pair[0]
+        value = pair[1]
+        result[key.to_s] = value
+      end
+      result
+    end
+
+    def close
+      @database.close
+    end
+
+    def database
+      @database
+    end
+
+    private
+
+    def store
+      s = @database.store(@name)
+      raise Error, "store '#{@name}' missing from KVS database" unless s
+      s
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
@@ -18,17 +18,13 @@ module IndexedDB
       @upgrading = upgrading
     end
 
-    def _js_store
-      @js_store
-    end
-
     # ---- One-shot autocommit operations ------------------------------------
 
     # Retrieve a value by primary key. Returns nil if not found.
     def get(key)
-      _with_readonly_store do |store|
-        req = store.get(_to_js_key(key))
-        _await_request(req)
+      with_readonly_store do |store|
+        req = store.get(to_js_key(key))
+        await_request(req)
       end
     end
 
@@ -38,70 +34,70 @@ module IndexedDB
     #   store.put({ id: 1, name: 'Alice' })         # key_path: 'id'
     #   store.put('some value', key: 'mykey')       # out-of-line key
     def put(value, key: nil)
-      _with_readwrite_store do |store|
+      with_readwrite_store do |store|
         js_value = JS::Bridge.to_js(value)
         req = if key.nil?
                 store.put(js_value)
               else
-                store.put(js_value, _to_js_key(key))
+                store.put(js_value, to_js_key(key))
               end
-        _await_request(req)
+        await_request(req)
       end
     end
 
     # Delete by primary key.
     def delete(key)
-      _with_readwrite_store do |store|
-        req = store.delete(_to_js_key(key))
-        _await_request(req)
+      with_readwrite_store do |store|
+        req = store.delete(to_js_key(key))
+        await_request(req)
       end
       nil
     end
 
     # Count records. Optionally pass a key or KeyRange.
     def count(key_or_range = nil)
-      _with_readonly_store do |store|
+      with_readonly_store do |store|
         req = if key_or_range.nil?
                 store.count
               else
-                store.count(_to_js_key(key_or_range))
+                store.count(to_js_key(key_or_range))
               end
-        _await_request(req).to_i
+        await_request(req).to_i
       end
     end
 
     # Remove all records from the store.
     def clear
-      _with_readwrite_store do |store|
+      with_readwrite_store do |store|
         req = store.clear
-        _await_request(req)
+        await_request(req)
       end
       nil
     end
 
     # Return all primary keys as an Array.
     def keys(range = nil)
-      _with_readonly_store do |store|
+      with_readonly_store do |store|
         req = if range.nil?
                 store.getAllKeys
               else
-                store.getAllKeys(_to_js_key(range))
+                store.getAllKeys(to_js_key(range))
               end
-        js_arr = _await_request(req)
-        _js_array_to_ruby(js_arr)
+        js_arr = await_request(req)
+        js_array_to_ruby(js_arr)
       end
     end
 
     # Return all values as an Array.
     def to_a(range = nil)
-      _with_readonly_store do |store|
+      with_readonly_store do |store|
         req = if range.nil?
                 store.getAll
               else
-                store.getAll(_to_js_key(range))
+                store.getAll(to_js_key(range))
               end
-        js_arr = _await_request(req)
-        _js_array_to_ruby(js_arr)
+        js_arr = await_request(req)
+        js_array_to_ruby(js_arr)
       end
     end
 
@@ -116,7 +112,6 @@ module IndexedDB
       all_keys = keys(range)
       all_values = to_a(range)
 
-      # Build pairs manually (Array#zip not available in PicoRuby)
       pairs = [] #: Array[[untyped, untyped]]
       i = 0
       while i < all_keys.length
@@ -142,7 +137,7 @@ module IndexedDB
 
     # Create a secondary index. Valid only inside the upgrade block.
     def create_index(index_name, key_path, unique: false, multi_entry: false)
-      _ensure_upgrading!('create_index')
+      ensure_upgrading!('create_index')
       opts = JS.global.create_object
       opts[:unique] = unique
       opts[:multiEntry] = multi_entry
@@ -152,14 +147,14 @@ module IndexedDB
 
     # Delete a secondary index. Valid only inside the upgrade block.
     def delete_index(index_name)
-      _ensure_upgrading!('delete_index')
+      ensure_upgrading!('delete_index')
       @js_store.deleteIndex(index_name.to_s) # steep:ignore
       nil
     end
 
     # List index names on this store.
     def index_names
-      js_store = @js_store || _get_readonly_store
+      js_store = @js_store || get_readonly_store
       list = js_store[:indexNames]
       n = list[:length].to_i
       result = [] #: Array[String]
@@ -171,41 +166,55 @@ module IndexedDB
       result
     end
 
-    # ---- Internal helpers --------------------------------------------------
+    # ---- Cross-class internals (called by Index) ---------------------------
 
-    def _with_readonly_store
-      _ensure_not_upgrading!
-      tx = @database._js_db.transaction(@name, 'readonly')
+    def with_readonly_store
+      ensure_not_upgrading!
+      tx = @database.js_db.transaction(@name, 'readonly')
       store = tx.objectStore(@name)
       yield store
     end
 
-    def _with_readwrite_store
-      _ensure_not_upgrading!
-      tx = @database._js_db.transaction(@name, 'readwrite')
-      store = tx.objectStore(@name)
-      yield store
-    end
-
-    def _get_readonly_store
-      tx = @database._js_db.transaction(@name, 'readonly')
-      tx.objectStore(@name)
-    end
-
-    def _await_request(req)
-      promise = Helper._request_to_promise(req)
+    def await_request(req)
+      promise = Helper.request_to_promise(req)
       promise.await
     end
 
-    def _to_js_key(key)
-      # KeyRange objects are already JS::Object; pass through
+    def to_js_key(key)
       return key if key.is_a?(JS::Object)
       JS::Bridge.to_js(key)
     end
 
-    def _js_to_ruby(js_val)
+    def js_array_to_ruby(js_arr)
+      if js_arr.nil?
+        return [] #: Array[untyped]
+      end
+      n = js_arr[:length].to_i
+      result = [] #: Array[untyped]
+      i = 0
+      while i < n
+        result << js_to_ruby(js_arr[i])
+        i += 1
+      end
+      result
+    end
+
+    private
+
+    def with_readwrite_store
+      ensure_not_upgrading!
+      tx = @database.js_db.transaction(@name, 'readwrite')
+      store = tx.objectStore(@name)
+      yield store
+    end
+
+    def get_readonly_store
+      tx = @database.js_db.transaction(@name, 'readonly')
+      tx.objectStore(@name)
+    end
+
+    def js_to_ruby(js_val)
       return nil if js_val.nil?
-      # Primitives auto-convert; objects need JSON round-trip for deep conversion
       if js_val.is_a?(JS::Object)
         json_str = JS.global[:JSON].stringify(js_val).to_s # steep:ignore
         JSON.parse(json_str)
@@ -214,26 +223,12 @@ module IndexedDB
       end
     end
 
-    def _js_array_to_ruby(js_arr)
-      if js_arr.nil?
-        return [] #: Array[untyped]
-      end
-      n = js_arr[:length].to_i
-      result = [] #: Array[untyped]
-      i = 0
-      while i < n
-        result << _js_to_ruby(js_arr[i])
-        i += 1
-      end
-      result
-    end
-
-    def _ensure_upgrading!(op)
+    def ensure_upgrading!(op)
       return if @upgrading
       raise SchemaError, "#{op} can only be called inside the upgrade block"
     end
 
-    def _ensure_not_upgrading!
+    def ensure_not_upgrading!
       return unless @upgrading
       raise SchemaError, "Cannot perform data operations during upgrade; use one-shot operations after open returns"
     end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
@@ -20,11 +20,13 @@ module IndexedDB
 
     # ---- One-shot autocommit operations ------------------------------------
 
-    # Retrieve a value by primary key. Returns nil if not found.
+    # Retrieve a value by primary key. Returns nil if not found. Composite
+    # values come back as Ruby Hashes/Arrays, not JS::Object, so callers can
+    # use `is_a?(Hash)` and pattern matching uniformly.
     def get(key)
       with_readonly_store do |store|
         req = store.get(to_js_key(key))
-        await_request(req)
+        js_to_ruby(await_request(req))
       end
     end
 
@@ -199,6 +201,16 @@ module IndexedDB
       result
     end
 
+    def js_to_ruby(js_val)
+      return nil if js_val.nil?
+      if js_val.is_a?(JS::Object)
+        json_str = JS.global[:JSON].stringify(js_val).to_s # steep:ignore
+        JSON.parse(json_str)
+      else
+        js_val
+      end
+    end
+
     private
 
     def with_readwrite_store
@@ -211,16 +223,6 @@ module IndexedDB
     def get_readonly_store
       tx = @database.js_db.transaction(@name, 'readonly')
       tx.objectStore(@name)
-    end
-
-    def js_to_ruby(js_val)
-      return nil if js_val.nil?
-      if js_val.is_a?(JS::Object)
-        json_str = JS.global[:JSON].stringify(js_val).to_s # steep:ignore
-        JSON.parse(json_str)
-      else
-        js_val
-      end
     end
 
     def ensure_upgrading!(op)

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
@@ -1,8 +1,13 @@
 module IndexedDB
-  # Phase A: stub. Only the constructor and accessors used by Database
-  # during upgrade are defined here. The one-shot autocommit operations
-  # (#get, #put, #delete, #count, #clear, #keys, #to_a, #each, #index,
-  # #create_index) are added in Phase B.
+  # Wraps an IDBObjectStore. Two modes:
+  #
+  #   * upgrading: true  - constructed during the upgrade callback with an
+  #     explicit IDBObjectStore from the versionchange transaction. Schema
+  #     mutations (create_index) are valid. Await is forbidden.
+  #
+  #   * upgrading: false - normal runtime mode. Each operation opens a fresh
+  #     one-shot transaction, awaits a single Promise, and returns. Safe by
+  #     construction (transaction auto-commits after one await).
   class Store
     attr_reader :name
 
@@ -15,6 +20,222 @@ module IndexedDB
 
     def _js_store
       @js_store
+    end
+
+    # ---- One-shot autocommit operations ------------------------------------
+
+    # Retrieve a value by primary key. Returns nil if not found.
+    def get(key)
+      _with_readonly_store do |store|
+        req = store.get(_to_js_key(key))
+        _await_request(req)
+      end
+    end
+
+    # Store a value. If key_path was set on the store, the key is extracted
+    # from the value. Otherwise, pass `key:` explicitly.
+    #
+    #   store.put({ id: 1, name: 'Alice' })         # key_path: 'id'
+    #   store.put('some value', key: 'mykey')       # out-of-line key
+    def put(value, key: nil)
+      _with_readwrite_store do |store|
+        js_value = JS::Bridge.to_js(value)
+        req = if key.nil?
+                store.put(js_value)
+              else
+                store.put(js_value, _to_js_key(key))
+              end
+        _await_request(req)
+      end
+    end
+
+    # Delete by primary key.
+    def delete(key)
+      _with_readwrite_store do |store|
+        req = store.delete(_to_js_key(key))
+        _await_request(req)
+      end
+      nil
+    end
+
+    # Count records. Optionally pass a key or KeyRange.
+    def count(key_or_range = nil)
+      _with_readonly_store do |store|
+        req = if key_or_range.nil?
+                store.count
+              else
+                store.count(_to_js_key(key_or_range))
+              end
+        _await_request(req).to_i
+      end
+    end
+
+    # Remove all records from the store.
+    def clear
+      _with_readwrite_store do |store|
+        req = store.clear
+        _await_request(req)
+      end
+      nil
+    end
+
+    # Return all primary keys as an Array.
+    def keys(range = nil)
+      _with_readonly_store do |store|
+        req = if range.nil?
+                store.getAllKeys
+              else
+                store.getAllKeys(_to_js_key(range))
+              end
+        js_arr = _await_request(req)
+        _js_array_to_ruby(js_arr)
+      end
+    end
+
+    # Return all values as an Array.
+    def to_a(range = nil)
+      _with_readonly_store do |store|
+        req = if range.nil?
+                store.getAll
+              else
+                store.getAll(_to_js_key(range))
+              end
+        js_arr = _await_request(req)
+        _js_array_to_ruby(js_arr)
+      end
+    end
+
+    # Iterate over [key, value] pairs.
+    # Note: Due to IndexedDB transaction semantics (transactions auto-commit
+    # when the JS event loop becomes idle, and await yields to the event loop),
+    # cursor-based iteration is not possible. This method uses getAll/getAllKeys
+    # to fetch all data in one transaction, then iterates in Ruby.
+    def each(range = nil, direction: :next)
+      return to_enum(:each, range, direction: direction) unless block_given?
+
+      all_keys = keys(range)
+      all_values = to_a(range)
+
+      # Build pairs manually (Array#zip not available in PicoRuby)
+      pairs = [] #: Array[[untyped, untyped]]
+      i = 0
+      while i < all_keys.length
+        pairs << [all_keys[i], all_values[i]]
+        i += 1
+      end
+
+      pairs = pairs.reverse if direction == :prev || direction == 'prev'
+
+      pairs.each do |pair|
+        yield pair
+      end
+    end
+
+    # ---- Index access ------------------------------------------------------
+
+    # Returns an Index object for the named secondary index.
+    def index(index_name)
+      Index.new(self, index_name.to_s)
+    end
+
+    # ---- Schema mutations (upgrade only) -----------------------------------
+
+    # Create a secondary index. Valid only inside the upgrade block.
+    def create_index(index_name, key_path, unique: false, multi_entry: false)
+      _ensure_upgrading!('create_index')
+      opts = JS.global.create_object
+      opts[:unique] = unique
+      opts[:multiEntry] = multi_entry
+      @js_store.createIndex(index_name.to_s, key_path.to_s, opts) # steep:ignore
+      nil
+    end
+
+    # Delete a secondary index. Valid only inside the upgrade block.
+    def delete_index(index_name)
+      _ensure_upgrading!('delete_index')
+      @js_store.deleteIndex(index_name.to_s) # steep:ignore
+      nil
+    end
+
+    # List index names on this store.
+    def index_names
+      js_store = @js_store || _get_readonly_store
+      list = js_store[:indexNames]
+      n = list[:length].to_i
+      result = [] #: Array[String]
+      i = 0
+      while i < n
+        result << list.item(i).to_s
+        i += 1
+      end
+      result
+    end
+
+    # ---- Internal helpers --------------------------------------------------
+
+    def _with_readonly_store
+      _ensure_not_upgrading!
+      tx = @database._js_db.transaction(@name, 'readonly')
+      store = tx.objectStore(@name)
+      yield store
+    end
+
+    def _with_readwrite_store
+      _ensure_not_upgrading!
+      tx = @database._js_db.transaction(@name, 'readwrite')
+      store = tx.objectStore(@name)
+      yield store
+    end
+
+    def _get_readonly_store
+      tx = @database._js_db.transaction(@name, 'readonly')
+      tx.objectStore(@name)
+    end
+
+    def _await_request(req)
+      promise = Helper._request_to_promise(req)
+      promise.await
+    end
+
+    def _to_js_key(key)
+      # KeyRange objects are already JS::Object; pass through
+      return key if key.is_a?(JS::Object)
+      JS::Bridge.to_js(key)
+    end
+
+    def _js_to_ruby(js_val)
+      return nil if js_val.nil?
+      # Primitives auto-convert; objects need JSON round-trip for deep conversion
+      if js_val.is_a?(JS::Object)
+        json_str = JS.global[:JSON].stringify(js_val).to_s # steep:ignore
+        JSON.parse(json_str)
+      else
+        js_val
+      end
+    end
+
+    def _js_array_to_ruby(js_arr)
+      if js_arr.nil?
+        return [] #: Array[untyped]
+      end
+      n = js_arr[:length].to_i
+      result = [] #: Array[untyped]
+      i = 0
+      while i < n
+        result << _js_to_ruby(js_arr[i])
+        i += 1
+      end
+      result
+    end
+
+    def _ensure_upgrading!(op)
+      return if @upgrading
+      raise SchemaError, "#{op} can only be called inside the upgrade block"
+    end
+
+    def _ensure_not_upgrading!
+      return unless @upgrading
+      raise SchemaError, "Cannot perform data operations during upgrade; use one-shot operations after open returns"
     end
   end
 end

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
@@ -1,0 +1,20 @@
+module IndexedDB
+  # Phase A: stub. Only the constructor and accessors used by Database
+  # during upgrade are defined here. The one-shot autocommit operations
+  # (#get, #put, #delete, #count, #clear, #keys, #to_a, #each, #index,
+  # #create_index) are added in Phase B.
+  class Store
+    attr_reader :name
+
+    def initialize(database, name, js_store: nil, upgrading: false)
+      @database = database
+      @name = name
+      @js_store = js_store
+      @upgrading = upgrading
+    end
+
+    def _js_store
+      @js_store
+    end
+  end
+end

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -19,6 +19,7 @@ module IndexedDB
   module Helper
     def self._request_to_promise: (untyped js_request) -> untyped
     def self._open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
+    def self._transaction_to_promise: (untyped js_transaction) -> untyped
   end
 
   module KeyRange
@@ -40,6 +41,7 @@ module IndexedDB
     def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> Store
     def delete_store: (String name) -> nil
     def store: (String name) -> Store
+    def batch: (String | Array[String] store_names, ?mode: Symbol | String) { (Batch) -> void } -> nil
 
     def _store_for: (untyped js_store, String name) -> Store
     def _mark_upgrade_done: () -> void
@@ -47,6 +49,28 @@ module IndexedDB
     def _upgrading?: () -> bool
 
     private def _ensure_upgrading!: (String op) -> void
+    private def _ensure_not_upgrading!: () -> void
+  end
+
+  class Batch
+    def initialize: (Database database, Array[String] store_names, Symbol | String mode) -> void
+    def []: (String | Symbol store_name) -> StoreView
+    def _await_complete: () -> nil
+
+    class StoreView
+      attr_reader name: String
+      def initialize: (untyped js_store, String name) -> void
+      def put: (untyped value, ?key: untyped?) -> nil
+      def add: (untyped value, ?key: untyped?) -> nil
+      def delete: (untyped key) -> nil
+      def clear: () -> nil
+      def get: (untyped key) -> untyped
+      def count: (?untyped? key_or_range) -> Integer
+      def keys: (?untyped? range) -> Array[untyped]
+      def to_a: (?untyped? range) -> Array[untyped]
+      def each: (*untyped) -> untyped
+      def index: (untyped name) -> untyped
+    end
   end
 
   class Store
@@ -120,6 +144,7 @@ module IndexedDB
     def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> InMemoryStore
     def delete_store: (String name) -> nil
     def store: (String name) -> InMemoryStore?
+    def batch: (String | Array[String] store_names, ?mode: Symbol | String) { (InMemoryBatch) -> void } -> nil
 
     def _mark_upgrade_done: () -> void
     def _upgrading?: () -> bool
@@ -128,6 +153,26 @@ module IndexedDB
     def _store_data: (String store_name) -> Hash[untyped, untyped]
 
     private def _ensure_upgrading!: (String op) -> void
+  end
+
+  class InMemoryBatch
+    def initialize: (InMemoryDatabase database, Array[String] store_names, Symbol | String mode) -> void
+    def []: (String | Symbol store_name) -> InMemoryBatchView
+  end
+
+  class InMemoryBatchView
+    attr_reader name: String
+    def initialize: (InMemoryDatabase database, String name) -> void
+    def put: (untyped value, ?key: untyped?) -> nil
+    def add: (untyped value, ?key: untyped?) -> nil
+    def delete: (untyped key) -> nil
+    def clear: () -> nil
+    def get: (untyped key) -> untyped
+    def count: (?untyped? key_or_range) -> Integer
+    def keys: (?untyped? range) -> Array[untyped]
+    def to_a: (?untyped? range) -> Array[untyped]
+    def each: (*untyped) -> untyped
+    def index: (untyped name) -> untyped
   end
 
   class InMemoryStore

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -211,4 +211,31 @@ module IndexedDB
     def to_a: () -> Array[untyped]
     def each: () ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
   end
+
+  class KVS
+    DEFAULT_STORE: String
+
+    attr_reader name: String
+
+    def self.open: (String name, ?store: String | Symbol, ?fallback: bool) -> KVS
+
+    def initialize: (db_like database, String store_name) -> void
+
+    def []: (String | Symbol key) -> untyped
+    def []=: (String | Symbol key, untyped value) -> untyped
+    def delete: (String | Symbol key) -> nil
+    def has_key?: (String | Symbol key) -> bool
+    def size: () -> Integer
+    alias length size
+    def empty?: () -> bool
+    def clear: () -> nil
+    def keys: () -> Array[String]
+    def values: () -> Array[untyped]
+    def each: () ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
+    def to_h: () -> Hash[String, untyped]
+    def close: () -> void
+    def database: () -> db_like
+
+    private def store: () -> store_like
+  end
 end

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -13,13 +13,14 @@ module IndexedDB
 
   def self.available?: () -> bool
   def self.open: (String name, ?version: Integer, ?fallback: bool) ?{ (db_like, Integer, Integer) -> void } -> db_like
-  def self._open_real: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> Database
-  def self._open_fallback: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
+
+  private def self.open_real: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> Database
+  private def self.open_fallback: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
 
   module Helper
-    def self._request_to_promise: (untyped js_request) -> untyped
-    def self._open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
-    def self._transaction_to_promise: (untyped js_transaction) -> untyped
+    def self.request_to_promise: (untyped js_request) -> untyped
+    def self.open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
+    def self.transaction_to_promise: (untyped js_transaction) -> untyped
   end
 
   module KeyRange
@@ -43,19 +44,19 @@ module IndexedDB
     def store: (String name) -> Store
     def batch: (String | Array[String] store_names, ?mode: Symbol | String) { (Batch) -> void } -> nil
 
-    def _store_for: (untyped js_store, String name) -> Store
-    def _mark_upgrade_done: () -> void
-    def _js_db: () -> untyped
-    def _upgrading?: () -> bool
+    def mark_upgrade_done: () -> void
+    def js_db: () -> untyped
+    def upgrading?: () -> bool
 
-    private def _ensure_upgrading!: (String op) -> void
-    private def _ensure_not_upgrading!: () -> void
+    private def store_for: (untyped js_store, String name) -> Store
+    private def ensure_upgrading!: (String op) -> void
+    private def ensure_not_upgrading!: () -> void
   end
 
   class Batch
     def initialize: (Database database, Array[String] store_names, Symbol | String mode) -> void
     def []: (String | Symbol store_name) -> StoreView
-    def _await_complete: () -> nil
+    def await_complete: () -> nil
 
     class StoreView
       attr_reader name: String
@@ -96,18 +97,17 @@ module IndexedDB
     def delete_index: (String index_name) -> nil
     def index_names: () -> Array[String]
 
-    # Internal
-    def _js_store: () -> untyped
-    def _with_readonly_store: [T] () { (untyped) -> T } -> T
-    def _with_readwrite_store: [T] () { (untyped) -> T } -> T
-    def _get_readonly_store: () -> untyped
-    def _await_request: (untyped req) -> untyped
-    def _to_js_key: (untyped key) -> untyped
-    def _js_to_ruby: (untyped js_val) -> untyped
-    def _js_array_to_ruby: (untyped js_arr) -> Array[untyped]
+    # Cross-class internals (called by Index)
+    def with_readonly_store: [T] () { (untyped) -> T } -> T
+    def await_request: (untyped req) -> untyped
+    def to_js_key: (untyped key) -> untyped
+    def js_array_to_ruby: (untyped js_arr) -> Array[untyped]
 
-    private def _ensure_upgrading!: (String op) -> void
-    private def _ensure_not_upgrading!: () -> void
+    private def with_readwrite_store: [T] () { (untyped) -> T } -> T
+    private def get_readonly_store: () -> untyped
+    private def js_to_ruby: (untyped js_val) -> untyped
+    private def ensure_upgrading!: (String op) -> void
+    private def ensure_not_upgrading!: () -> void
   end
 
   class Index
@@ -146,33 +146,12 @@ module IndexedDB
     def store: (String name) -> InMemoryStore?
     def batch: (String | Array[String] store_names, ?mode: Symbol | String) { (InMemoryBatch) -> void } -> nil
 
-    def _mark_upgrade_done: () -> void
-    def _upgrading?: () -> bool
-    def _db_name: () -> String
-    def _store_meta: (String store_name) -> Hash[Symbol, untyped]
-    def _store_data: (String store_name) -> Hash[untyped, untyped]
+    def mark_upgrade_done: () -> void
+    def upgrading?: () -> bool
+    def store_meta: (String store_name) -> Hash[Symbol, untyped]
+    def store_data: (String store_name) -> Hash[untyped, untyped]
 
-    private def _ensure_upgrading!: (String op) -> void
-  end
-
-  class InMemoryBatch
-    def initialize: (InMemoryDatabase database, Array[String] store_names, Symbol | String mode) -> void
-    def []: (String | Symbol store_name) -> InMemoryBatchView
-  end
-
-  class InMemoryBatchView
-    attr_reader name: String
-    def initialize: (InMemoryDatabase database, String name) -> void
-    def put: (untyped value, ?key: untyped?) -> nil
-    def add: (untyped value, ?key: untyped?) -> nil
-    def delete: (untyped key) -> nil
-    def clear: () -> nil
-    def get: (untyped key) -> untyped
-    def count: (?untyped? key_or_range) -> Integer
-    def keys: (?untyped? range) -> Array[untyped]
-    def to_a: (?untyped? range) -> Array[untyped]
-    def each: (*untyped) -> untyped
-    def index: (untyped name) -> untyped
+    private def ensure_upgrading!: (String op) -> void
   end
 
   class InMemoryStore
@@ -195,12 +174,32 @@ module IndexedDB
     def delete_index: (String index_name) -> nil
     def index_names: () -> Array[String]
 
-    def _data: () -> Hash[untyped, untyped]
-    def _meta: () -> Hash[Symbol, untyped]
+    def data: () -> Hash[untyped, untyped]
+    def meta: () -> Hash[Symbol, untyped]
 
-    private def _extract_key: (untyped value, String key_path) -> untyped
-    private def _deep_copy: (untyped obj) -> untyped
-    private def _ensure_upgrading!: (String op) -> void
+    private def extract_key: (untyped value, String key_path) -> untyped
+    private def deep_copy: (untyped obj) -> untyped
+    private def ensure_upgrading!: (String op) -> void
+  end
+
+  class InMemoryBatch
+    def initialize: (InMemoryDatabase database, Array[String] store_names, Symbol | String mode) -> void
+    def []: (String | Symbol store_name) -> InMemoryBatchView
+  end
+
+  class InMemoryBatchView
+    attr_reader name: String
+    def initialize: (InMemoryDatabase database, String name) -> void
+    def put: (untyped value, ?key: untyped?) -> nil
+    def add: (untyped value, ?key: untyped?) -> nil
+    def delete: (untyped key) -> nil
+    def clear: () -> nil
+    def get: (untyped key) -> untyped
+    def count: (?untyped? key_or_range) -> Integer
+    def keys: (?untyped? range) -> Array[untyped]
+    def to_a: (?untyped? range) -> Array[untyped]
+    def each: (*untyped) -> untyped
+    def index: (untyped name) -> untyped
   end
 
   class InMemoryIndex
@@ -213,4 +212,3 @@ module IndexedDB
     def each: () ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
   end
 end
-

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -102,10 +102,10 @@ module IndexedDB
     def await_request: (untyped req) -> untyped
     def to_js_key: (untyped key) -> untyped
     def js_array_to_ruby: (untyped js_arr) -> Array[untyped]
+    def js_to_ruby: (untyped js_val) -> untyped
 
     private def with_readwrite_store: [T] () { (untyped) -> T } -> T
     private def get_readonly_store: () -> untyped
-    private def js_to_ruby: (untyped js_val) -> untyped
     private def ensure_upgrading!: (String op) -> void
     private def ensure_not_upgrading!: () -> void
   end

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -1,0 +1,71 @@
+module IndexedDB
+  class Error < StandardError end
+  class NotSupportedError < Error end
+  class OpenError < Error end
+  class BlockedError < Error end
+  class AwaitInBatchError < Error end
+  class SchemaError < Error end
+
+  # Either backend (real IDB or in-memory fallback) implements the same
+  # observable API. Returned from IndexedDB.open and yielded to upgrade blocks.
+  type db_like = Database | InMemoryDatabase
+
+  def self.available?: () -> bool
+  def self.open: (String name, ?version: Integer, ?fallback: bool) ?{ (db_like, Integer, Integer) -> void } -> db_like
+  def self._open_real: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> Database
+  def self._open_fallback: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
+
+  module Helper
+    def self._request_to_promise: (untyped js_request) -> untyped
+    def self._open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
+  end
+
+  class Database
+    attr_reader name: String
+
+    def initialize: (untyped js_db, name: String, upgrading: bool) -> void
+    def closed?: () -> bool
+    def close: () -> void
+    def version: () -> Integer
+    def store_names: () -> Array[String]
+    def has_store?: (String name) -> bool
+    def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> Store
+    def delete_store: (String name) -> nil
+    def store: (String name) -> Store
+
+    def _store_for: (untyped js_store, String name) -> Store
+    def _mark_upgrade_done: () -> void
+    def _js_db: () -> untyped
+    def _upgrading?: () -> bool
+
+    private def _ensure_upgrading!: (String op) -> void
+  end
+
+  class Store
+    attr_reader name: String
+
+    def initialize: (Database database, String name, ?js_store: untyped, ?upgrading: bool) -> void
+
+    def _js_store: () -> untyped
+  end
+
+  class InMemoryDatabase
+    def self.open: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
+
+    def initialize: (String name, Integer version) -> void
+
+    def name: () -> String
+    def version: () -> Integer
+    def closed?: () -> bool
+    def close: () -> void
+    def store_names: () -> Array[String]
+    def has_store?: (String name) -> bool
+    def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> nil
+    def delete_store: (String name) -> nil
+    def store: (String name) -> Store?
+
+    def _mark_upgrade_done: () -> void
+
+    private def _ensure_upgrading!: (String op) -> void
+  end
+end

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -9,6 +9,7 @@ module IndexedDB
   # Either backend (real IDB or in-memory fallback) implements the same
   # observable API. Returned from IndexedDB.open and yielded to upgrade blocks.
   type db_like = Database | InMemoryDatabase
+  type store_like = Store | InMemoryStore
 
   def self.available?: () -> bool
   def self.open: (String name, ?version: Integer, ?fallback: bool) ?{ (db_like, Integer, Integer) -> void } -> db_like
@@ -18,6 +19,13 @@ module IndexedDB
   module Helper
     def self._request_to_promise: (untyped js_request) -> untyped
     def self._open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
+  end
+
+  module KeyRange
+    def self.only: (untyped value) -> untyped
+    def self.lower_bound: (untyped lower, ?exclude: bool) -> untyped
+    def self.upper_bound: (untyped upper, ?exclude: bool) -> untyped
+    def self.bound: (untyped lower, untyped upper, ?exclude_lower: bool, ?exclude_upper: bool) -> untyped
   end
 
   class Database
@@ -46,10 +54,59 @@ module IndexedDB
 
     def initialize: (Database database, String name, ?js_store: untyped, ?upgrading: bool) -> void
 
+    # One-shot operations
+    def get: (untyped key) -> untyped
+    def put: (untyped value, ?key: untyped?) -> untyped
+    def delete: (untyped key) -> nil
+    def count: (?untyped? key_or_range) -> Integer
+    def clear: () -> nil
+    def keys: (?untyped? range) -> Array[untyped]
+    def to_a: (?untyped? range) -> Array[untyped]
+    def each: (?untyped? range, ?direction: Symbol) ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
+
+    # Index access
+    def index: (String index_name) -> Index
+
+    # Schema mutations (upgrade only)
+    def create_index: (String index_name, String key_path, ?unique: bool, ?multi_entry: bool) -> nil
+    def delete_index: (String index_name) -> nil
+    def index_names: () -> Array[String]
+
+    # Internal
     def _js_store: () -> untyped
+    def _with_readonly_store: [T] () { (untyped) -> T } -> T
+    def _with_readwrite_store: [T] () { (untyped) -> T } -> T
+    def _get_readonly_store: () -> untyped
+    def _await_request: (untyped req) -> untyped
+    def _to_js_key: (untyped key) -> untyped
+    def _js_to_ruby: (untyped js_val) -> untyped
+    def _js_array_to_ruby: (untyped js_arr) -> Array[untyped]
+
+    private def _ensure_upgrading!: (String op) -> void
+    private def _ensure_not_upgrading!: () -> void
+  end
+
+  class Index
+    attr_reader name: String
+
+    def initialize: (Store store, String name) -> void
+
+    def get: (untyped key) -> untyped
+    def get_all: (?untyped? key_or_range, ?count: Integer?) -> Array[untyped]
+    def count: (?untyped? key_or_range) -> Integer
+    def to_a: (?untyped? range) -> Array[untyped]
+    def each: (?untyped? range, ?direction: Symbol) ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
+    def keys: (?untyped? range) -> Array[untyped]
   end
 
   class InMemoryDatabase
+    self.@stores: Hash[[String, String], Hash[untyped, untyped]]
+    self.@meta: Hash[String, Hash[Symbol, untyped]]
+
+    def self.stores: () -> Hash[[String, String], Hash[untyped, untyped]]
+    def self.stores=: (Hash[[String, String], Hash[untyped, untyped]]) -> Hash[[String, String], Hash[untyped, untyped]]
+    def self.meta: () -> Hash[String, Hash[Symbol, untyped]]
+    def self.meta=: (Hash[String, Hash[Symbol, untyped]]) -> Hash[String, Hash[Symbol, untyped]]
     def self.open: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
 
     def initialize: (String name, Integer version) -> void
@@ -60,12 +117,55 @@ module IndexedDB
     def close: () -> void
     def store_names: () -> Array[String]
     def has_store?: (String name) -> bool
-    def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> nil
+    def create_store: (String name, ?key_path: String?, ?auto_increment: bool) -> InMemoryStore
     def delete_store: (String name) -> nil
-    def store: (String name) -> Store?
+    def store: (String name) -> InMemoryStore?
 
     def _mark_upgrade_done: () -> void
+    def _upgrading?: () -> bool
+    def _db_name: () -> String
+    def _store_meta: (String store_name) -> Hash[Symbol, untyped]
+    def _store_data: (String store_name) -> Hash[untyped, untyped]
 
     private def _ensure_upgrading!: (String op) -> void
   end
+
+  class InMemoryStore
+    attr_reader name: String
+
+    def initialize: (InMemoryDatabase database, String name, ?upgrading: bool) -> void
+
+    def get: (untyped key) -> untyped
+    def put: (untyped value, ?key: untyped?) -> untyped
+    def delete: (untyped key) -> nil
+    def count: (?untyped? key_or_range) -> Integer
+    def clear: () -> nil
+    def keys: (?untyped? range) -> Array[untyped]
+    def to_a: (?untyped? range) -> Array[untyped]
+    def each: (?untyped? range, ?direction: Symbol) ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
+
+    def index: (String index_name) -> InMemoryIndex
+
+    def create_index: (String index_name, String key_path, ?unique: bool, ?multi_entry: bool) -> nil
+    def delete_index: (String index_name) -> nil
+    def index_names: () -> Array[String]
+
+    def _data: () -> Hash[untyped, untyped]
+    def _meta: () -> Hash[Symbol, untyped]
+
+    private def _extract_key: (untyped value, String key_path) -> untyped
+    private def _deep_copy: (untyped obj) -> untyped
+    private def _ensure_upgrading!: (String op) -> void
+  end
+
+  class InMemoryIndex
+    attr_reader name: String
+
+    def initialize: (InMemoryStore store, String name) -> void
+
+    def get: (untyped key) -> untyped
+    def to_a: () -> Array[untyped]
+    def each: () ?{ ([untyped, untyped]) -> void } -> (Enumerator[[untyped, untyped], void] | void)
+  end
 end
+

--- a/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
+++ b/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
@@ -145,7 +145,7 @@ EM_JS(int, idb_transaction_to_promise, (int tx_ref_id), {
  *****************************************************/
 
 /*
- * IndexedDB::Helper._request_to_promise(js_request) -> JS::Promise
+ * IndexedDB::Helper.request_to_promise(js_request) -> JS::Promise
  */
 static mrb_value
 mrb_idb_helper_request_to_promise(mrb_state *mrb, mrb_value self)
@@ -168,7 +168,7 @@ mrb_idb_helper_request_to_promise(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * IndexedDB::Helper._transaction_to_promise(js_transaction) -> JS::Promise
+ * IndexedDB::Helper.transaction_to_promise(js_transaction) -> JS::Promise
  */
 static mrb_value
 mrb_idb_helper_transaction_to_promise(mrb_state *mrb, mrb_value self)
@@ -191,7 +191,7 @@ mrb_idb_helper_transaction_to_promise(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * IndexedDB::Helper._open_with_upgrade(name, version, callback_id) -> JS::Promise
+ * IndexedDB::Helper.open_with_upgrade(name, version, callback_id) -> JS::Promise
  *
  * callback_id may be 0 to skip the upgrade hook (e.g. when opening at the
  * current version with no schema work to do).
@@ -221,11 +221,11 @@ mrb_picoruby_indexeddb_gem_init(mrb_state *mrb)
   struct RClass *module_IndexedDB = mrb_define_module_id(mrb, MRB_SYM(IndexedDB));
   struct RClass *module_Helper = mrb_define_module_under_id(mrb, module_IndexedDB, MRB_SYM(Helper));
 
-  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_request_to_promise),
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(request_to_promise),
     mrb_idb_helper_request_to_promise, MRB_ARGS_REQ(1));
-  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_open_with_upgrade),
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(open_with_upgrade),
     mrb_idb_helper_open_with_upgrade, MRB_ARGS_REQ(3));
-  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_transaction_to_promise),
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(transaction_to_promise),
     mrb_idb_helper_transaction_to_promise, MRB_ARGS_REQ(1));
 }
 

--- a/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
+++ b/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
@@ -1,0 +1,181 @@
+#include <emscripten.h>
+
+#include "mruby.h"
+#include "mruby/presym.h"
+#include "mruby/class.h"
+#include "mruby/data.h"
+#include "mruby/string.h"
+#include "mruby/variable.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Shared types from picoruby-wasm/src/mruby/js.c */
+typedef struct picorb_js_obj {
+  int ref_id;
+} picorb_js_obj;
+
+extern struct RClass *class_JS_Object;
+extern mrb_value wrap_ref_as_js_object(mrb_state *mrb, int ref_id);
+
+/*****************************************************
+ * EM_JS helpers
+ *
+ * Two entry points only:
+ *   1. idb_request_to_promise(req_ref_id)
+ *      Wraps an IDBRequest in a Promise so Ruby can use JS::Promise#await.
+ *   2. idb_open_with_upgrade(name, version, upgrade_callback_id)
+ *      Opens a database. Inside onupgradeneeded the registered Ruby callback
+ *      is invoked synchronously via call_ruby_callback_sync_generic so that
+ *      schema mutations (createObjectStore / createIndex) run on the JS
+ *      stack as required by the spec.
+ *****************************************************/
+
+EM_JS(int, idb_request_to_promise, (int req_ref_id), {
+  try {
+    const req = globalThis.picorubyRefs[req_ref_id];
+    if (!req) {
+      console.error('idb_request_to_promise: invalid ref_id', req_ref_id);
+      return -1;
+    }
+    const promise = new Promise((resolve, reject) => {
+      req.onsuccess = () => { resolve(req.result); };
+      req.onerror = () => {
+        const msg = (req.error && req.error.message) || 'IDB request failed';
+        reject(new Error(msg));
+      };
+    });
+    return globalThis.picorubyRefs.push(promise) - 1;
+  } catch (e) {
+    console.error('idb_request_to_promise failed:', e);
+    return -1;
+  }
+});
+
+EM_JS(int, idb_open_with_upgrade, (const char *name_ptr, int version, uintptr_t callback_id), {
+  try {
+    const name = UTF8ToString(name_ptr);
+    const idb = globalThis.indexedDB;
+    if (!idb) {
+      console.error('idb_open_with_upgrade: indexedDB unavailable');
+      return -1;
+    }
+    const req = (version > 0) ? idb.open(name, version) : idb.open(name);
+
+    req.onupgradeneeded = (event) => {
+      if (callback_id === 0) return;
+      const db = req.result;
+      const oldV = event.oldVersion;
+      const newV = event.newVersion;
+
+      const dbRef = globalThis.picorubyRefs.push(db) - 1;
+      const oldRef = globalThis.picorubyRefs.push(oldV) - 1;
+      const newRef = globalThis.picorubyRefs.push(newV) - 1;
+
+      const argRefIds = [dbRef, oldRef, newRef];
+      const argRefIdsPtr = _malloc(argRefIds.length * 4);
+      for (let i = 0; i < argRefIds.length; i++) {
+        HEAP32[(argRefIdsPtr >> 2) + i] = argRefIds[i];
+      }
+      try {
+        ccall(
+          'call_ruby_callback_sync_generic',
+          'number',
+          ['number', 'number', 'number'],
+          [callback_id, argRefIdsPtr, argRefIds.length]
+        );
+      } catch (e) {
+        console.error('idb upgrade callback threw:', e);
+      } finally {
+        _free(argRefIdsPtr);
+      }
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      req.onsuccess = () => { resolve(req.result); };
+      req.onerror = () => {
+        const msg = (req.error && req.error.message) || 'IDB open failed';
+        reject(new Error(msg));
+      };
+      req.onblocked = () => {
+        reject(new Error('IDB open blocked: another connection holds an older version'));
+      };
+    });
+    return globalThis.picorubyRefs.push(promise) - 1;
+  } catch (e) {
+    console.error('idb_open_with_upgrade failed:', e);
+    return -1;
+  }
+});
+
+/*****************************************************
+ * mruby methods
+ *****************************************************/
+
+/*
+ * IndexedDB::Helper._request_to_promise(js_request) -> JS::Promise
+ */
+static mrb_value
+mrb_idb_helper_request_to_promise(mrb_state *mrb, mrb_value self)
+{
+  mrb_value req_obj;
+  mrb_get_args(mrb, "o", &req_obj);
+
+  if (!mrb_obj_is_kind_of(mrb, req_obj, class_JS_Object)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "expected JS::Object (IDBRequest)");
+  }
+  picorb_js_obj *req = (picorb_js_obj *)DATA_PTR(req_obj);
+  if (!req) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "JS::Object has no data");
+  }
+  int promise_id = idb_request_to_promise(req->ref_id);
+  if (promise_id < 0) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "idb_request_to_promise failed");
+  }
+  return wrap_ref_as_js_object(mrb, promise_id);
+}
+
+/*
+ * IndexedDB::Helper._open_with_upgrade(name, version, callback_id) -> JS::Promise
+ *
+ * callback_id may be 0 to skip the upgrade hook (e.g. when opening at the
+ * current version with no schema work to do).
+ */
+static mrb_value
+mrb_idb_helper_open_with_upgrade(mrb_state *mrb, mrb_value self)
+{
+  const char *name;
+  mrb_int version;
+  mrb_int callback_id;
+  mrb_get_args(mrb, "zii", &name, &version, &callback_id);
+
+  int promise_id = idb_open_with_upgrade(name, (int)version, (uintptr_t)callback_id);
+  if (promise_id < 0) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "idb_open_with_upgrade failed");
+  }
+  return wrap_ref_as_js_object(mrb, promise_id);
+}
+
+/*****************************************************
+ * Gem init
+ *****************************************************/
+
+void
+mrb_picoruby_indexeddb_gem_init(mrb_state *mrb)
+{
+  struct RClass *module_IndexedDB = mrb_define_module_id(mrb, MRB_SYM(IndexedDB));
+  struct RClass *module_Helper = mrb_define_module_under_id(mrb, module_IndexedDB, MRB_SYM(Helper));
+
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_request_to_promise),
+    mrb_idb_helper_request_to_promise, MRB_ARGS_REQ(1));
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_open_with_upgrade),
+    mrb_idb_helper_open_with_upgrade, MRB_ARGS_REQ(3));
+}
+
+void
+mrb_picoruby_indexeddb_gem_final(mrb_state *mrb)
+{
+}

--- a/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
+++ b/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
@@ -24,7 +24,7 @@ extern mrb_value wrap_ref_as_js_object(mrb_state *mrb, int ref_id);
 /*****************************************************
  * EM_JS helpers
  *
- * Two entry points only:
+ * Three entry points:
  *   1. idb_request_to_promise(req_ref_id)
  *      Wraps an IDBRequest in a Promise so Ruby can use JS::Promise#await.
  *   2. idb_open_with_upgrade(name, version, upgrade_callback_id)
@@ -32,6 +32,10 @@ extern mrb_value wrap_ref_as_js_object(mrb_state *mrb, int ref_id);
  *      is invoked synchronously via call_ruby_callback_sync_generic so that
  *      schema mutations (createObjectStore / createIndex) run on the JS
  *      stack as required by the spec.
+ *   3. idb_transaction_to_promise(tx_ref_id)
+ *      Wraps an IDBTransaction's oncomplete/onerror/onabort events as a
+ *      single Promise. Used by Database#batch to atomically commit a group
+ *      of write operations.
  *****************************************************/
 
 EM_JS(int, idb_request_to_promise, (int req_ref_id), {
@@ -111,6 +115,31 @@ EM_JS(int, idb_open_with_upgrade, (const char *name_ptr, int version, uintptr_t 
   }
 });
 
+EM_JS(int, idb_transaction_to_promise, (int tx_ref_id), {
+  try {
+    const tx = globalThis.picorubyRefs[tx_ref_id];
+    if (!tx) {
+      console.error('idb_transaction_to_promise: invalid ref_id', tx_ref_id);
+      return -1;
+    }
+    const promise = new Promise((resolve, reject) => {
+      tx.oncomplete = () => { resolve(true); };
+      tx.onerror = () => {
+        const msg = (tx.error && tx.error.message) || 'IDB transaction error';
+        reject(new Error(msg));
+      };
+      tx.onabort = () => {
+        const msg = (tx.error && tx.error.message) || 'IDB transaction aborted';
+        reject(new Error(msg));
+      };
+    });
+    return globalThis.picorubyRefs.push(promise) - 1;
+  } catch (e) {
+    console.error('idb_transaction_to_promise failed:', e);
+    return -1;
+  }
+});
+
 /*****************************************************
  * mruby methods
  *****************************************************/
@@ -134,6 +163,29 @@ mrb_idb_helper_request_to_promise(mrb_state *mrb, mrb_value self)
   int promise_id = idb_request_to_promise(req->ref_id);
   if (promise_id < 0) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "idb_request_to_promise failed");
+  }
+  return wrap_ref_as_js_object(mrb, promise_id);
+}
+
+/*
+ * IndexedDB::Helper._transaction_to_promise(js_transaction) -> JS::Promise
+ */
+static mrb_value
+mrb_idb_helper_transaction_to_promise(mrb_state *mrb, mrb_value self)
+{
+  mrb_value tx_obj;
+  mrb_get_args(mrb, "o", &tx_obj);
+
+  if (!mrb_obj_is_kind_of(mrb, tx_obj, class_JS_Object)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "expected JS::Object (IDBTransaction)");
+  }
+  picorb_js_obj *tx = (picorb_js_obj *)DATA_PTR(tx_obj);
+  if (!tx) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "JS::Object has no data");
+  }
+  int promise_id = idb_transaction_to_promise(tx->ref_id);
+  if (promise_id < 0) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "idb_transaction_to_promise failed");
   }
   return wrap_ref_as_js_object(mrb, promise_id);
 }
@@ -173,6 +225,8 @@ mrb_picoruby_indexeddb_gem_init(mrb_state *mrb)
     mrb_idb_helper_request_to_promise, MRB_ARGS_REQ(1));
   mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_open_with_upgrade),
     mrb_idb_helper_open_with_upgrade, MRB_ARGS_REQ(3));
+  mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(_transaction_to_promise),
+    mrb_idb_helper_transaction_to_promise, MRB_ARGS_REQ(1));
 }
 
 void

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -80,8 +80,11 @@
       <li><a href="terminal.html">R2P2 Terminal (Web Serial API)</a></li>
       <li><a href="regexp.html">Regular expression test</a></li>
     </ul>
-    <div>Funicular tests</div>
+    <div>IndexedDB tests</div>
     <ul>
+      <li><a href="indexeddb/open.html">Open database</a></li>
+    </ul>
+    <div>Funicular tests</div>
     <ul>
       <li><a href="funicular/test_vdom.html">VDOM test</a></li>
       <li><a href="funicular/test_diff_patch.html">Diff & Patch test</a></li>

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -83,6 +83,7 @@
     <div>IndexedDB tests</div>
     <ul>
       <li><a href="indexeddb/open.html">Open database</a></li>
+      <li><a href="indexeddb/crud.html">Store CRUD operations</a></li>
     </ul>
     <div>Funicular tests</div>
     <ul>

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -85,6 +85,7 @@
       <li><a href="indexeddb/open.html">Open database</a></li>
       <li><a href="indexeddb/crud.html">Store CRUD operations</a></li>
       <li><a href="indexeddb/batch.html">Batch operations</a></li>
+      <li><a href="indexeddb/kvs.html">KVS facade</a></li>
     </ul>
     <div>Funicular tests</div>
     <ul>

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -84,6 +84,7 @@
     <ul>
       <li><a href="indexeddb/open.html">Open database</a></li>
       <li><a href="indexeddb/crud.html">Store CRUD operations</a></li>
+      <li><a href="indexeddb/batch.html">Batch operations</a></li>
     </ul>
     <div>Funicular tests</div>
     <ul>

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -86,6 +86,7 @@
       <li><a href="indexeddb/crud.html">Store CRUD operations</a></li>
       <li><a href="indexeddb/batch.html">Batch operations</a></li>
       <li><a href="indexeddb/kvs.html">KVS facade</a></li>
+      <li><a href="indexeddb/funicular_cache.html">Funicular HTTP cache</a></li>
     </ul>
     <div>Funicular tests</div>
     <ul>

--- a/mrbgems/picoruby-wasm/demo/www/indexeddb
+++ b/mrbgems/picoruby-wasm/demo/www/indexeddb
@@ -1,0 +1,1 @@
+../../../picoruby-indexeddb/demo/


### PR DESCRIPTION
This pull request adds the new `picoruby-indexeddb` gem, a Ruby-idiomatic IndexedDB wrapper for PicoRuby.wasm, and integrates it into the build configuration. It also introduces comprehensive documentation and demo applications to validate and showcase the gem’s features, including atomic batch transactions and store CRUD operations.

**New Gem Integration:**

* Added `picoruby-indexeddb` as a core gem in the build configuration (`build_config/picoruby-wasm.rb`) to make IndexedDB support available in PicoRuby.wasm builds.

**Documentation:**

* Added a detailed `README.md` for `picoruby-indexeddb` describing features, usage patterns, API reference, error handling, and dependencies.

**Demo Applications:**

* Added `demo/batch.html` to demonstrate and test atomic multi-store transactions using `Database#batch`, including error cases for await-bearing calls inside a batch and store view caching.
* Added `demo/crud.html` to verify basic store operations such as `put`, `get`, `delete`, `count`, `clear`, `keys`, `to_a`, and `each`.

**Other Updates:**

* Updated the `picoruby-funicular` submodule to a new commit, possibly to align with the new gem or fix compatibility issues.