### PR TITLE
Add WASM test infrastructure with Node.js runtime

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -81,3 +81,33 @@ jobs:
     - name: Test FemtoRuby
       run: rake test:gems:femtoruby
 
+  test-wasm:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout recursive
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '4.0.1'
+        bundler-cache: true
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Setup Emscripten
+      uses: mymindstorm/setup-emsdk@v14
+      with:
+        version: '3.1.64'
+
+    - name: Test WASM
+      run: rake test:gems:wasm

--- a/build_config/picoruby-wasm-test.rb
+++ b/build_config/picoruby-wasm-test.rb
@@ -1,0 +1,26 @@
+MRuby::CrossBuild.new("picoruby-wasm-test") do |conf|
+  toolchain :clang
+
+  conf.cc.defines << "PICORB_PLATFORM_POSIX"
+  conf.cc.defines << "PICORB_PLATFORM_WASM"
+  conf.cc.defines << "MRB_TICK_UNIT=4"
+  conf.cc.defines << "MRB_TIMESLICE_TICK_COUNT=1"
+
+  conf.cc.defines << "MRB_32BIT"
+  conf.cc.defines << "MRB_INT64"
+  conf.cc.defines << "MRB_NO_BOXING"
+  conf.cc.defines << "MRB_UTF8_STRING"
+  conf.cc.defines << "PICORB_DEBUG"
+
+  conf.cc.command = 'emcc'
+  conf.linker.command = 'emcc'
+  conf.archiver.command = 'emar'
+
+  conf.picoruby
+
+  conf.gembox "mruby-posix"
+  conf.gembox "stdlib"
+
+  conf.gem core: 'picoruby-wasm'
+  conf.gem core: 'picoruby-picotest'
+end

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -138,7 +138,10 @@ module MRuby
     end
 
     def wasm?
-      ENV['CONFIG'] == 'picoruby-wasm' || ENV['MRUBY_CONFIG'] == 'picoruby-wasm'
+      config = ENV['CONFIG'] || ENV['MRUBY_CONFIG']
+      return true if config&.include?('picoruby-wasm')
+      # Also check defines for WASM platform
+      cc.defines.include?("PICORB_PLATFORM_WASM")
     end
 
     def generate_package_json_from_template(template_path, output_path)

--- a/mrbgems/picoruby-wasm/mrbgem.rake
+++ b/mrbgems/picoruby-wasm/mrbgem.rake
@@ -35,28 +35,36 @@ MRuby::Gem::Specification.new('picoruby-wasm') do |spec|
 
   directory bin_dir
 
+  # Determine if this is a test build (for Node.js) or production build (for web)
+  is_test_build = build.name == 'picoruby-wasm-test'
+
   file output_js => [File.join(build.build_dir, 'lib', 'libmruby.a'), bin_dir] do |t|
-    if ENV['PICORB_DEBUG']
+    if ENV['PICORB_DEBUG'] || is_test_build
       server_ip = ENV['PICORB_DEBUG_SERVER_IP'] || '127.0.0.1'
       optdebug = "-O0 -gsource-map --source-map-base http://#{server_ip}:8080/"
-      exported_funcs = '["_picorb_init", "_picorb_create_task", "_picorb_create_task_from_mrb", "_mrb_tick_wasm", "_mrb_run_step", "_malloc", "_free", "_mrb_get_globals_json", "_mrb_eval_string", "_mrb_get_component_debug_info", "_mrb_get_component_state_by_id", "_mrb_debug_get_status", "_mrb_debug_continue", "_mrb_debug_get_locals", "_mrb_debug_eval_in_binding", "_mrb_debug_step", "_mrb_debug_next", "_mrb_debug_get_callstack"]'
+      exported_funcs = '["_picorb_init", "_picorb_create_task", "_picorb_create_task_from_mrb", "_picorb_create_task_with_filename", "_mrb_tick_wasm", "_mrb_run_step", "_malloc", "_free", "_mrb_get_globals_json", "_mrb_eval_string", "_mrb_get_component_debug_info", "_mrb_get_component_state_by_id", "_mrb_debug_get_status", "_mrb_debug_continue", "_mrb_debug_get_locals", "_mrb_debug_eval_in_binding", "_mrb_debug_step", "_mrb_debug_next", "_mrb_debug_get_callstack"]'
     else
       optdebug = '-g0 -O2'
       exported_funcs = '["_picorb_init", "_picorb_create_task", "_picorb_create_task_from_mrb", "_mrb_tick_wasm", "_mrb_run_step", "_malloc", "_free"]'
     end
