### PR TITLE
Improve picoruby-json using Regexp in WASM build

### DIFF
--- a/mrbgems/picoruby-json/mrblib/json.rb
+++ b/mrbgems/picoruby-json/mrblib/json.rb
@@ -15,6 +15,25 @@ module JSON
   class GeneratorError < JSONError; end
   class DiggerError < JSONError; end
 
+  # Detect WASM build for Regexp-based optimization (lazy, cached)
+  def self.wasm_build?
+    return @wasm_build unless @wasm_build.nil?
+    @wasm_build = RUBY_DESCRIPTION.include?("wasm32")
+  end
+
+  # Regexp patterns (lazy initialization)
+  def self.ws_pattern
+    @ws_pattern ||= /^[ \t\n\r]+/
+  end
+
+  def self.string_content_pattern
+    @string_content_pattern ||= /^[^"\\]+/
+  end
+
+  def self.number_pattern
+    @number_pattern ||= /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/
+  end
+
   module Common
     def expect(char)
       if @json[@index] != char
@@ -24,8 +43,14 @@ module JSON
     end
 
     def skip_whitespace
-      while @index < @json.length && [' ', "\t", "\n", "\r"].include?(@json[@index])
-        @index += 1
+      if JSON.wasm_build?
+        if md = JSON.ws_pattern.match(@json, @index)
+          @index = md.end(0)
+        end
+      else
+        while @index < @json.length && [' ', "\t", "\n", "\r"].include?(@json[@index])
+          @index += 1
+        end
       end
     end
 
@@ -159,18 +184,32 @@ module JSON
           @index += 1
           return str
         else
-          @index += 1
+          if JSON.wasm_build?
+            if md = JSON.string_content_pattern.match(@json, @index)
+              @index = md.end(0)
+            else
+              @index += 1
+            end
+          else
+            @index += 1
+          end
         end
       end
       raise JSON::DiggerError.new("Unterminated string")
     end
 
     def dig_number
-      while char = @json[@index]
-        if char == '-' || char == '.' || char == 'e' || char == 'E' || ('0' <= char && char <= '9')
-          @index += 1
-        else
-          break
+      if JSON.wasm_build?
+        if md = JSON.number_pattern.match(@json, @index)
+          @index = md.end(0)
+        end
+      else
+        while char = @json[@index]
+          if char == '-' || char == '.' || char == 'e' || char == 'E' || ('0' <= char && char <= '9')
+            @index += 1
+          else
+            break
+          end
         end
       end
     end
@@ -463,8 +502,18 @@ module JSON
             @index += snip.length
           end
         else
-          result += @json[@index].to_s
-          @index += 1
+          if JSON.wasm_build?
+            if md = JSON.string_content_pattern.match(@json, @index)
+              result += md[0]
+              @index = md.end(0)
+            else
+              result += @json[@index].to_s
+              @index += 1
+            end
+          else
+            result += @json[@index].to_s
+            @index += 1
+          end
         end
         if @index >= @json.length
           raise JSON::ParserError.new("Unterminated string")
@@ -537,39 +586,55 @@ module JSON
     end
 
     def parse_number
-      start = @index
-      is_float = false
-      is_negative = @json[@index] == '-'
-      @index += 1 if is_negative
-
-      # Integer part
-      while @index < @json.length && is_digit?(@json[@index])
-        @index += 1
-      end
-
-      # Fractional part
-      if @index < @json.length && @json[@index] == '.'
-        is_float = true
-        @index += 1
-        while @index < @json.length && is_digit?(@json[@index])
-          @index += 1
+      if JSON.wasm_build?
+        md = JSON.number_pattern.match(@json, @index)
+        unless md
+          raise JSON::ParserError.new("Invalid number at index #{@index}")
         end
-      end
-
-      # Exponent part
-      if @index < @json.length && (@json[@index] == 'e' || @json[@index] == 'E')
-        is_float = true
-        @index += 1
-        @index += 1 if @index < @json.length && (@json[@index] == '+' || @json[@index] == '-')
-        while @index < @json.length && is_digit?(@json[@index])
-          @index += 1
+        matched = md[0]
+        start = @index
+        @index = md.end(0)
+        is_float = matched.include?('.') || matched.include?('e') || matched.include?('E')
+        if is_float
+          parse_float(start, @index)
+        else
+          parse_integer(start, @index)
         end
-      end
-
-      if is_float
-        parse_float(start, @index)
       else
-        parse_integer(start, @index)
+        start = @index
+        is_float = false
+        is_negative = @json[@index] == '-'
+        @index += 1 if is_negative
+
+        # Integer part
+        while @index < @json.length && is_digit?(@json[@index])
+          @index += 1
+        end
+
+        # Fractional part
+        if @index < @json.length && @json[@index] == '.'
+          is_float = true
+          @index += 1
+          while @index < @json.length && is_digit?(@json[@index])
+            @index += 1
+          end
+        end
+
+        # Exponent part
+        if @index < @json.length && (@json[@index] == 'e' || @json[@index] == 'E')
+          is_float = true
+          @index += 1
+          @index += 1 if @index < @json.length && (@json[@index] == '+' || @json[@index] == '-')
+          while @index < @json.length && is_digit?(@json[@index])
+            @index += 1
+          end
+        end
+
+        if is_float
+          parse_float(start, @index)
+        else
+          parse_integer(start, @index)
+        end
       end
     end
 
@@ -609,11 +674,11 @@ module JSON
           elsif decimal_divider == 1.0
             result = result * 10 + (byte - 48)
           else
-            decimal_divider *= 10
             result += (byte - 48) / decimal_divider
+            decimal_divider *= 10
           end
         when '.'
-          # Do nothing, just move to the next character
+          decimal_divider = 10.0
         when 'e', 'E'
           parsing_exponent = true
         when '-'

--- a/mrbgems/picoruby-json/mrblib/json.rb
+++ b/mrbgems/picoruby-json/mrblib/json.rb
@@ -173,7 +173,7 @@ module JSON
 
     # Override to never use Regexp for Digger (performance)
     def skip_whitespace
-      while @index < @json.length && [' ', "\t", "\n", "\r"].include?(@json[@index])
+      while @index < @json.length && [' ', "\t", "\n", "\r"].include?(@json[@index] || "")
         @index += 1
       end
     end
@@ -509,7 +509,7 @@ module JSON
         else
           if JSON.use_regexp?
             if md = JSON.string_content_pattern.match(@json, @index)
-              result += md[0]
+              result += md[0] || ""
               @index = md.end(0)
             else
               result += @json[@index].to_s
@@ -596,7 +596,7 @@ module JSON
         unless md
           raise JSON::ParserError.new("Invalid number at index #{@index}")
         end
-        matched = md[0]
+        matched = md[0] || ""
         start = @index
         @index = md.end(0)
         is_float = matched.include?('.') || matched.include?('e') || matched.include?('E')

--- a/mrbgems/picoruby-json/mrblib/json.rb
+++ b/mrbgems/picoruby-json/mrblib/json.rb
@@ -426,6 +426,7 @@ module JSON
     end
 
     def parse
+      skip_whitespace
       case @json[@index]
       when '{'
         parse_object

--- a/mrbgems/picoruby-json/mrblib/json.rb
+++ b/mrbgems/picoruby-json/mrblib/json.rb
@@ -21,6 +21,17 @@ module JSON
     @wasm_build = RUBY_DESCRIPTION.include?("wasm32")
   end
 
+  # Toggle for Regexp optimization (can be set to false for benchmarking)
+  # Defaults to wasm_build? but can be overridden: JSON.use_regexp = false
+  def self.use_regexp?
+    return @use_regexp unless @use_regexp.nil?
+    @use_regexp = wasm_build?
+  end
+
+  def self.use_regexp=(val)
+    @use_regexp = val
+  end
+
   # Regexp patterns (lazy initialization)
   def self.ws_pattern
     @ws_pattern ||= /^[ \t\n\r]+/
@@ -43,7 +54,7 @@ module JSON
     end
 
     def skip_whitespace
-      if JSON.wasm_build?
+      if JSON.use_regexp?
         if md = JSON.ws_pattern.match(@json, @index)
           @index = md.end(0)
         end
@@ -160,6 +171,13 @@ module JSON
       @stack = []
     end
 
+    # Override to never use Regexp for Digger (performance)
+    def skip_whitespace
+      while @index < @json.length && [' ', "\t", "\n", "\r"].include?(@json[@index])
+        @index += 1
+      end
+    end
+
     def push_stack(type)
       @stack.push(type)
       #puts "push_stack: #{@stack}, index: #{@index}"
@@ -184,32 +202,18 @@ module JSON
           @index += 1
           return str
         else
-          if JSON.wasm_build?
-            if md = JSON.string_content_pattern.match(@json, @index)
-              @index = md.end(0)
-            else
-              @index += 1
-            end
-          else
-            @index += 1
-          end
+          @index += 1
         end
       end
       raise JSON::DiggerError.new("Unterminated string")
     end
 
     def dig_number
-      if JSON.wasm_build?
-        if md = JSON.number_pattern.match(@json, @index)
-          @index = md.end(0)
-        end
-      else
-        while char = @json[@index]
-          if char == '-' || char == '.' || char == 'e' || char == 'E' || ('0' <= char && char <= '9')
-            @index += 1
-          else
-            break
-          end
+      while char = @json[@index]
+        if char == '-' || char == '.' || char == 'e' || char == 'E' || ('0' <= char && char <= '9')
+          @index += 1
+        else
+          break
         end
       end
     end
@@ -503,7 +507,7 @@ module JSON
             @index += snip.length
           end
         else
-          if JSON.wasm_build?
+          if JSON.use_regexp?
             if md = JSON.string_content_pattern.match(@json, @index)
               result += md[0]
               @index = md.end(0)
@@ -587,7 +591,7 @@ module JSON
     end
 
     def parse_number
-      if JSON.wasm_build?
+      if JSON.use_regexp?
         md = JSON.number_pattern.match(@json, @index)
         unless md
           raise JSON::ParserError.new("Invalid number at index #{@index}")

--- a/mrbgems/picoruby-json/sig/json.rbs
+++ b/mrbgems/picoruby-json/sig/json.rbs
@@ -12,8 +12,21 @@ module JSON
   class DiggerError < JSONError
   end
 
+  @wasm_build: bool?
+  @use_regexp: bool?
+  @ws_pattern: Regexp?
+  @string_content_pattern: Regexp?
+  @number_pattern: Regexp?
+
+  def self.wasm_build?: () -> bool
+  def self.use_regexp?: () -> bool
+  def self.use_regexp=: (bool) -> bool
+  def self.ws_pattern: () -> Regexp
+  def self.string_content_pattern: () -> Regexp
+  def self.number_pattern: () -> Regexp
+
   module Common
-    private def expect: (String) -> void
+    private def expect: (String?) -> void
     private def skip_whitespace: () -> void
     private def parse_true: () -> true
     private def parse_false: () -> false

--- a/mrbgems/picoruby-json/test/target_vm
+++ b/mrbgems/picoruby-json/test/target_vm
@@ -1,0 +1,1 @@
+picoruby

--- a/mrbgems/picoruby-wasm/demo/www/index.html
+++ b/mrbgems/picoruby-wasm/demo/www/index.html
@@ -79,6 +79,7 @@
       <li><a href="ble_ota_demo.html">Web Bluetooth OTA (BLE UART DFU) demo</a></li>
       <li><a href="terminal.html">R2P2 Terminal (Web Serial API)</a></li>
       <li><a href="regexp.html">Regular expression test</a></li>
+      <li><a href="json.html">JSON test</a></li>
     </ul>
     <div>IndexedDB tests</div>
     <ul>

--- a/mrbgems/picoruby-wasm/demo/www/json.html
+++ b/mrbgems/picoruby-wasm/demo/www/json.html
@@ -14,13 +14,14 @@
     <h1>JSON Tests</h1>
 
     <button id="run-tests">Run Tests</button>
+    <button id="run-benchmark">Run Benchmark</button>
     <div id="output"></div>
 
     <script type="text/ruby">
       require 'js'
 
       output = JS.document.getElementById('output')
-      output.textContent = "Ready. Click Run Tests."
+      output.textContent = "Ready. Click Run Tests or Run Benchmark."
 
       def assert_equal(expected, actual, label)
         if expected == actual
@@ -104,6 +105,87 @@
 
         summary = "<b>#{pass_count} passed, #{fail_count} failed</b>\n\n"
         output.innerHTML = summary + results.join("\n")
+      end
+
+      JS.document.getElementById('run-benchmark').addEventListener('click') do |event|
+        output.textContent = "Generating test data...\n"
+
+        # Generate JSON with longer strings
+        long_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 10
+        items = []
+        i = 0
+        while i < 50
+          items << '{"id":' + i.to_s + ',"description":"' + long_text + '","tags":["tag1","tag2","tag3"],"score":' + (i * 1.5).to_s + '}'
+          i += 1
+        end
+        large_json = '[' + items.join(',') + ']'
+
+        output.textContent += "JSON size: #{large_json.length} bytes\n"
+        iterations = 5
+
+        # Benchmark with Regexp
+        JSON.use_regexp = true
+        output.textContent += "\n=== With Regexp ===\n"
+
+        GC.start
+        start_time = Time.now
+        j = 0
+        while j < iterations
+          JSON.parse(large_json)
+          j += 1
+        end
+        regexp_parse_time = Time.now - start_time
+        output.textContent += "JSON.parse x #{iterations}: #{(regexp_parse_time * 1000).to_i} ms\n"
+
+        GC.start
+        start_time = Time.now
+        j = 0
+        while j < iterations
+          digger = JSON::Digger.new(large_json)
+          digger.dig(25, "description").parse
+          j += 1
+        end
+        regexp_digger_time = Time.now - start_time
+        output.textContent += "Digger x #{iterations}: #{(regexp_digger_time * 1000).to_i} ms\n"
+
+        # Benchmark without Regexp
+        JSON.use_regexp = false
+        output.textContent += "\n=== Without Regexp ===\n"
+
+        GC.start
+        start_time = Time.now
+        j = 0
+        while j < iterations
+          JSON.parse(large_json)
+          j += 1
+        end
+        no_regexp_parse_time = Time.now - start_time
+        output.textContent += "JSON.parse x #{iterations}: #{(no_regexp_parse_time * 1000).to_i} ms\n"
+
+        GC.start
+        start_time = Time.now
+        j = 0
+        while j < iterations
+          digger = JSON::Digger.new(large_json)
+          digger.dig(25, "description").parse
+          j += 1
+        end
+        no_regexp_digger_time = Time.now - start_time
+        output.textContent += "Digger x #{iterations}: #{(no_regexp_digger_time * 1000).to_i} ms\n"
+
+        # Comparison
+        output.textContent += "\n=== Comparison ===\n"
+        if no_regexp_parse_time > 0
+          parse_speedup = no_regexp_parse_time / regexp_parse_time
+          output.textContent += "Parse speedup: #{parse_speedup.to_s[0, 4]}x\n"
+        end
+        if no_regexp_digger_time > 0
+          digger_speedup = no_regexp_digger_time / regexp_digger_time
+          output.textContent += "Digger speedup: #{digger_speedup.to_s[0, 4]}x\n"
+        end
+
+        # Reset to default
+        JSON.use_regexp = nil
       end
     </script>
     <script src="init.iife.js"></script>

--- a/mrbgems/picoruby-wasm/demo/www/json.html
+++ b/mrbgems/picoruby-wasm/demo/www/json.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="test.css">
+    <style>
+      #output { white-space: pre-wrap; font-family: monospace; background: #f4f4f4; padding: 10px; margin: 10px 0; min-height: 100px; border: 1px solid #ccc; }
+      .pass { color: green; }
+      .fail { color: red; }
+    </style>
+  </head>
+  <body>
+    <div><a href="index.html">Back</a></div>
+    <h1>JSON Tests</h1>
+
+    <button id="run-tests">Run Tests</button>
+    <div id="output"></div>
+
+    <script type="text/ruby">
+      require 'js'
+
+      output = JS.document.getElementById('output')
+      output.textContent = "Ready. Click Run Tests."
+
+      def assert_equal(expected, actual, label)
+        if expected == actual
+          "<span class='pass'>PASS</span> #{label}"
+        else
+          "<span class='fail'>FAIL</span> #{label}\n  expected: #{expected.inspect}\n  actual:   #{actual.inspect}"
+        end
+      end
+
+      JS.document.getElementById('run-tests').addEventListener('click') do |event|
+        results = []
+
+        # WASM build check
+        results << assert_equal(true, JSON.wasm_build?, "JSON.wasm_build? is true")
+
+        # JSON.parse basic tests
+        results << assert_equal({"a" => 1, "b" => "hello"}, JSON.parse('{"a":1,"b":"hello"}'), "JSON.parse object")
+        results << assert_equal([1, "two", true, nil], JSON.parse('[1, "two", true, null]'), "JSON.parse array")
+
+        # Numbers
+        results << assert_equal(123, JSON.parse('[123]')[0], "JSON.parse integer")
+        results << assert_equal(-456, JSON.parse('[-456]')[0], "JSON.parse negative")
+        results << assert_equal(3.14, JSON.parse('[3.14]')[0], "JSON.parse float")
+
+        # Strings
+        results << assert_equal("hello", JSON.parse('["hello"]')[0], "JSON.parse string")
+
+        # UTF-8
+        results << assert_equal("日本語", JSON.parse('["日本語"]')[0], "JSON.parse UTF-8")
+
+        # JSON.generate
+        results << assert_equal('{"a":1}', JSON.generate({a: 1}), "JSON.generate object")
+
+        # Digger
+        json_str = '{"user":{"name":"Taro"}}'
+        digger = JSON::Digger.new(json_str)
+        results << assert_equal("Taro", digger.dig("user", "name").parse, "JSON::Digger")
+
+        # Summary
+        pass_count = 0
+        fail_count = 0
+        results.each do |r|
+          if r.include?("PASS")
+            pass_count += 1
+          else
+            fail_count += 1
+          end
+        end
+
+        summary = "<b>#{pass_count} passed, #{fail_count} failed</b>\n\n"
+        output.innerHTML = summary + results.join("\n")
+      end
+    </script>
+    <script src="init.iife.js"></script>
+  </body>
+</html>

--- a/mrbgems/picoruby-wasm/demo/www/json.html
+++ b/mrbgems/picoruby-wasm/demo/www/json.html
@@ -39,6 +39,26 @@
         # JSON.parse basic tests
         results << assert_equal({"a" => 1, "b" => "hello"}, JSON.parse('{"a":1,"b":"hello"}'), "JSON.parse object")
         results << assert_equal([1, "two", true, nil], JSON.parse('[1, "two", true, null]'), "JSON.parse array")
+        results << assert_equal({"nested" => {"key" => "value"}}, JSON.parse('{"nested":{"key":"value"}}'), "JSON.parse nested")
+
+        # Whitespace handling
+        results << assert_equal({"a" => 1}, JSON.parse('  {  "a"  :  1  }  '), "JSON.parse whitespace")
+        results << assert_equal([1, 2, 3], JSON.parse('  [  1  ,  2  ,  3  ]  '), "JSON.parse array whitespace")
+
+        # More numbers
+        results << assert_equal(0, JSON.parse('[0]')[0], "JSON.parse zero")
+        results << assert_equal(-2.5, JSON.parse('[-2.5]')[0], "JSON.parse negative float")
+        results << assert_equal(1.0e10, JSON.parse('[1e10]')[0], "JSON.parse exponential")
+
+        # Boolean and null
+        results << assert_equal(true, JSON.parse('[true]')[0], "JSON.parse true")
+        results << assert_equal(false, JSON.parse('[false]')[0], "JSON.parse false")
+        results << assert_equal(nil, JSON.parse('[null]')[0], "JSON.parse null")
+
+        # More generate
+        results << assert_equal('[1,2,3]', JSON.generate([1, 2, 3]), "JSON.generate array")
+        results << assert_equal('true', JSON.generate(true), "JSON.generate true")
+        results << assert_equal('null', JSON.generate(nil), "JSON.generate null")
 
         # Numbers
         results << assert_equal(123, JSON.parse('[123]')[0], "JSON.parse integer")
@@ -50,6 +70,8 @@
 
         # UTF-8
         results << assert_equal("日本語", JSON.parse('["日本語"]')[0], "JSON.parse UTF-8")
+        results << assert_equal("😀", JSON.parse('["😀"]')[0], "JSON.parse emoji")
+        results << assert_equal({"name" => "田中"}, JSON.parse('{"name":"田中"}'), "JSON.parse UTF-8 object")
 
         # JSON.generate
         results << assert_equal('{"a":1}', JSON.generate({a: 1}), "JSON.generate object")
@@ -58,6 +80,16 @@
         json_str = '{"user":{"name":"Taro"}}'
         digger = JSON::Digger.new(json_str)
         results << assert_equal("Taro", digger.dig("user", "name").parse, "JSON::Digger")
+
+        # Digger with array
+        json_arr = '{"posts":[{"title":"Post 1"},{"title":"Post 2"}]}'
+        digger2 = JSON::Digger.new(json_arr)
+        results << assert_equal("Post 2", digger2.dig("posts", 1, "title").parse, "JSON::Digger array")
+
+        # Digger UTF-8
+        json_utf8 = '{"user":{"name":"田中太郎"}}'
+        digger3 = JSON::Digger.new(json_utf8)
+        results << assert_equal("田中太郎", digger3.dig("user", "name").parse, "JSON::Digger UTF-8")
 
         # Summary
         pass_count = 0

--- a/mrbgems/picoruby-wasm/demo/www/regexp.html
+++ b/mrbgems/picoruby-wasm/demo/www/regexp.html
@@ -146,6 +146,167 @@
         results << assert_equal(2, Regexp::EXTENDED, "EXTENDED constant")
         results << assert_equal(4, Regexp::MULTILINE, "MULTILINE constant")
 
+        # match with pos (2nd argument)
+        re_pos = Regexp.new("\\d+")
+        md_pos = re_pos.match("ab12cd34", 4)
+        results << assert_equal("34", md_pos[0], "Regexp#match with pos skips earlier match")
+        results << assert_equal(6, md_pos.begin(0), "Regexp#match with pos: begin reflects original index")
+        results << assert_equal(8, md_pos.end(0), "Regexp#match with pos: end reflects original index")
+        results << assert_equal("ab12cd", md_pos.pre_match, "Regexp#match with pos: pre_match")
+        results << assert_equal("", md_pos.post_match, "Regexp#match with pos: post_match")
+        results << assert_equal(nil, re_pos.match("ab12cd34", 9), "Regexp#match with pos beyond length returns nil")
+        results << assert_equal(true, re_pos.match?("ab12cd34", 4), "Regexp#match? with pos")
+        results << assert_equal(false, re_pos.match?("abcdef", 0), "Regexp#match? with pos no match")
+
+        md_str_pos = "foo123bar456".match(Regexp.new("(\\d+)"), 6)
+        results << assert_equal("456", md_str_pos[1], "String#match with pos: capture")
+        results << assert_equal(9, md_str_pos.begin(0), "String#match with pos: begin")
+        results << assert_equal(true, "foo123bar".match?(Regexp.new("\\d+"), 3), "String#match? with pos")
+
+        # String#gsub with replacement string
+        results << assert_equal("abXXcdXX",
+          "ab12cd34".gsub(Regexp.new("\\d+"), "XX"),
+          "String#gsub with literal replacement")
+        results << assert_equal("ab[12]cd[34]",
+          "ab12cd34".gsub(Regexp.new("(\\d+)"), "[\\1]"),
+          "String#gsub with capture backreference")
+        results << assert_equal("<&>foo<&>",
+          "abcfoodef".gsub(Regexp.new("(abc|def)"), "<&>"),
+          "String#gsub treats \\& as separator literal")
+        results << assert_equal("<abc>foo<def>",
+          "abcfoodef".gsub(Regexp.new("(abc|def)"), "<\\&>"),
+          "String#gsub with \\& expands to full match")
+        results << assert_equal("a\\b",
+          "axb".gsub(Regexp.new("x"), "\\\\"),
+          "String#gsub with escaped backslash")
+        results << assert_equal("",
+          "".gsub(Regexp.new("x"), "Y"),
+          "String#gsub on empty string returns empty")
+        results << assert_equal("abc",
+          "abc".gsub(Regexp.new("z"), "Y"),
+          "String#gsub no match returns original")
+
+        # String#gsub with block
+        results << assert_equal("ab[12]cd[34]",
+          "ab12cd34".gsub(Regexp.new("\\d+")) { |m| "[#{m}]" },
+          "String#gsub with block")
+        results << assert_equal("AB12CD34",
+          "ab12cd34".gsub(Regexp.new("[a-z]+")) { |m| m.upcase },
+          "String#gsub block calls upcase")
+
+        # String#sub (only first match)
+        results << assert_equal("abXXcd34",
+          "ab12cd34".sub(Regexp.new("\\d+"), "XX"),
+          "String#sub only replaces first match")
+        results << assert_equal("ab[12]cd34",
+          "ab12cd34".sub(Regexp.new("(\\d+)")) { |m| "[#{m}]" },
+          "String#sub with block")
+
+        # UTF-8 in gsub: replace Japanese characters
+        results << assert_equal("hello[world]",
+          "helloworld".sub(Regexp.new("world"), "[\\&]"),
+          "sub with \\& in ASCII")
+        results << assert_equal("XXあいうXX",
+          "12あいう34".gsub(Regexp.new("\\d+"), "XX"),
+          "gsub preserves multibyte chars between matches")
+        results << assert_equal("[あ][い][う]",
+          "あいう".gsub(Regexp.new(".")) { |c| "[#{c}]" },
+          "gsub with multibyte target")
+
+        # Zero-width match should advance one char (no infinite loop)
+        results << assert_equal("|a|b|c|",
+          "abc".gsub(Regexp.new("")) { "|" },
+          "gsub with zero-width: surrounds each char with |")
+
+        # ---- UTF-8 (multibyte) tests ----
+
+        # BMP characters (Japanese): each is 3 UTF-8 bytes but 1 code point.
+        md_jp = Regexp.new("世界").match("こんにちは世界")
+        results << assert_equal("世界", md_jp[0], "UTF-8: BMP literal match")
+        results << assert_equal(5, md_jp.begin(0), "UTF-8: BMP begin uses char index")
+        results << assert_equal(7, md_jp.end(0), "UTF-8: BMP end uses char index")
+        results << assert_equal("こんにちは", md_jp.pre_match, "UTF-8: BMP pre_match")
+        results << assert_equal("", md_jp.post_match, "UTF-8: BMP post_match (end)")
+
+        md_jp2 = Regexp.new("世").match("こんにちは世界")
+        results << assert_equal(5, md_jp2.begin(0), "UTF-8: single-kanji begin")
+        results << assert_equal(6, md_jp2.end(0), "UTF-8: single-kanji end")
+        results << assert_equal("界", md_jp2.post_match, "UTF-8: single-kanji post_match")
+
+        # Hiragana character class
+        md_hira = Regexp.new("[ぁ-ん]+").match("Hello こんにちは World")
+        results << assert_equal("こんにちは", md_hira[0], "UTF-8: hiragana class match")
+        results << assert_equal(6, md_hira.begin(0), "UTF-8: hiragana class begin")
+        results << assert_equal(11, md_hira.end(0), "UTF-8: hiragana class end")
+        results << assert_equal("Hello ", md_hira.pre_match, "UTF-8: hiragana class pre_match")
+        results << assert_equal(" World", md_hira.post_match, "UTF-8: hiragana class post_match")
+
+        # Unicode property escape requires the 'u' flag, which we auto-add.
+        # NOTE: JS RegExp accepts \p{Script=Hiragana} (or sc=Hiragana). The
+        # Onigmo shorthand \p{Hiragana} is not portable to JS RegExp.
+        md_prop = Regexp.new("\\p{sc=Hiragana}+").match("Hello こんにちは World")
+        results << assert_equal("こんにちは", md_prop[0], "UTF-8: \\p{sc=Hiragana} match (auto-u flag)")
+
+        # Multiple captures spanning multibyte boundaries.
+        md_caps = Regexp.new("(\\d+)(\\D+)(\\d+)").match("12あいう34")
+        results << assert_equal("12", md_caps[1], "UTF-8: cap1 ASCII digits")
+        results << assert_equal("あいう", md_caps[2], "UTF-8: cap2 Japanese")
+        results << assert_equal("34", md_caps[3], "UTF-8: cap3 ASCII digits")
+        results << assert_equal(0, md_caps.begin(1), "UTF-8: cap1 begin")
+        results << assert_equal(2, md_caps.end(1), "UTF-8: cap1 end")
+        results << assert_equal(2, md_caps.begin(2), "UTF-8: cap2 begin")
+        results << assert_equal(5, md_caps.end(2), "UTF-8: cap2 end")
+        results << assert_equal(5, md_caps.begin(3), "UTF-8: cap3 begin")
+        results << assert_equal(7, md_caps.end(3), "UTF-8: cap3 end")
+
+        # Astral plane (emoji): 'u' flag should make . match a full code point.
+        md_emoji = Regexp.new("a(.)b").match("a😀b")
+        results << assert_equal("😀", md_emoji[1], "UTF-8: astral . capture")
+        results << assert_equal(1, md_emoji.begin(1), "UTF-8: astral begin")
+        results << assert_equal(2, md_emoji.end(1), "UTF-8: astral end")
+
+        md_emoji2 = Regexp.new("(.)😀(.)").match("a😀b")
+        results << assert_equal("a", md_emoji2[1], "UTF-8: pre-astral cap")
+        results << assert_equal("b", md_emoji2[2], "UTF-8: post-astral cap")
+        results << assert_equal(2, md_emoji2.begin(2), "UTF-8: post-astral begin")
+
+        # pos with multibyte input.
+        re_p = Regexp.new("\\d+")
+        md_pos_jp = re_p.match("ab12あいう34", 5)
+        results << assert_equal("34", md_pos_jp[0], "UTF-8: pos skips multibyte chars")
+        results << assert_equal(7, md_pos_jp.begin(0), "UTF-8: pos: begin reflects original char index")
+        results << assert_equal("ab12あいう", md_pos_jp.pre_match, "UTF-8: pos: pre_match correct")
+        results << assert_equal(true, "あいう123".match?(Regexp.new("\\d+"), 3), "UTF-8: match? with pos past multibyte")
+        results << assert_equal(false, "あいう123".match?(Regexp.new("\\d+"), 6), "UTF-8: match? with pos beyond all chars")
+
+        # gsub keeps multibyte chars between matches.
+        results << assert_equal("XXあいうXX",
+          "12あいう34".gsub(Regexp.new("\\d+"), "XX"),
+          "UTF-8: gsub keeps multibyte chars")
+
+        # gsub block called per code point with .
+        results << assert_equal("[あ][い][う]",
+          "あいう".gsub(Regexp.new(".")) { |c| "[#{c}]" },
+          "UTF-8: gsub with . matches each code point")
+
+        # gsub replaces astral code point.
+        results << assert_equal("a-b-c",
+          "a😀b😀c".gsub(Regexp.new("😀"), "-"),
+          "UTF-8: gsub replaces astral code point")
+
+        # gsub with capture backreference containing multibyte.
+        results << assert_equal("<こんにちは>世界",
+          "こんにちは世界".sub(Regexp.new("([ぁ-ん]+)"), "<\\1>"),
+          "UTF-8: sub with multibyte capture backref")
+
+        # =~ returns character index (not byte) for multibyte input.
+        results << assert_equal(6,
+          "Hello 世界" =~ Regexp.new("世"),
+          "UTF-8: =~ returns char index")
+        results << assert_equal(1,
+          "a😀b" =~ Regexp.new("😀"),
+          "UTF-8: =~ char index across astral")
+
         pass_count = 0
         fail_count = 0
         results.each do |r|

--- a/mrbgems/picoruby-wasm/docs/regular_expression.md
+++ b/mrbgems/picoruby-wasm/docs/regular_expression.md
@@ -9,6 +9,13 @@ The compiler translates regexp literals (`/pattern/flags`) into `Regexp.compile(
 The runtime creates a JS `RegExp` object under the hood, so the actual matching behavior follows
 the ECMAScript specification, not Onigmo (CRuby's engine).
 
+mruby strings in this build are UTF-8 (`MRB_UTF8_STRING`). Indices returned by
+`MatchData#begin`/`#end`, `Regexp#=~` and `String#=~` are **Unicode code-point
+(character) offsets** -- consistent with how `String#[]` and `String#length`
+behave on UTF-8 strings -- so they can be used directly to slice the original
+string. `MatchData#pre_match` and `#post_match` similarly return substrings cut
+at code-point boundaries.
+
 ## Basic Usage
 
 ```ruby
@@ -41,7 +48,10 @@ Ruby flags are translated to JavaScript `RegExp` flags:
 | `x`       | Extended (free-spacing) | _(none)_ | Silently accepted; JS has no equivalent |
 
 Additionally, the JS `m` (multiline) flag is **always enabled** so that `^` and `$` match
-line boundaries, matching default Ruby behavior.
+line boundaries, matching default Ruby behavior. The JS `u` (Unicode) and `d`
+(hasIndices) flags are also auto-added so that `.` / character classes /
+`\p{...}` operate on Unicode code points, and per-capture offsets are accurate
+even when the same substring appears multiple times.
 
 ### Integer flags
 
@@ -63,9 +73,9 @@ re = Regexp.new("hello", Regexp::IGNORECASE | Regexp::MULTILINE)
 |--------|--------|-------------|
 | `Regexp.compile(pattern, flags=nil)` | Regexp | Create from string; called by literal syntax |
 | `Regexp.new(pattern, flags=nil)` | Regexp | Alias for `compile` |
-| `Regexp#match(str)` | MatchData or nil | Execute match |
-| `Regexp#match?(str)` | true/false | Test without creating MatchData |
-| `Regexp#=~(str)` | Integer or nil | Match index |
+| `Regexp#match(str, pos=0)` | MatchData or nil | Execute match. `pos` is a character (code-point) offset; negative `pos` raises ArgumentError; out-of-range returns nil |
+| `Regexp#match?(str, pos=0)` | true/false | Test without creating MatchData; same `pos` semantics |
+| `Regexp#=~(str)` | Integer or nil | Match position as a character offset |
 | `Regexp#source` | String | Pattern string |
 | `Regexp#to_s` | String | `"(?flags:source)"` |
 | `Regexp#inspect` | String | `"/source/flags"` |
@@ -83,19 +93,37 @@ re = Regexp.new("hello", Regexp::IGNORECASE | Regexp::MULTILINE)
 | `MatchData#to_s` | String | Full match string |
 | `MatchData#string` | String | Original string (frozen) |
 | `MatchData#regexp` | Regexp | The Regexp that produced this match |
-| `MatchData#pre_match` | String | Substring before the match |
-| `MatchData#post_match` | String | Substring after the match |
-| `MatchData#begin(n)` | Integer or nil | Start byte position of nth capture |
-| `MatchData#end(n)` | Integer or nil | End byte position of nth capture |
+| `MatchData#pre_match` | String | Substring before the match (cut at a UTF-8 code-point boundary) |
+| `MatchData#post_match` | String | Substring after the match (cut at a UTF-8 code-point boundary) |
+| `MatchData#begin(n)` | Integer or nil | Start character (code-point) offset of nth capture |
+| `MatchData#end(n)` | Integer or nil | End character (code-point) offset of nth capture |
 | `MatchData#inspect` | String | Human-readable representation |
 
 ## String Extensions
 
 | Method | Return | Description |
 |--------|--------|-------------|
-| `String#match(regexp_or_str)` | MatchData or nil | Match against Regexp or pattern string |
-| `String#match?(regexp_or_str)` | true/false | Test without creating MatchData |
-| `String#=~(regexp)` | Integer or nil | Match index |
+| `String#match(regexp_or_str, pos=0)` | MatchData or nil | Match against Regexp or pattern string. `pos` is a character (code-point) offset |
+| `String#match?(regexp_or_str, pos=0)` | true/false | Test without creating MatchData; same `pos` semantics |
+| `String#=~(regexp)` | Integer or nil | Match position as a character offset |
+| `String#sub(pattern, replacement)` | String | Replace the first match. `pattern` may be a Regexp or a String literal pattern |
+| `String#sub(pattern) { \|m\| ... }` | String | Block form; the block result (`to_s`-coerced) replaces the match |
+| `String#gsub(pattern, replacement)` | String | Replace all matches |
+| `String#gsub(pattern) { \|m\| ... }` | String | Block form |
+
+In the replacement-string form of `sub`/`gsub`, the following special sequences
+are expanded:
+
+| Sequence  | Expands to |
+|-----------|-----------|
+| `\&`, `\0` | The full match |
+| `\1` .. `\9` | The nth capture group |
+| `\\` | A literal backslash |
+
+Other backslash sequences (e.g. `\x`) are left as-is. The `\\&` placeholder
+inside a Ruby string literal corresponds to `\&` in the replacement string;
+double the backslashes when copying examples from Ruby source. Note: named
+back-references (`\k<name>`) are not yet supported.
 
 ## Differences from CRuby
 
@@ -105,7 +133,11 @@ re = Regexp.new("hello", Regexp::IGNORECASE | Regexp::MULTILINE)
 - **`x` flag**: Accepted but has no effect (no comment/whitespace stripping).
 - **Encoding argument**: A third argument to `Regexp.compile` is accepted but ignored.
 - **Lookbehind**: JS supports lookbehind (`(?<=...)`, `(?<!...)`); CRuby also does, but syntax details may differ.
-- **Unicode properties**: JS `\p{...}` requires the `u` flag; this implementation does not add `u` automatically.
+- **Unicode properties**: This implementation auto-adds the `u` flag, so `\p{...}` is always available. However, JS RegExp uses ECMAScript property syntax, which differs from Onigmo:
+    - General Category shorthand works the same: `\p{Letter}`, `\p{Number}`.
+    - **Script values must be qualified**: write `\p{Script=Hiragana}` or `\p{sc=Hiragana}`. Onigmo's `\p{Hiragana}` shorthand is **not** accepted by JS RegExp.
+- **Replacement strings**: `sub`/`gsub` support `\0`/`\&`, `\1`..`\9`, and `\\`. Named back-references (`\k<name>`) and Ruby's `\'`/`\``/`\+` are not supported.
+- **Enumerator form**: `sub`/`gsub` without a block or replacement raises ArgumentError; they do not return an Enumerator.
 
 ## Implementation
 

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -2399,7 +2399,7 @@ EM_JS(void, js_inspect_to_buffer, (int ref_id, char* buf, int buf_size), {
       try {
         if (v.constructor && v.constructor.name) ctor = v.constructor.name;
       } catch (e) {}
-      let extras = '';
+      let extras = "";
       try {
         if (typeof Event !== 'undefined' && v instanceof Event) {
           if (v.type) extras += ' type=' + JSON.stringify(String(v.type));

--- a/mrbgems/picoruby-wasm/src/mruby/regexp.c
+++ b/mrbgems/picoruby-wasm/src/mruby/regexp.c
@@ -7,6 +7,7 @@
 #include "mruby/string.h"
 #include "mruby/variable.h"
 #include "mruby/array.h"
+#include "mruby/proc.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,7 +54,13 @@ static const struct mrb_data_type picorb_match_data_type = {
 
 EM_JS(int, regexp_new, (const char *pattern, const char *flags), {
   try {
-    var re = new RegExp(UTF8ToString(pattern), UTF8ToString(flags));
+    var flagStr = UTF8ToString(flags);
+    // Auto-add 'd' flag (ES2022) so result.indices is available for per-capture offsets.
+    if (flagStr.indexOf('d') < 0) flagStr += 'd';
+    // Auto-add 'u' flag so '.', char classes and \p{...} operate on Unicode
+    // code points -- mruby strings here are UTF-8 (MRB_UTF8_STRING).
+    if (flagStr.indexOf('u') < 0) flagStr += 'u';
+    var re = new RegExp(UTF8ToString(pattern), flagStr);
     return globalThis.picorubyRefs.push(re) - 1;
   } catch(e) {
     console.error('RegExp creation failed:', e);
@@ -71,31 +78,98 @@ EM_JS(int, regexp_test, (int ref_id, const char *str, int str_len), {
   }
 });
 
-EM_JS(int, regexp_exec, (int ref_id, const char *str, int str_len), {
+// regexp_exec stores a "match info" object with per-capture offsets translated
+// into UTF-8 bytes (for slicing mruby strings) and Unicode code points (for
+// MRI-compatible char indices in #begin/#end).
+//
+// base_byte and base_char let the caller match against a tail-slice of the
+// original string (for the second `pos` argument to Regexp#match etc.) while
+// keeping returned offsets relative to the original string.
+EM_JS(int, regexp_exec, (int ref_id, const char *str, int str_len, int base_byte, int base_char), {
   try {
     var re = globalThis.picorubyRefs[ref_id];
     re.lastIndex = 0;
-    var result = re.exec(UTF8ToString(str, str_len));
+    var jsStr = UTF8ToString(str, str_len);
+    var result = re.exec(jsStr);
     if (result === null) return -1;
-    return globalThis.picorubyRefs.push(result) - 1;
+
+    var entries = [];
+    for (var i = 0; i < result.length; i++) {
+      var item = result[i];
+      if (item === undefined) {
+        entries.push(null);
+        continue;
+      }
+      var startU16, endU16;
+      if (i === 0) {
+        startU16 = result.index;
+        endU16 = result.index + item.length;
+      } else if (result.indices && result.indices[i]) {
+        startU16 = result.indices[i][0];
+        endU16 = result.indices[i][1];
+      } else {
+        // Fallback when 'd' flag is unavailable: search from match start.
+        startU16 = jsStr.indexOf(item, result.index);
+        endU16 = startU16 < 0 ? -1 : startU16 + item.length;
+      }
+      var prefix = jsStr.slice(0, startU16);
+      var matchPart = jsStr.slice(startU16, endU16);
+      var byteStart = lengthBytesUTF8(prefix);
+      var byteLen = lengthBytesUTF8(matchPart);
+      var charStart = 0;
+      for (var _c1 of prefix) charStart++;
+      var charLen = 0;
+      for (var _c2 of matchPart) charLen++;
+      entries.push({
+        byteStart: base_byte + byteStart,
+        byteEnd: base_byte + byteStart + byteLen,
+        charStart: base_char + charStart,
+        charEnd: base_char + charStart + charLen,
+        text: item
+      });
+    }
+    var info = { entries: entries, length: result.length };
+    return globalThis.picorubyRefs.push(info) - 1;
   } catch(e) {
+    console.error('RegExp exec failed:', e);
     return -1;
   }
 });
 
-EM_JS(int, regexp_match_index, (int ref_id), {
-  var result = globalThis.picorubyRefs[ref_id];
-  return result.index;
+EM_JS(int, regexp_match_length, (int ref_id), {
+  var info = globalThis.picorubyRefs[ref_id];
+  return info.length;
 });
 
-EM_JS(int, regexp_match_length, (int ref_id), {
-  var result = globalThis.picorubyRefs[ref_id];
-  return result.length;
+EM_JS(int, regexp_match_byte_begin, (int ref_id, int idx), {
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  return (e == null) ? -1 : e.byteStart;
+});
+
+EM_JS(int, regexp_match_byte_end, (int ref_id, int idx), {
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  return (e == null) ? -1 : e.byteEnd;
+});
+
+EM_JS(int, regexp_match_char_begin, (int ref_id, int idx), {
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  return (e == null) ? -1 : e.charStart;
+});
+
+EM_JS(int, regexp_match_char_end, (int ref_id, int idx), {
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  return (e == null) ? -1 : e.charEnd;
 });
 
 EM_JS(char *, regexp_match_item, (int ref_id, int idx), {
-  var result = globalThis.picorubyRefs[ref_id];
-  var item = result[idx];
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  if (e == null) return 0;
+  var item = e.text;
   if (item === undefined) return 0;
   var len = lengthBytesUTF8(item) + 1;
   var ptr = _malloc(len);
@@ -104,8 +178,17 @@ EM_JS(char *, regexp_match_item, (int ref_id, int idx), {
 });
 
 EM_JS(int, regexp_match_item_is_undefined, (int ref_id, int idx), {
-  var result = globalThis.picorubyRefs[ref_id];
-  return (result[idx] === undefined) ? 1 : 0;
+  var info = globalThis.picorubyRefs[ref_id];
+  var e = info.entries[idx];
+  return (e == null) ? 1 : 0;
+});
+
+// Drop a transient match-info object (used by gsub/sub loops to avoid
+// growing globalThis.picorubyRefs without bound).
+EM_JS(void, regexp_release_ref, (int ref_id), {
+  if (globalThis.picorubyRefs && ref_id >= 0 && ref_id < globalThis.picorubyRefs.length) {
+    globalThis.picorubyRefs[ref_id] = null;
+  }
 });
 
 EM_JS(char *, regexp_source, (int ref_id), {
@@ -125,6 +208,31 @@ EM_JS(char *, regexp_flags, (int ref_id), {
   stringToUTF8(str, ptr, len);
   return ptr;
 });
+
+/* Helper: convert a character (code point) offset into a UTF-8 byte offset
+ * within str. Returns the byte offset, or -1 if char_pos exceeds the number
+ * of code points in str. char_pos == 0 returns 0; char_pos == char_length(str)
+ * returns str_len (i.e. one-past-the-end is allowed). */
+static int
+utf8_char_to_byte(const char *str, int str_len, int char_pos)
+{
+  if (char_pos <= 0) return 0;
+  int b = 0;
+  int c = 0;
+  while (c < char_pos && b < str_len) {
+    unsigned char ch = (unsigned char)str[b];
+    int step;
+    if (ch < 0x80)      step = 1;
+    else if (ch < 0xC0) step = 1; /* stray continuation byte; advance defensively */
+    else if (ch < 0xE0) step = 2;
+    else if (ch < 0xF0) step = 3;
+    else                step = 4;
+    b += step;
+    c++;
+  }
+  if (c < char_pos) return -1;
+  return b;
+}
 
 /* Helper: build JS flags string from Ruby flags string */
 static void
@@ -224,19 +332,33 @@ mrb_regexp_compile(mrb_state *mrb, mrb_value self)
   return regexp_create_obj(mrb, ref_id);
 }
 
-/* Regexp#match(str) -> MatchData or nil */
+/* Regexp#match(str, pos=0) -> MatchData or nil */
 static mrb_value
 mrb_regexp_match(mrb_state *mrb, mrb_value self)
 {
   mrb_value str_val;
-  mrb_get_args(mrb, "S", &str_val);
+  mrb_int pos = 0;
+  mrb_get_args(mrb, "S|i", &str_val, &pos);
 
   picorb_regexp *re = (picorb_regexp *)DATA_PTR(self);
   if (!re) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "Regexp not initialized");
   }
 
-  int match_ref = regexp_exec(re->ref_id, RSTRING_PTR(str_val), RSTRING_LEN(str_val));
+  if (pos < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative pos is not supported");
+  }
+
+  int byte_off = utf8_char_to_byte(RSTRING_PTR(str_val), RSTRING_LEN(str_val), (int)pos);
+  if (byte_off < 0) {
+    return mrb_nil_value();
+  }
+
+  int match_ref = regexp_exec(re->ref_id,
+                              RSTRING_PTR(str_val) + byte_off,
+                              RSTRING_LEN(str_val) - byte_off,
+                              byte_off,
+                              (int)pos);
   if (match_ref < 0) {
     return mrb_nil_value();
   }
@@ -246,19 +368,31 @@ mrb_regexp_match(mrb_state *mrb, mrb_value self)
   return match_data_create_obj(mrb, match_ref, frozen_str, self);
 }
 
-/* Regexp#match?(str) -> true/false */
+/* Regexp#match?(str, pos=0) -> true/false */
 static mrb_value
 mrb_regexp_match_p(mrb_state *mrb, mrb_value self)
 {
   mrb_value str_val;
-  mrb_get_args(mrb, "S", &str_val);
+  mrb_int pos = 0;
+  mrb_get_args(mrb, "S|i", &str_val, &pos);
 
   picorb_regexp *re = (picorb_regexp *)DATA_PTR(self);
   if (!re) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "Regexp not initialized");
   }
 
-  int result = regexp_test(re->ref_id, RSTRING_PTR(str_val), RSTRING_LEN(str_val));
+  if (pos < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative pos is not supported");
+  }
+
+  int byte_off = utf8_char_to_byte(RSTRING_PTR(str_val), RSTRING_LEN(str_val), (int)pos);
+  if (byte_off < 0) {
+    return mrb_false_value();
+  }
+
+  int result = regexp_test(re->ref_id,
+                           RSTRING_PTR(str_val) + byte_off,
+                           RSTRING_LEN(str_val) - byte_off);
   return mrb_bool_value(result);
 }
 
@@ -290,12 +424,12 @@ mrb_regexp_match_op(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "Regexp not initialized");
   }
 
-  int match_ref = regexp_exec(re->ref_id, RSTRING_PTR(str_val), RSTRING_LEN(str_val));
+  int match_ref = regexp_exec(re->ref_id, RSTRING_PTR(str_val), RSTRING_LEN(str_val), 0, 0);
   if (match_ref < 0) {
     return mrb_nil_value();
   }
 
-  int idx = regexp_match_index(match_ref);
+  int idx = regexp_match_char_begin(match_ref, 0);
   return mrb_fixnum_value(idx);
 }
 
@@ -545,8 +679,9 @@ mrb_match_data_pre_match(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MatchData not initialized");
   }
 
-  int match_idx = regexp_match_index(md->ref_id);
-  return mrb_str_new(mrb, RSTRING_PTR(md->str), match_idx);
+  int byte_start = regexp_match_byte_begin(md->ref_id, 0);
+  if (byte_start < 0) return mrb_str_new_lit(mrb, "");
+  return mrb_str_new(mrb, RSTRING_PTR(md->str), byte_start);
 }
 
 /* MatchData#post_match -> String */
@@ -558,21 +693,13 @@ mrb_match_data_post_match(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MatchData not initialized");
   }
 
-  int match_idx = regexp_match_index(md->ref_id);
-  char *full_match = regexp_match_item(md->ref_id, 0);
-  if (!full_match) return mrb_str_new_lit(mrb, "");
-
-  int full_len = (int)strlen(full_match);
-  free(full_match);
-
-  int post_start = match_idx + full_len;
+  int byte_end = regexp_match_byte_end(md->ref_id, 0);
   int str_len = RSTRING_LEN(md->str);
-  if (str_len <= post_start) return mrb_str_new_lit(mrb, "");
-
-  return mrb_str_new(mrb, RSTRING_PTR(md->str) + post_start, str_len - post_start);
+  if (byte_end < 0 || str_len <= byte_end) return mrb_str_new_lit(mrb, "");
+  return mrb_str_new(mrb, RSTRING_PTR(md->str) + byte_end, str_len - byte_end);
 }
 
-/* MatchData#begin(idx) -> Integer */
+/* MatchData#begin(idx) -> Integer (character offset) */
 static mrb_value
 mrb_match_data_begin(mrb_state *mrb, mrb_value self)
 {
@@ -584,43 +711,12 @@ mrb_match_data_begin(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MatchData not initialized");
   }
 
-  if (idx == 0) {
-    return mrb_fixnum_value(regexp_match_index(md->ref_id));
-  }
-
-  /* For captures (idx > 0), compute position by searching in original string */
-  int match_start = regexp_match_index(md->ref_id);
-  char *full_match = regexp_match_item(md->ref_id, 0);
-  if (!full_match) return mrb_nil_value();
-
-  if (regexp_match_item_is_undefined(md->ref_id, (int)idx)) {
-    free(full_match);
-    return mrb_nil_value();
-  }
-
-  char *capture = regexp_match_item(md->ref_id, (int)idx);
-  if (!capture) {
-    free(full_match);
-    return mrb_nil_value();
-  }
-
-  /* Find capture within the original string starting from match_start */
-  const char *str_ptr = RSTRING_PTR(md->str) + match_start;
-  const char *found = strstr(str_ptr, capture);
-  int result;
-  if (found) {
-    result = (int)(found - RSTRING_PTR(md->str));
-  } else {
-    result = -1;
-  }
-
-  free(full_match);
-  free(capture);
-  if (result < 0) return mrb_nil_value();
-  return mrb_fixnum_value(result);
+  int char_begin = regexp_match_char_begin(md->ref_id, (int)idx);
+  if (char_begin < 0) return mrb_nil_value();
+  return mrb_fixnum_value(char_begin);
 }
 
-/* MatchData#end(idx) -> Integer */
+/* MatchData#end(idx) -> Integer (character offset) */
 static mrb_value
 mrb_match_data_end(mrb_state *mrb, mrb_value self)
 {
@@ -632,35 +728,9 @@ mrb_match_data_end(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "MatchData not initialized");
   }
 
-  if (idx == 0) {
-    int start = regexp_match_index(md->ref_id);
-    char *full_match = regexp_match_item(md->ref_id, 0);
-    if (!full_match) return mrb_nil_value();
-    int end_pos = start + (int)strlen(full_match);
-    free(full_match);
-    return mrb_fixnum_value(end_pos);
-  }
-
-  if (regexp_match_item_is_undefined(md->ref_id, (int)idx)) {
-    return mrb_nil_value();
-  }
-
-  char *capture = regexp_match_item(md->ref_id, (int)idx);
-  if (!capture) return mrb_nil_value();
-
-  int match_start = regexp_match_index(md->ref_id);
-  const char *str_ptr = RSTRING_PTR(md->str) + match_start;
-  const char *found = strstr(str_ptr, capture);
-  int result;
-  if (found) {
-    result = (int)(found - RSTRING_PTR(md->str)) + (int)strlen(capture);
-  } else {
-    result = -1;
-  }
-
-  free(capture);
-  if (result < 0) return mrb_nil_value();
-  return mrb_fixnum_value(result);
+  int char_end = regexp_match_char_end(md->ref_id, (int)idx);
+  if (char_end < 0) return mrb_nil_value();
+  return mrb_fixnum_value(char_end);
 }
 
 /* MatchData#captures -> Array (excluding [0]) */
@@ -773,17 +843,31 @@ ensure_regexp(mrb_state *mrb, mrb_value pattern)
   return mrb_nil_value(); /* not reached */
 }
 
-/* String#match(regexp_or_str) -> MatchData or nil */
+/* String#match(regexp_or_str, pos=0) -> MatchData or nil */
 static mrb_value
 mrb_string_match(mrb_state *mrb, mrb_value self)
 {
   mrb_value pattern;
-  mrb_get_args(mrb, "o", &pattern);
+  mrb_int pos = 0;
+  mrb_get_args(mrb, "o|i", &pattern, &pos);
+
+  if (pos < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative pos is not supported");
+  }
 
   mrb_value re = ensure_regexp(mrb, pattern);
   picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
 
-  int match_ref = regexp_exec(re_data->ref_id, RSTRING_PTR(self), RSTRING_LEN(self));
+  int byte_off = utf8_char_to_byte(RSTRING_PTR(self), RSTRING_LEN(self), (int)pos);
+  if (byte_off < 0) {
+    return mrb_nil_value();
+  }
+
+  int match_ref = regexp_exec(re_data->ref_id,
+                              RSTRING_PTR(self) + byte_off,
+                              RSTRING_LEN(self) - byte_off,
+                              byte_off,
+                              (int)pos);
   if (match_ref < 0) {
     return mrb_nil_value();
   }
@@ -793,17 +877,29 @@ mrb_string_match(mrb_state *mrb, mrb_value self)
   return match_data_create_obj(mrb, match_ref, frozen_str, re);
 }
 
-/* String#match?(regexp_or_str) -> true/false */
+/* String#match?(regexp_or_str, pos=0) -> true/false */
 static mrb_value
 mrb_string_match_p(mrb_state *mrb, mrb_value self)
 {
   mrb_value pattern;
-  mrb_get_args(mrb, "o", &pattern);
+  mrb_int pos = 0;
+  mrb_get_args(mrb, "o|i", &pattern, &pos);
+
+  if (pos < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "negative pos is not supported");
+  }
 
   mrb_value re = ensure_regexp(mrb, pattern);
   picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
 
-  int result = regexp_test(re_data->ref_id, RSTRING_PTR(self), RSTRING_LEN(self));
+  int byte_off = utf8_char_to_byte(RSTRING_PTR(self), RSTRING_LEN(self), (int)pos);
+  if (byte_off < 0) {
+    return mrb_false_value();
+  }
+
+  int result = regexp_test(re_data->ref_id,
+                           RSTRING_PTR(self) + byte_off,
+                           RSTRING_LEN(self) - byte_off);
   return mrb_bool_value(result);
 }
 
@@ -817,13 +913,182 @@ mrb_string_match_op(mrb_state *mrb, mrb_value self)
   mrb_value re = ensure_regexp(mrb, pattern);
   picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
 
-  int match_ref = regexp_exec(re_data->ref_id, RSTRING_PTR(self), RSTRING_LEN(self));
+  int match_ref = regexp_exec(re_data->ref_id, RSTRING_PTR(self), RSTRING_LEN(self), 0, 0);
   if (match_ref < 0) {
     return mrb_nil_value();
   }
 
-  int idx = regexp_match_index(match_ref);
+  int idx = regexp_match_char_begin(match_ref, 0);
   return mrb_fixnum_value(idx);
+}
+
+/* Helper: width in bytes of the UTF-8 character starting at byte_pos. */
+static int
+utf8_step(const char *str, int str_len, int byte_pos)
+{
+  if (byte_pos >= str_len) return 0;
+  unsigned char ch = (unsigned char)str[byte_pos];
+  if (ch < 0x80)      return 1;
+  if (ch < 0xC0)      return 1; /* stray continuation byte; advance defensively */
+  if (ch < 0xE0)      return 2;
+  if (ch < 0xF0)      return 3;
+  return 4;
+}
+
+/* Helper: append a captured-text item to a result string, freeing the
+ * malloc'd C string returned by regexp_match_item. */
+static void
+append_match_item(mrb_state *mrb, mrb_value result, int match_ref, int capture_idx)
+{
+  if (regexp_match_item_is_undefined(match_ref, capture_idx)) return;
+  char *item = regexp_match_item(match_ref, capture_idx);
+  if (!item) return;
+  mrb_str_cat_cstr(mrb, result, item);
+  free(item);
+}
+
+/* Helper: expand a replacement template (\\0/\\&, \\1..\\9, \\\\) against the
+ * captures of the given match. Other backslash sequences are kept literally. */
+static mrb_value
+expand_replacement(mrb_state *mrb, const char *repl, int repl_len, int match_ref)
+{
+  mrb_value result = mrb_str_new(mrb, NULL, 0);
+  int capture_count = regexp_match_length(match_ref);
+  int i = 0;
+  while (i < repl_len) {
+    char ch = repl[i];
+    if (ch == '\\' && i + 1 < repl_len) {
+      char next = repl[i + 1];
+      if (next >= '0' && next <= '9') {
+        int idx = next - '0';
+        if (idx < capture_count) {
+          append_match_item(mrb, result, match_ref, idx);
+        }
+        i += 2;
+        continue;
+      }
+      if (next == '&') {
+        append_match_item(mrb, result, match_ref, 0);
+        i += 2;
+        continue;
+      }
+      if (next == '\\') {
+        mrb_str_cat(mrb, result, "\\", 1);
+        i += 2;
+        continue;
+      }
+      /* Unknown escape: keep the backslash and the following character. */
+      mrb_str_cat(mrb, result, &repl[i], 2);
+      i += 2;
+      continue;
+    }
+    mrb_str_cat(mrb, result, &ch, 1);
+    i += 1;
+  }
+  return result;
+}
+
+/* Shared implementation of String#sub / String#gsub for both block and
+ * replacement-string forms. */
+static mrb_value
+do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
+{
+  mrb_value pattern;
+  mrb_value replacement = mrb_undef_value();
+  mrb_value block = mrb_nil_value();
+  mrb_get_args(mrb, "o|S&", &pattern, &replacement, &block);
+
+  mrb_bool has_replacement = !mrb_undef_p(replacement);
+  mrb_bool has_block = !mrb_nil_p(block);
+
+  if (has_replacement && has_block) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "both block and replacement argument given");
+  }
+  if (!has_replacement && !has_block) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (given 1, expected 2)");
+  }
+
+  mrb_value re = ensure_regexp(mrb, pattern);
+  picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
+
+  const char *str_ptr = RSTRING_PTR(self);
+  int str_len = RSTRING_LEN(self);
+
+  mrb_value result = mrb_str_new(mrb, NULL, 0);
+  int byte_pos = 0;
+  int char_pos = 0;
+
+  while (byte_pos <= str_len) {
+    int match_ref = regexp_exec(re_data->ref_id,
+                                str_ptr + byte_pos,
+                                str_len - byte_pos,
+                                byte_pos,
+                                char_pos);
+    if (match_ref < 0) break;
+
+    int byte_begin = regexp_match_byte_begin(match_ref, 0);
+    int byte_end   = regexp_match_byte_end(match_ref, 0);
+    int char_end   = regexp_match_char_end(match_ref, 0);
+
+    /* Append the unmatched prefix between the previous position and this match. */
+    if (byte_begin > byte_pos) {
+      mrb_str_cat(mrb, result, str_ptr + byte_pos, byte_begin - byte_pos);
+    }
+
+    /* Compute and append the replacement text. */
+    if (has_block) {
+      char *full = regexp_match_item(match_ref, 0);
+      mrb_value full_str = mrb_str_new_cstr(mrb, full ? full : "");
+      if (full) free(full);
+      mrb_value yielded = mrb_yield(mrb, block, full_str);
+      mrb_value yield_str = mrb_obj_as_string(mrb, yielded);
+      mrb_str_cat_str(mrb, result, yield_str);
+    } else {
+      mrb_value expanded = expand_replacement(mrb,
+                                              RSTRING_PTR(replacement),
+                                              RSTRING_LEN(replacement),
+                                              match_ref);
+      mrb_str_cat_str(mrb, result, expanded);
+    }
+
+    regexp_release_ref(match_ref);
+
+    /* Advance position. For zero-width matches, also append and skip one
+     * UTF-8 character so we don't loop forever. */
+    if (byte_end == byte_begin) {
+      int step = utf8_step(str_ptr, str_len, byte_pos);
+      if (step == 0) break;
+      mrb_str_cat(mrb, result, str_ptr + byte_pos, step);
+      byte_pos += step;
+      char_pos += 1;
+    } else {
+      byte_pos = byte_end;
+      char_pos = char_end;
+    }
+
+    if (!global) break;
+  }
+
+  /* Append the remainder. */
+  if (byte_pos < str_len) {
+    mrb_str_cat(mrb, result, str_ptr + byte_pos, str_len - byte_pos);
+  }
+
+  return result;
+}
+
+/* String#gsub(pattern, replacement) / String#gsub(pattern) { |m| ... } */
+static mrb_value
+mrb_string_gsub(mrb_state *mrb, mrb_value self)
+{
+  return do_string_sub_gsub(mrb, self, TRUE);
+}
+
+/* String#sub(pattern, replacement) / String#sub(pattern) { |m| ... } */
+static mrb_value
+mrb_string_sub(mrb_state *mrb, mrb_value self)
+{
+  return do_string_sub_gsub(mrb, self, FALSE);
 }
 
 /* ---- Init function ---- */
@@ -838,8 +1103,8 @@ mrb_regexp_init(mrb_state *mrb)
   mrb_define_class_method_id(mrb, class_Regexp, MRB_SYM(compile), mrb_regexp_compile, MRB_ARGS_ARG(1, 2));
   mrb_define_class_method_id(mrb, class_Regexp, MRB_SYM(new), mrb_regexp_compile, MRB_ARGS_ARG(1, 2));
 
-  mrb_define_method_id(mrb, class_Regexp, MRB_SYM(match), mrb_regexp_match, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, class_Regexp, MRB_SYM_Q(match), mrb_regexp_match_p, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_Regexp, MRB_SYM(match), mrb_regexp_match, MRB_ARGS_ARG(1, 1));
+  mrb_define_method_id(mrb, class_Regexp, MRB_SYM_Q(match), mrb_regexp_match_p, MRB_ARGS_ARG(1, 1));
   mrb_define_method_id(mrb, class_Regexp, mrb_intern_lit(mrb, "==="), mrb_regexp_case_eq, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_Regexp, mrb_intern_lit(mrb, "=~"), mrb_regexp_match_op, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_Regexp, MRB_SYM(source), mrb_regexp_source, MRB_ARGS_NONE());
@@ -872,7 +1137,9 @@ mrb_regexp_init(mrb_state *mrb)
 
   /* String extensions */
   struct RClass *string_class = mrb->string_class;
-  mrb_define_method_id(mrb, string_class, MRB_SYM(match), mrb_string_match, MRB_ARGS_REQ(1));
-  mrb_define_method_id(mrb, string_class, MRB_SYM_Q(match), mrb_string_match_p, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, string_class, MRB_SYM(match), mrb_string_match, MRB_ARGS_ARG(1, 1));
+  mrb_define_method_id(mrb, string_class, MRB_SYM_Q(match), mrb_string_match_p, MRB_ARGS_ARG(1, 1));
   mrb_define_method_id(mrb, string_class, mrb_intern_lit(mrb, "=~"), mrb_string_match_op, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, string_class, MRB_SYM(gsub), mrb_string_gsub, MRB_ARGS_ARG(1, 1) | MRB_ARGS_BLOCK());
+  mrb_define_method_id(mrb, string_class, MRB_SYM(sub), mrb_string_sub, MRB_ARGS_ARG(1, 1) | MRB_ARGS_BLOCK());
 }


