### PR TITLE
Add GC pool region support

### DIFF
--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -54,6 +54,15 @@ heap_exit_critical(void)
   #define HEAP_SIZE (HEAP_SIZE_KB * 1024)
 #endif
 
+#if defined(PICORB_VM_MRUBY)
+  #ifndef MRB_GC_POOL_SIZE
+    #define MRB_GC_POOL_SIZE (HEAP_SIZE / 6)
+  #endif
+  #define MRB_ESTALLOC_POOL_SIZE (HEAP_SIZE - MRB_GC_POOL_SIZE)
+#else
+  #define MRB_ESTALLOC_POOL_SIZE HEAP_SIZE
+#endif
+
 #if defined(R2P2_ALLOC_LIBC)
   #define heap_pool NULL
 #else
@@ -144,7 +153,8 @@ main(void)
   int ret = 0;
 
 #if defined(PICORB_VM_MRUBY)
-  mrb_state *mrb = mrb_open_with_custom_alloc(heap_pool, HEAP_SIZE);
+  mrb_state *mrb = mrb_open_with_custom_alloc(heap_pool + MRB_GC_POOL_SIZE, MRB_ESTALLOC_POOL_SIZE);
+  mrb_gc_add_region(mrb, heap_pool, MRB_GC_POOL_SIZE);
 #if defined(PICORB_ALLOC_ESTALLOC)
   critical_section_init(&heap_critsec);
   mrb_alloc_set_critical_section(heap_enter_critical, heap_exit_critical);


### PR DESCRIPTION
Separating the GC pool from the ESTALLOC allocator prevents them from competing for the
same memory region, leading to more predictable memory behavior.

When using mruby VM, the heap is now split into two regions:
- A GC pool registered via `mrb_gc_add_region`
- An ESTALLOC pool used for the main allocator

This allows mruby's GC to manage objects in a dedicated memory region separate from the
ESTALLOC allocator.