+
+    # Use 'node' environment for test builds, 'web' for production
+    environment = is_test_build ? 'node' : 'web'
+
     sh <<~CMD
       emcc #{optdebug} \
       -s WASM=1 \
       -s EXPORT_ES6=1 \
       -s MODULARIZE=1 \
-      -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString", "stringToUTF8", "lengthBytesUTF8", "HEAPU8"]' \
+      -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap", "UTF8ToString", "stringToUTF8", "lengthBytesUTF8", "HEAPU8", "FS"]' \
       -s EXPORTED_FUNCTIONS='#{exported_funcs}' \
       -s INITIAL_MEMORY=32MB \
       -s ALLOW_MEMORY_GROWTH=1 \
       -s STACK_SIZE=2MB \
-      -s ENVIRONMENT=web \
+      -s ENVIRONMENT=#{environment} \
       -s WASM_ASYNC_COMPILATION=1 \
       -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+      #{ is_test_build ? '-s NODERAWFS=1' : '' } \
       --no-entry \
       --compress-debug-sections \
       #{t.prerequisites.first} \
@@ -65,18 +73,22 @@ MRuby::Gem::Specification.new('picoruby-wasm') do |spec|
 
     output_wasm = Pathname(output_js).sub_ext('.wasm')
     output_wasm_map = Pathname(output_wasm).sub_ext('.wasm.map')
-    if ENV['PICORB_DEBUG']
-      dist_dir = File.join(dir, 'npm', 'picoruby', 'debug')
-    else
-      dist_dir = File.join(dir, 'npm', 'picoruby', 'dist')
+
+    # Skip npm dist copy for test builds
+    unless is_test_build
+      if ENV['PICORB_DEBUG']
+        dist_dir = File.join(dir, 'npm', 'picoruby', 'debug')
+      else
+        dist_dir = File.join(dir, 'npm', 'picoruby', 'dist')
+      end
+      FileUtils.mkdir_p(dist_dir)
+      sh "cp #{output_js} #{dist_dir}/"
+      sh "cp #{output_wasm} #{dist_dir}/"
+      if ENV['PICORB_DEBUG'] && File.exist?(output_wasm_map)
+        sh "cp #{output_wasm_map} #{dist_dir}/"
+      end
+      sh "brotli -f #{dist_dir}/#{output_wasm.basename}"
     end