### PR DESCRIPTION
This pull request introduces significant performance optimizations and testing improvements for the JSON parser in the WASM build, as well as enhanced documentation and test coverage for regular expressions and JSON handling.

**JSON Parsing Performance and WASM Optimization:**

* [`mrbgems/picoruby-json/mrblib/json.rb`](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R18-R47): Adds a WASM build auto-detection (`JSON.wasm_build?`) and a toggleable `use_regexp` setting to enable Regexp-based optimizations for whitespace, string, and number parsing. These optimizations improve JSON parsing speed on WASM, and can be benchmarked or disabled for comparison. [[1]](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R18-R47) [[2]](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R57-R66) [[3]](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R509-R522) [[4]](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R594-R608) [[5]](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R644)
* [`mrbgems/picoruby-json/mrblib/json.rb`](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996R174-R180): Ensures the Digger class always uses the non-Regexp path for whitespace skipping, as this is faster for its use case.
* [`mrbgems/picoruby-json/mrblib/json.rb`](diffhunk://#diff-a781dcd5fea3f6efe7b679d95de74494862ac4e95796665074273d8ec0e65996L612-R686): Fixes a bug in float parsing so that the decimal divider is updated after the digit is processed, improving accuracy.

**Testing and Benchmarking:**

* `mrbgems/picoruby-wasm/demo/www/json.html`, `mrbgems/picoruby-wasm/demo/www/index.html`: Adds a new JSON test and benchmark page to the WASM demo, covering JSON parsing/generation, whitespace handling, UTF-8, and Digger usage. Includes a benchmark comparing Regexp and non-Regexp parsing modes. [[1]](diffhunk://#diff-ffa9db957eeae6c718256e9d8586ee1e6115013899eaeec098cf361cb60a0f4dR1-R193) [[2]](diffhunk://#diff-9d1cdf8189c973b644043c06a7936b17dfb30414c3b4dc2a0b995d0ecab31086R82)

**Regular Expression Documentation and Tests:**

* [`mrbgems/picoruby-wasm/docs/regular_expression.md`](diffhunk://#diff-23ab02e22896296c993d2ea186f3475a82c290fb6d63568a109ddbd6e4cd2a0dR12-R18): Documents that all string/regexp indices and slices are in Unicode code-point offsets, not bytes, and that the JS `u` and `d` flags are always enabled for correct Unicode and index handling. [[1]](diffhunk://#diff-23ab02e22896296c993d2ea186f3475a82c290fb6d63568a109ddbd6e4cd2a0dR12-R18) [[2]](diffhunk://#diff-23ab02e22896296c993d2ea186f3475a82c290fb6d63568a109ddbd6e4cd2a0dL44-R54)
* [`mrbgems/picoruby-wasm/demo/www/regexp.html`](diffhunk://#diff-edaf95ad50fd43f43b69ea3eb6a13af915b75a06eccbbf7635f8d76431c9255bR149-R309): Expands the test suite for regular expressions, especially for UTF-8 and edge cases, to ensure correct behavior in the WASM environment.