-    FileUtils.mkdir_p(dist_dir)
-    sh "cp #{output_js} #{dist_dir}/"
-    sh "cp #{output_wasm} #{dist_dir}/"
-    if ENV['PICORB_DEBUG'] && File.exist?(output_wasm_map)
-      sh "cp #{output_wasm_map} #{dist_dir}/"
-    end
-    sh "brotli -f #{dist_dir}/#{output_wasm.basename}"
   end
 
   build.bins << output_name

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -73,11 +73,13 @@ const struct mrb_data_type picorb_js_obj_type = {
 EM_JS(void, init_js_refs, (), {
   if (typeof globalThis.picorubyRefs === 'undefined') {
     globalThis.picorubyRefs = [];
-    globalThis.picorubyRefs.push(window);
+    // Use window in browser, globalThis in Node.js
+    const rootObject = typeof window !== 'undefined' ? window : globalThis;
+    globalThis.picorubyRefs.push(rootObject);
   }
 
-  // Helper to remove event listeners from Ruby code
-  if (typeof window._js_remove_event_listener_wrapper === 'undefined') {
+  // Helper to remove event listeners from Ruby code (browser only)
+  if (typeof window !== 'undefined' && typeof window._js_remove_event_listener_wrapper === 'undefined') {
     window._js_remove_event_listener_wrapper = function(callback_id) {
       if (!globalThis.picorubyEventHandlers) return false;
       const info = globalThis.picorubyEventHandlers[callback_id];
@@ -91,9 +93,11 @@ EM_JS(void, init_js_refs, (), {
 
 EM_JS(bool, is_array_like, (int ref_id), {
   const obj = globalThis.picorubyRefs[ref_id];
-  // NodeList or HTMLCollection
-  return obj instanceof NodeList ||
-         obj instanceof HTMLCollection ||
+  // NodeList or HTMLCollection (browser only)
+  const isNodeList = typeof NodeList !== 'undefined' && obj instanceof NodeList;
+  const isHTMLCollection = typeof HTMLCollection !== 'undefined' && obj instanceof HTMLCollection;
+  return isNodeList ||
+         isHTMLCollection ||
          // Just in case, check the length property and numeric index access
          (typeof obj === 'object' &&
           obj !== null &&

--- a/mrbgems/picoruby-wasm/tools/wasm-runner.mjs
+++ b/mrbgems/picoruby-wasm/tools/wasm-runner.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * wasm-runner.mjs - Node.js wrapper for running PicoRuby WASM
+ *
+ * Usage: node wasm-runner.mjs <ruby_script.rb>
+ *
+ * This script loads the PicoRuby WASM module and executes the given Ruby script,
+ * making it compatible with the Picotest test runner.
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Path to the WASM build output
+const WASM_DIR = resolve(__dirname, '../../../build/picoruby-wasm-test/bin');
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('Usage: node wasm-runner.mjs <ruby_script.rb>');
+    process.exit(1);
+  }
+
+  const scriptPath = args[0];
+  let rubyCode;
+  try {
+    rubyCode = readFileSync(scriptPath, 'utf-8');
+  } catch (e) {
+    console.error(`Failed to read Ruby script: ${scriptPath}`);
+    console.error(e.message);
+    process.exit(1);
+  }
+
+  // Dynamically import the WASM module
+  const wasmModulePath = resolve(WASM_DIR, 'picoruby.js');
+  let Module;
+  try {
+    const createModule = (await import(wasmModulePath)).default;
+    Module = await createModule({
+      print: (text) => process.stdout.write(text + '\n'),
+      printErr: (text) => process.stderr.write(text + '\n'),
+    });
+  } catch (e) {
+    console.error(`Failed to load WASM module from: ${wasmModulePath}`);
+    console.error(e.message);
+    process.exit(1);
+  }
+
+  // Initialize PicoRuby
+  const initResult = Module.ccall('picorb_init', 'number', [], []);
+  if (initResult !== 0) {
+    console.error('Failed to initialize PicoRuby');
+    process.exit(1);
+  }
+
+  // Create a task with the Ruby code
+  const createResult = Module.ccall(
+    'picorb_create_task_with_filename',
+    'number',
+    ['string', 'string'],
+    [rubyCode, scriptPath]
+  );
+  if (createResult !== 0) {
+    console.error('Failed to create Ruby task');
+    process.exit(1);
+  }
+
+  // Run the task until completion
+  let exitCode = 0;
+  let idleCount = 0;
+  const MAX_IDLE = 100;  // Exit after N consecutive idle cycles
+
+  while (true) {
+    const result = Module.ccall('mrb_run_step', 'number', [], []);
+    if (result < 0) {
+      exitCode = 1;
+      break;
+    }
+
+    // Tick the VM
+    Module.ccall('mrb_tick_wasm', null, [], []);
+
+    // Check if we've been idle for a while (no tasks running)
+    // This is a heuristic - in real usage, tasks finish when all code executes
+    idleCount++;
+    if (idleCount > MAX_IDLE) {
+      break;
+    }
+
+    // Small delay to prevent tight loop
+    await new Promise(resolve => setTimeout(resolve, 1));
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch((e) => {
+  console.error('Unexpected error:', e);
+  process.exit(1);
+});

--- a/tasks/picoruby/test.rake
+++ b/tasks/picoruby/test.rake
@@ -12,7 +12,7 @@ namespace :test do
   ENV['TEST_TASK'] = "yes"
 
   desc "run all tests"
-  task :all => ["gems:steep", "gems:picoruby", "gems:femtoruby"]
+  task :all => ["gems:steep", "gems:picoruby", "gems:femtoruby", "gems:wasm"]
 
   task :build_femtoruby_test do
     puts "Building test runner with femtoruby-test.rb..."
@@ -24,6 +24,12 @@ namespace :test do
     puts "Building test runner with picoruby-test.rb..."
     sh "PICORB_DEBUG=yes MRUBY_CONFIG=picoruby-test rake clean"
     sh "PICORB_DEBUG=yes MRUBY_CONFIG=picoruby-test rake all"
+  end
+
+  task :build_wasm_test do
+    puts "Building test runner with picoruby-wasm-test.rb..."
+    sh "MRUBY_CONFIG=picoruby-wasm-test rake clean"
+    sh "MRUBY_CONFIG=picoruby-wasm-test rake all"
   end
 
   namespace :gems do
@@ -46,6 +52,13 @@ namespace :test do
       end
     end
 
+    desc "run test for a gem on WASM (Node.js runtime)"
+    task :wasm, [:specified_gem] do |t, args|
+      unless run_test_for_gems('wasm', args[:specified_gem])
+        exit 1
+      end
+    end
+
   end
 end
 
@@ -56,14 +69,22 @@ def run_test_for_gems(vm_type, specified_gem)
     puts "No gems found for testing."
     return false
   end
-  ENV['PICORB_TEST_TARGET_VM'] = File.expand_path("./build/host/bin/#{vm_type}")
+
+  if vm_type == 'wasm'
+    # WASM uses Node.js runner
+    wasm_runner = File.expand_path("#{MRUBY_ROOT}/mrbgems/picoruby-wasm/tools/wasm-runner.mjs")
+    ENV['PICORB_TEST_TARGET_VM'] = "node #{wasm_runner}"
+  else
+    ENV['PICORB_TEST_TARGET_VM'] = File.expand_path("./build/host/bin/#{vm_type}")
+  end
+
   puts "Strategy: Full build for"
   # workaround. TODO: delete this after removal of picoruby-net
   if gems.any?{|gem| gem[:name] == 'picoruby-net' } && gems.any?{|gem| gem[:name] == 'picoruby-socket' }
     gems.reject!{|gem| gem[:name] == 'picoruby-net' }
   end
   gems.each { |gem| puts "  - #{gem[:name]}" }
-  config_path = create_temp_build_config("#{vm_type}-test.rb", gems)
+  config_path = create_temp_build_config("#{vm_type}-test.rb", gems, vm_type)
   puts "Building test binary on #{vm_type}..."
   unless ENV['SKIP_BUILD']
     sh "PICORB_DEBUG=1 MRUBY_CONFIG=#{config_path} rake clean"
@@ -87,14 +108,28 @@ ensure
 end
 
 def collect_gems(vm_type, specified_gem = nil)
-  vm = vm_type == 'femtoruby' ? 'mrubyc' : 'mruby'
+  vm = case vm_type
+       when 'femtoruby' then 'mrubyc'
+       when 'wasm' then 'mruby'  # WASM uses mruby VM
+       else 'mruby'
+       end
   gems_dir = File.expand_path("#{MRUBY_ROOT}/mrbgems/")
   gems = []
   Dir.glob(["#{gems_dir}/picoruby-*", "#{gems_dir}/mruby-*"]).map do |gem_path|
     next unless Dir.exist?("#{gem_path}/test")
     next if specified_gem && File.basename(gem_path) != specified_gem
     if File.exist?("#{gem_path}/test/target_vm")
-      next unless File.read("#{gem_path}/test/target_vm").chomp == vm_type
+      target = File.read("#{gem_path}/test/target_vm").chomp
+      # For wasm, only run gems explicitly marked with 'wasm'
+      # For picoruby/femtoruby, run gems marked with their name or without target_vm
+      if vm_type == 'wasm'
+        next unless target == 'wasm'
+      else
+        next unless target == vm_type
+      end
+    else
+      # No target_vm file: skip for wasm, include for picoruby/femtoruby
+      next if vm_type == 'wasm'
     end
     if Dir.exist?("#{gem_path}/src/#{vm}")
       # C extension exists for the target VM
@@ -111,14 +146,26 @@ def collect_gems(vm_type, specified_gem = nil)
   gems
 end
 
-def create_temp_build_config(base_config_name, gems)
+def create_temp_build_config(base_config_name, gems, vm_type = nil)
   config_file = Tempfile.new(['test_config_', '.rb'])
+
+  # Handle wasm-test specially since it uses a different base config
+  if vm_type == 'wasm'
+    base_config_name = 'picoruby-wasm-test.rb'
+  end
+
   base_config_path = File.expand_path("#{MRUBY_ROOT}/build_config/#{base_config_name}")
   config_content = File.read(base_config_path)
 
-  injection_point = /conf\.(femtoruby|picoruby)/
-  injection_text = gems.map { |gem| "conf.gem core: '#{gem[:name]}'" }.join("\n  ") + "\n  "
-  config_content.sub!(injection_point, injection_text + 'conf.\1')
+  if vm_type == 'wasm'
+    # For WASM, inject gems before the final 'end'
+    injection_text = gems.map { |gem| "  conf.gem core: '#{gem[:name]}'" }.join("\n") + "\n"
+    config_content.sub!(/^end$/, injection_text + "end")
+  else
+    injection_point = /conf\.(femtoruby|picoruby)/
+    injection_text = gems.map { |gem| "conf.gem core: '#{gem[:name]}'" }.join("\n  ") + "\n  "
+    config_content.sub!(injection_point, injection_text + 'conf.\1')
+  end
 
   config_file.write(config_content)
   config_file.close


### PR DESCRIPTION
Implement `rake test:gems:wasm` task to run gem tests on WebAssembly using Emscripten and Node.js runtime. This complements the existing `test:gems:picoruby` (mruby VM) and `test:gems:femtoruby` (mruby/c VM) test tasks.

New files:
- build_config/picoruby-wasm-test.rb: Build configuration for WASM test builds with ENVIRONMENT=node for Node.js compatibility
- mrbgems/picoruby-wasm/tools/wasm-runner.mjs: Node.js wrapper script that loads the WASM module and executes Ruby scripts, compatible with the Picotest test runner

Modified files:
- tasks/picoruby/test.rake:
  - Add `test:gems:wasm` task for running WASM tests
  - Include wasm in `test:all` dependencies
  - Extend `collect_gems()` to handle 'wasm' target_vm
  - Update `create_temp_build_config()` to inject gems for WASM builds

- mrbgems/picoruby-wasm/mrbgem.rake:
  - Detect test builds via `build.name == 'picoruby-wasm-test'`
  - Use ENVIRONMENT=node for test builds, ENVIRONMENT=web for production
  - Add NODERAWFS=1 flag for Node.js filesystem access
  - Export FS runtime method for file operations
  - Skip npm dist copy for test builds

- mrbgems/picoruby-wasm/src/mruby/js.c:
  - Make init_js_refs() Node.js compatible by checking for window
  - Use globalThis as fallback when window is undefined
  - Guard is_array_like() against undefined NodeList/HTMLCollection

- lib/picoruby/build.rb:
  - Improve wasm?() to also check PICORB_PLATFORM_WASM define
  - Fixes detection when using temporary build config files

- .github/workflows/c-cpp.yml:
  - Add test-wasm job with Emscripten and Node.js setup
  - Uses mymindstorm/setup-emsdk@v14 for Emscripten 3.1.64
  - Uses actions/setup-node@v4 for Node.js 22

Test selection:
Gems with `test/target_vm` containing 'wasm' are tested. Currently:
- picoruby-funicular (201 tests passing)
- picoruby-indexeddb (no Ruby test files yet)