### PR TITLE
Enable DHCP-backed CYW43 AP mode and add experimental AP HTTP sample

### DIFF
--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -45,6 +45,7 @@ CYW43.enable_ap_mode("PICO-TIMER", "12345678")
 
 puts "AP started"
 puts "AP IP: #{CYW43.ap_ipv4_address}"
+puts "Connect a client, then open http://#{CYW43.ap_ipv4_address}/"
 ```
 
 ### Experimental AP + HTTP Sample
@@ -54,7 +55,7 @@ See:
 - `mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb`
 
 This sample is intentionally experimental.
-It is meant to confirm whether a client can reach a tiny PicoRuby `TCPServer` over AP mode with the current SDK-default AP behavior.
+It is meant to confirm whether a client can reach a tiny PicoRuby `TCPServer` over AP mode with PicoRuby's current built-in AP + DHCP behavior.
 
 ## API
 
@@ -106,9 +107,9 @@ It is meant to confirm whether a client can reach a tiny PicoRuby `TCPServer` ov
 - Specific to Raspberry Pi Pico W and similar boards
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
-- `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
-- PicoRuby now exposes AP-side IPv4 information, but not AP-side DHCP control, custom AP IP configuration, or connected client listing
-- AP usability beyond SSID visibility still needs more hardware verification
+- `enable_ap_mode` starts a minimal DHCP-backed AP on the default `192.168.4.0/24` network
+- PicoRuby exposes AP-side IPv4 information, but not custom AP IP configuration, DHCP control, or connected client listing yet
+- AP + HTTP behavior still needs more hardware verification across client devices
 - See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
 - See `mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb` for the experimental AP + HTTP sample
-- TODO: add AP status/IP control helpers as needed before documenting a supported AP HTTP workflow
+- TODO: add AP status/IP control helpers before documenting a fully supported AP HTTP workflow

--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -35,6 +35,17 @@ CYW43.disconnect
 CYW43.disable_sta_mode
 ```
 
+### Access Point Mode
+
+```ruby
+require "cyw43"
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+```
+
 ## API
 
 ### CYW43 Module Methods
@@ -43,6 +54,8 @@ CYW43.disable_sta_mode
 - `CYW43.initialized?()` - Check if initialized
 - `CYW43.enable_sta_mode()` - Enable station mode
 - `CYW43.disable_sta_mode()` - Disable station mode
+- `CYW43.enable_ap_mode(ssid, password, auth = CYW43::Auth::WPA2_AES_PSK)` - Enable access point mode
+- `CYW43.disable_ap_mode()` - Disable access point mode
 - `CYW43.connect_timeout(ssid, password, auth, timeout_ms)` - Connect to WiFi with timeout
 - `CYW43.disconnect()` - Disconnect from WiFi
 - `CYW43.link_connected?(print_status = false)` - Check connection status
@@ -80,3 +93,8 @@ CYW43.disable_sta_mode
 - Specific to Raspberry Pi Pico W and similar boards
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
+- `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
+- PicoRuby does not yet expose AP-side DHCP server, AP IP configuration, or connected client listing
+- Clients may associate to the SSID without receiving an IP address until DHCP/IP helpers are added
+- See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
+- TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample

--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -47,6 +47,15 @@ puts "AP started"
 puts "AP IP: #{CYW43.ap_ipv4_address}"
 ```
 
+### Experimental AP + HTTP Sample
+
+See:
+
+- `mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb`
+
+This sample is intentionally experimental.
+It is meant to confirm whether a client can reach a tiny PicoRuby `TCPServer` over AP mode with the current SDK-default AP behavior.
+
 ## API
 
 ### CYW43 Module Methods
@@ -101,4 +110,5 @@ puts "AP IP: #{CYW43.ap_ipv4_address}"
 - PicoRuby now exposes AP-side IPv4 information, but not AP-side DHCP control, custom AP IP configuration, or connected client listing
 - AP usability beyond SSID visibility still needs more hardware verification
 - See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
-- TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample
+- See `mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb` for the experimental AP + HTTP sample
+- TODO: add AP status/IP control helpers as needed before documenting a supported AP HTTP workflow

--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -44,6 +44,7 @@ CYW43.init("JP")
 CYW43.enable_ap_mode("PICO-TIMER", "12345678")
 
 puts "AP started"
+puts "AP IP: #{CYW43.ap_ipv4_address}"
 ```
 
 ## API
@@ -62,6 +63,9 @@ puts "AP started"
 - `CYW43.tcpip_link_status()` - Get link status code
 - `CYW43.tcpip_link_status_name()` - Get link status name
 - `CYW43.dhcp_supplied?()` - Check if DHCP supplied IP
+- `CYW43.ap_ipv4_address()` - Get AP-side IPv4 address
+- `CYW43.ap_ipv4_netmask()` - Get AP-side IPv4 netmask
+- `CYW43.ap_ipv4_gateway()` - Get AP-side IPv4 gateway
 
 ### Authentication Types
 
@@ -94,7 +98,7 @@ puts "AP started"
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
 - `enable_ap_mode` only enables the CYW43 AP radio/auth path for now
-- PicoRuby does not yet expose AP-side DHCP server, AP IP configuration, or connected client listing
-- Clients may associate to the SSID without receiving an IP address until DHCP/IP helpers are added
+- PicoRuby now exposes AP-side IPv4 information, but not AP-side DHCP control, custom AP IP configuration, or connected client listing
+- AP usability beyond SSID visibility still needs more hardware verification
 - See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample
 - TODO: add AP-side IP/DHCP helpers before documenting a supported HTTP server sample

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb
@@ -3,7 +3,8 @@ require "socket"
 
 # Experimental AP + HTTP sample for Pico W / Pico 2 W.
 # This is intended for hardware confirmation only.
-# If a client cannot reach the page, future AP status/IP/DHCP work may still be needed.
+# AP mode now starts a minimal DHCP server for the default 192.168.4.0/24 network.
+# If a client still cannot reach the page, future AP status/IP control work may still be needed.
 
 CYW43.init("JP")
 CYW43.enable_ap_mode("PICO-TIMER", "12345678")

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb
@@ -1,0 +1,39 @@
+require "cyw43"
+require "socket"
+
+# Experimental AP + HTTP sample for Pico W / Pico 2 W.
+# This is intended for hardware confirmation only.
+# If a client cannot reach the page, future AP status/IP/DHCP work may still be needed.
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+ap_ip = CYW43.ap_ipv4_address
+puts "AP started"
+puts "AP IP: #{ap_ip || 'unassigned'}"
+puts "Open: http://#{ap_ip}/" if ap_ip
+
+server = TCPServer.new("0.0.0.0", 80)
+puts "HTTP server listening on port 80"
+
+response = "Hello from PicoRuby AP mode\n"
+
+loop do
+  client = server.accept
+
+  begin
+    request_line = client.gets
+    puts "Request: #{request_line.inspect}" if request_line
+
+    client.write "HTTP/1.1 200 OK\r\n"
+    client.write "Content-Type: text/plain\r\n"
+    client.write "Content-Length: #{response.bytesize}\r\n"
+    client.write "Connection: close\r\n"
+    client.write "\r\n"
+    client.write response
+  rescue => e
+    puts "HTTP sample error: #{e.class}: #{e.message}"
+  ensure
+    client.close
+  end
+end

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -1,0 +1,19 @@
+require "cyw43"
+
+# Minimal AP mode example for Pico W / Pico 2 W.
+# TODO: add AP-side DHCP/IP helpers before expanding this into a supported HTTP sample.
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PICO-TIMER", "12345678")
+
+puts "AP started"
+puts "Clients may need a static IP until DHCP support is added."
+
+led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
+
+loop do
+  led.write(1)
+  sleep 0.5
+  led.write(0)
+  sleep 0.5
+end

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -7,7 +7,7 @@ CYW43.init("JP")
 CYW43.enable_ap_mode("PICO-TIMER", "12345678")
 
 puts "AP started"
-puts "Clients may need a static IP until DHCP support is added."
+puts "AP IP: #{CYW43.ap_ipv4_address || 'unassigned'}"
 
 led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
 

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -33,6 +33,9 @@ extern void lwip_end(void);
 const char *CYW43_ipv4_address(char *buf, size_t buflen);
 const char *CYW43_ipv4_netmask(char *buf, size_t buflen);
 const char *CYW43_ipv4_gateway(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_address(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_netmask(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_gateway(char *buf, size_t buflen);
 #endif
 void CYW43_GPIO_write(uint8_t, uint8_t);
 uint8_t CYW43_GPIO_read(uint8_t pin);

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -14,10 +14,13 @@ void CYW43_arch_deinit(void);
 #ifdef USE_WIFI
 void CYW43_arch_enable_sta_mode(void);
 void CYW43_arch_disable_sta_mode(void);
+void CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth);
+void CYW43_arch_disable_ap_mode(void);
 int CYW43_wifi_connect_with_dhcp(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms);
 int CYW43_wifi_disconnect(void);
 int CYW43_tcpip_link_status(void);
 bool CYW43_dhcp_supplied(void);
+int CYW43_CONST_auth_wpa2_aes_psk(void);
 int CYW43_CONST_link_down(void);
 int CYW43_CONST_link_join(void);
 int CYW43_CONST_link_noip(void);
@@ -39,4 +42,3 @@ uint8_t CYW43_GPIO_read(uint8_t pin);
 #endif
 
 #endif /* CYW43_DEFINED_H_ */
-

--- a/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.c
@@ -1,0 +1,400 @@
+/*
+ * Minimal DHCP server for PicoRuby CYW43 AP mode.
+ *
+ * This implementation is adapted from the tiny DHCP server shipped in
+ * TinyUSB's networking helpers (MIT licensed, original copyright by
+ * Sergey Fetisov). The code here is reduced to the AP-mode use case
+ * needed by PicoRuby on Pico W / Pico 2 W.
+ */
+
+#include "../../include/cyw43.h"
+#include "ap_dhcp_server.h"
+
+#include "pico/cyw43_arch.h"
+#include "lwip/pbuf.h"
+#include "lwip/udp.h"
+#include "lwip/netif.h"
+#include "lwip/ip_addr.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define AP_DHCP_SERVER_PORT 67
+#define AP_DHCP_CLIENT_PORT 68
+#define AP_DHCP_MAX_LEASES 4
+#define AP_DHCP_FIRST_HOST 2
+#define AP_DHCP_LEASE_TIME_SEC (24 * 60 * 60)
+
+enum ap_dhcp_message_type {
+  AP_DHCP_DISCOVER = 1,
+  AP_DHCP_OFFER = 2,
+  AP_DHCP_REQUEST = 3,
+  AP_DHCP_ACK = 5,
+};
+
+enum ap_dhcp_option {
+  AP_DHCP_OPT_PAD = 0,
+  AP_DHCP_OPT_SUBNET_MASK = 1,
+  AP_DHCP_OPT_ROUTER = 3,
+  AP_DHCP_OPT_DNS_SERVER = 6,
+  AP_DHCP_OPT_IP_ADDRESS = 50,
+  AP_DHCP_OPT_LEASE_TIME = 51,
+  AP_DHCP_OPT_MESSAGE_TYPE = 53,
+  AP_DHCP_OPT_SERVER_ID = 54,
+  AP_DHCP_OPT_END = 255,
+};
+
+typedef struct {
+  uint8_t mac[6];
+  ip4_addr_t addr;
+  uint32_t lease_sec;
+} ap_dhcp_lease_t;
+
+typedef struct {
+  uint8_t op;
+  uint8_t htype;
+  uint8_t hlen;
+  uint8_t hops;
+  uint32_t xid;
+  uint16_t secs;
+  uint16_t flags;
+  uint8_t ciaddr[4];
+  uint8_t yiaddr[4];
+  uint8_t siaddr[4];
+  uint8_t giaddr[4];
+  uint8_t chaddr[16];
+  uint8_t legacy[192];
+  uint8_t magic[4];
+  uint8_t options[275];
+} ap_dhcp_packet_t;
+
+static struct udp_pcb *s_dhcp_pcb = NULL;
+static ap_dhcp_lease_t s_leases[AP_DHCP_MAX_LEASES];
+static ip4_addr_t s_router;
+static ip4_addr_t s_dns;
+
+static const uint8_t s_magic_cookie[4] = {0x63, 0x82, 0x53, 0x63};
+
+static void
+ap_dhcp_set_ip(uint8_t *dest, ip4_addr_t addr)
+{
+  memcpy(dest, &addr.addr, sizeof(addr.addr));
+}
+
+static ip4_addr_t
+ap_dhcp_get_ip(const uint8_t *src)
+{
+  ip4_addr_t addr;
+  memcpy(&addr.addr, src, sizeof(addr.addr));
+  return addr;
+}
+
+static bool
+ap_dhcp_lease_vacant(const ap_dhcp_lease_t *lease)
+{
+  static const uint8_t zero_mac[6] = {0};
+  return memcmp(lease->mac, zero_mac, sizeof(zero_mac)) == 0;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_lease_by_mac(const uint8_t *mac)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (memcmp(s_leases[i].mac, mac, 6) == 0) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_lease_by_ip(ip4_addr_t ip)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (s_leases[i].addr.addr == ip.addr) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_vacant_lease(void)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (ap_dhcp_lease_vacant(&s_leases[i])) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static void
+ap_dhcp_release_lease(ap_dhcp_lease_t *lease)
+{
+  memset(lease->mac, 0, sizeof(lease->mac));
+}
+
+static uint8_t *
+ap_dhcp_find_option(uint8_t *options, size_t options_len, uint8_t code)
+{
+  size_t i = 0;
+
+  while (i < options_len) {
+    uint8_t opt = options[i];
+    if (opt == AP_DHCP_OPT_END) {
+      break;
+    }
+    if (opt == AP_DHCP_OPT_PAD) {
+      i++;
+      continue;
+    }
+    if (i + 1 >= options_len) {
+      break;
+    }
+
+    uint8_t opt_len = options[i + 1];
+    if (i + 2 + opt_len > options_len) {
+      break;
+    }
+    if (opt == code) {
+      return &options[i];
+    }
+    i += 2 + opt_len;
+  }
+
+  return NULL;
+}
+
+static size_t
+ap_dhcp_fill_options(
+  uint8_t *dest,
+  uint8_t msg_type,
+  uint32_t lease_sec,
+  ip4_addr_t server_id,
+  ip4_addr_t router,
+  ip4_addr_t subnet_mask,
+  ip4_addr_t dns
+)
+{
+  uint8_t *ptr = dest;
+
+  *ptr++ = AP_DHCP_OPT_MESSAGE_TYPE;
+  *ptr++ = 1;
+  *ptr++ = msg_type;
+
+  *ptr++ = AP_DHCP_OPT_SERVER_ID;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, server_id);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_LEASE_TIME;
+  *ptr++ = 4;
+  *ptr++ = (lease_sec >> 24) & 0xff;
+  *ptr++ = (lease_sec >> 16) & 0xff;
+  *ptr++ = (lease_sec >> 8) & 0xff;
+  *ptr++ = lease_sec & 0xff;
+
+  *ptr++ = AP_DHCP_OPT_SUBNET_MASK;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, subnet_mask);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_ROUTER;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, router);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_DNS_SERVER;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, dns);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_END;
+
+  return (size_t)(ptr - dest);
+}
+
+static err_t
+ap_dhcp_send_reply(
+  struct udp_pcb *pcb,
+  struct netif *ap_netif,
+  ap_dhcp_packet_t *packet,
+  uint8_t msg_type,
+  ap_dhcp_lease_t *lease
+)
+{
+  size_t options_len;
+  size_t payload_len;
+  struct pbuf *pbuf;
+
+  packet->op = 2; /* BOOTREPLY */
+  packet->secs = 0;
+  packet->flags = 0;
+  memset(packet->ciaddr, 0, sizeof(packet->ciaddr));
+  ap_dhcp_set_ip(packet->yiaddr, lease->addr);
+  ap_dhcp_set_ip(packet->siaddr, *netif_ip4_addr(ap_netif));
+  memcpy(packet->magic, s_magic_cookie, sizeof(s_magic_cookie));
+  memset(packet->options, 0, sizeof(packet->options));
+
+  options_len = ap_dhcp_fill_options(
+    packet->options,
+    msg_type,
+    lease->lease_sec,
+    *netif_ip4_addr(ap_netif),
+    s_router,
+    *netif_ip4_netmask(ap_netif),
+    s_dns
+  );
+
+  payload_len = offsetof(ap_dhcp_packet_t, options) + options_len;
+  pbuf = pbuf_alloc(PBUF_TRANSPORT, payload_len, PBUF_RAM);
+  if (!pbuf) {
+    return ERR_MEM;
+  }
+
+  memcpy(pbuf->payload, packet, payload_len);
+  err_t err = udp_sendto_if(pcb, pbuf, IP_ADDR_BROADCAST, AP_DHCP_CLIENT_PORT, ap_netif);
+  pbuf_free(pbuf);
+  return err;
+}
+
+static void
+ap_dhcp_udp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *pbuf, const ip_addr_t *addr, u16_t port)
+{
+  ap_dhcp_packet_t packet;
+  ap_dhcp_lease_t *lease = NULL;
+  struct netif *ap_netif;
+  uint8_t *msg_type_opt;
+
+  (void)arg;
+  (void)addr;
+  (void)port;
+
+  if (!pbuf) {
+    return;
+  }
+
+  ap_netif = netif_get_by_index(pbuf->if_idx);
+  if (!ap_netif || ap_netif != &cyw43_state.netif[CYW43_ITF_AP]) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  memset(&packet, 0, sizeof(packet));
+  pbuf_copy_partial(pbuf, &packet, LWIP_MIN((u16_t)sizeof(packet), pbuf->tot_len), 0);
+
+  if (memcmp(packet.magic, s_magic_cookie, sizeof(s_magic_cookie)) != 0) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  msg_type_opt = ap_dhcp_find_option(packet.options, sizeof(packet.options), AP_DHCP_OPT_MESSAGE_TYPE);
+  if (!msg_type_opt || msg_type_opt[1] != 1) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  switch (msg_type_opt[2]) {
+    case AP_DHCP_DISCOVER:
+      lease = ap_dhcp_find_lease_by_mac(packet.chaddr);
+      if (!lease) {
+        lease = ap_dhcp_find_vacant_lease();
+      }
+      if (lease) {
+        ap_dhcp_send_reply(pcb, ap_netif, &packet, AP_DHCP_OFFER, lease);
+      }
+      break;
+
+    case AP_DHCP_REQUEST: {
+      uint8_t *requested_ip_opt = ap_dhcp_find_option(packet.options, sizeof(packet.options), AP_DHCP_OPT_IP_ADDRESS);
+      if (!requested_ip_opt || requested_ip_opt[1] != 4) {
+        break;
+      }
+
+      lease = ap_dhcp_find_lease_by_mac(packet.chaddr);
+      if (lease) {
+        ap_dhcp_release_lease(lease);
+      }
+
+      lease = ap_dhcp_find_lease_by_ip(ap_dhcp_get_ip(requested_ip_opt + 2));
+      if (!lease || !ap_dhcp_lease_vacant(lease)) {
+        break;
+      }
+
+      memcpy(lease->mac, packet.chaddr, 6);
+      ap_dhcp_send_reply(pcb, ap_netif, &packet, AP_DHCP_ACK, lease);
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  pbuf_free(pbuf);
+}
+
+bool
+picoruby_ap_dhcp_server_start(void)
+{
+  struct netif *ap_netif = &cyw43_state.netif[CYW43_ITF_AP];
+  const ip4_addr_t *ap_ip = netif_ip4_addr(ap_netif);
+  const ip4_addr_t *ap_mask = netif_ip4_netmask(ap_netif);
+  uint32_t network;
+
+  if ((cyw43_state.itf_state & (1 << CYW43_ITF_AP)) == 0) {
+    return false;
+  }
+  if (!ap_ip || !ap_mask || ap_ip->addr == 0 || ap_mask->addr == 0) {
+    return false;
+  }
+
+  lwip_begin();
+
+  if (s_dhcp_pcb) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+  }
+
+  memset(s_leases, 0, sizeof(s_leases));
+  s_router = *ap_ip;
+  s_dns = *ap_ip;
+  network = lwip_ntohl(ap_ip->addr) & lwip_ntohl(ap_mask->addr);
+
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    s_leases[i].addr.addr = lwip_htonl(network | (AP_DHCP_FIRST_HOST + (uint32_t)i));
+    s_leases[i].lease_sec = AP_DHCP_LEASE_TIME_SEC;
+  }
+
+  s_dhcp_pcb = udp_new();
+  if (!s_dhcp_pcb) {
+    lwip_end();
+    return false;
+  }
+
+  ip_set_option(s_dhcp_pcb, SOF_BROADCAST);
+  if (udp_bind(s_dhcp_pcb, IP_ADDR_ANY, AP_DHCP_SERVER_PORT) != ERR_OK) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+    lwip_end();
+    return false;
+  }
+
+  udp_bind_netif(s_dhcp_pcb, ap_netif);
+  udp_recv(s_dhcp_pcb, ap_dhcp_udp_recv, NULL);
+
+  lwip_end();
+  return true;
+}
+
+void
+picoruby_ap_dhcp_server_stop(void)
+{
+  lwip_begin();
+  if (s_dhcp_pcb) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+  }
+  memset(s_leases, 0, sizeof(s_leases));
+  lwip_end();
+}

--- a/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.h
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.h
@@ -1,0 +1,9 @@
+#ifndef PICORUBY_CYW43_AP_DHCP_SERVER_H
+#define PICORUBY_CYW43_AP_DHCP_SERVER_H
+
+#include <stdbool.h>
+
+bool picoruby_ap_dhcp_server_start(void);
+void picoruby_ap_dhcp_server_stop(void);
+
+#endif /* PICORUBY_CYW43_AP_DHCP_SERVER_H */

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -60,6 +60,12 @@ CYW43_dhcp_supplied(void)
 }
 
 int
+CYW43_CONST_auth_wpa2_aes_psk(void)
+{
+  return CYW43_AUTH_WPA2_AES_PSK;
+}
+
+int
 CYW43_arch_init_with_country(const uint8_t *country)
 {
   int res;
@@ -97,6 +103,18 @@ void
 CYW43_arch_disable_sta_mode(void)
 {
   cyw43_arch_disable_sta_mode();
+}
+
+void
+CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth)
+{
+  cyw43_arch_enable_ap_mode(ssid, pw, auth);
+}
+
+void
+CYW43_arch_disable_ap_mode(void)
+{
+  cyw43_arch_disable_ap_mode();
 }
 
 int

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -153,46 +153,94 @@ CYW43_GPIO_read(uint8_t pin)
 }
 
 const char *
-CYW43_ipv4_address(char *buf, size_t buflen)
+cyw43_ipv4_address_for_if(int itf, char *buf, size_t buflen)
 {
   const char *res;
   lwip_begin();
-  const ip4_addr_t *ip = netif_ip4_addr(netif_default);
-  if (ip && ip->addr != 0) {
-    res = ipaddr_ntoa_r(ip, buf, buflen);
-  } else {
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
     res = NULL;
+  } else {
+    const ip4_addr_t *ip = netif_ip4_addr(&cyw43_state.netif[itf]);
+    if (ip && ip->addr != 0) {
+      res = ipaddr_ntoa_r(ip, buf, buflen);
+    } else {
+      res = NULL;
+    }
   }
   lwip_end();
   return res;
+}
+
+const char *
+cyw43_ipv4_netmask_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *netmask = netif_ip4_netmask(&cyw43_state.netif[itf]);
+    if (netmask && netmask->addr != 0) {
+      res = ipaddr_ntoa_r(netmask, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+const char *
+cyw43_ipv4_gateway_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *gateway = netif_ip4_gw(&cyw43_state.netif[itf]);
+    if (gateway && gateway->addr != 0) {
+      res = ipaddr_ntoa_r(gateway, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+const char *
+CYW43_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_netmask(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *netmask = netif_ip4_netmask(netif_default);
-  if (netmask && netmask->addr != 0) {
-    res = ipaddr_ntoa_r(netmask, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_gateway(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *gateway = netif_ip4_gw(netif_default);
-  if (gateway && gateway->addr != 0) {
-    res = ipaddr_ntoa_r(gateway, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_gateway_for_if(CYW43_ITF_STA, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_AP, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_netmask(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_AP, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_gateway(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_gateway_for_if(CYW43_ITF_AP, buf, buflen);
 }

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -1,4 +1,5 @@
 #include "../../include/cyw43.h"
+#include "ap_dhcp_server.h"
 
 #include "pico/cyw43_arch.h"
 #include "lwip/dhcp.h"
@@ -109,11 +110,13 @@ void
 CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth)
 {
   cyw43_arch_enable_ap_mode(ssid, pw, auth);
+  picoruby_ap_dhcp_server_start();
 }
 
 void
 CYW43_arch_disable_ap_mode(void)
 {
+  picoruby_ap_dhcp_server_stop();
   cyw43_arch_disable_ap_mode();
 }
 

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -28,6 +28,9 @@ class CYW43
   def self.ipv4_address: () -> (String | nil)
   def self.ipv4_netmask: () -> (String | nil)
   def self.ipv4_gateway: () -> (String | nil)
+  def self.ap_ipv4_address: () -> (String | nil)
+  def self.ap_ipv4_netmask: () -> (String | nil)
+  def self.ap_ipv4_gateway: () -> (String | nil)
   private def self._init: (String | nil country, bool force) -> bool
 
   # @sidebar hardware_device

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -19,6 +19,8 @@ class CYW43
   def self.disconnect: () -> bool
   def self.enable_sta_mode: () -> bool
   def self.disable_sta_mode: () -> bool
+  def self.enable_ap_mode: (String ssid, String password, ?Integer auth) -> bool
+  def self.disable_ap_mode: () -> bool
   def self.tcpip_link_status: () -> Integer
   def self.tcpip_link_status_name: () -> String
   def self.dhcp_supplied?: () -> bool

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -40,6 +40,7 @@ mrb_s_initialized_p(mrb_state *mrb, mrb_value klass)
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 
 static mrb_value
 mrb_s_enable_sta_mode(mrb_state *mrb, mrb_value klass)
@@ -72,6 +73,40 @@ mrb_s_disable_sta_mode(mrb_state *mrb, mrb_value klass)
 }
 
 static bool cyw43_arch_connected = false;
+
+static mrb_value
+mrb_s_enable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  const char *ssid;
+  const char *pass;
+  mrb_int auth = CYW43_CONST_auth_wpa2_aes_psk();
+  mrb_get_args(mrb, "zz|i", &ssid, &pass, &auth);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
+
+static mrb_value
+mrb_s_disable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
 
 static mrb_value
 mrb_s_connect_timeout(mrb_state *mrb, mrb_value klass)
@@ -217,6 +252,8 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
 #ifdef USE_WIFI
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_sta_mode), mrb_s_enable_sta_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_sta_mode), mrb_s_disable_sta_mode, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_ap_mode), mrb_s_enable_ap_mode, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_ap_mode), mrb_s_disable_ap_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(connect_timeout), mrb_s_connect_timeout, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disconnect), mrb_s_disconnect, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(tcpip_link_status), mrb_s_tcpip_link_status, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -221,6 +221,48 @@ mrb_cyw43_s_ipv4_gateway(mrb_state *mrb, mrb_value self)
     return mrb_str_new_cstr(mrb, gateway_str);
   }
 }
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_address(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char addr_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(addr_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, addr_str);
+  }
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_netmask(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, netmask_str);
+  }
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_gateway(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char gateway_str[16] = {0};
+  if (!CYW43_ap_ipv4_gateway(gateway_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, gateway_str);
+  }
+}
 #endif
 
 static mrb_value
@@ -261,6 +303,9 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_address), mrb_cyw43_s_ipv4_address, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_netmask), mrb_cyw43_s_ipv4_netmask, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_gateway), mrb_cyw43_s_ipv4_gateway, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_address"), mrb_cyw43_s_ap_ipv4_address, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_netmask"), mrb_cyw43_s_ap_ipv4_netmask, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_gateway"), mrb_cyw43_s_ap_ipv4_gateway, MRB_ARGS_NONE());
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_DOWN), mrb_fixnum_value(CYW43_CONST_link_down()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_JOIN), mrb_fixnum_value(CYW43_CONST_link_join()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_NOIP), mrb_fixnum_value(CYW43_CONST_link_noip()));

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -225,6 +225,39 @@ c_CYW43_ipv4_gateway(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   SET_RETURN(mrbc_string_new_cstr(vm, gateway_str));
 }
+
+static void
+c_CYW43_ap_ipv4_address(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char ip_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(ip_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, ip_str));
+}
+
+static void
+c_CYW43_ap_ipv4_netmask(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, netmask_str));
+}
+
+static void
+c_CYW43_ap_ipv4_gateway(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char gateway_str[16] = {0};
+  if (!CYW43_ap_ipv4_gateway(gateway_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, gateway_str));
+}
 #endif
 
 static void
@@ -260,6 +293,9 @@ mrbc_cyw43_init(mrbc_vm *vm)
   mrbc_define_method(vm, class_CYW43, "ipv4_address", c_CYW43_ipv4_address);
   mrbc_define_method(vm, class_CYW43, "ipv4_netmask", c_CYW43_ipv4_netmask);
   mrbc_define_method(vm, class_CYW43, "ipv4_gateway", c_CYW43_ipv4_gateway);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_address", c_CYW43_ap_ipv4_address);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_netmask", c_CYW43_ap_ipv4_netmask);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_gateway", c_CYW43_ap_ipv4_gateway);
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_DOWN"), &mrbc_integer_value(CYW43_CONST_link_down()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_JOIN"), &mrbc_integer_value(CYW43_CONST_link_join()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_NOIP"), &mrbc_integer_value(CYW43_CONST_link_noip()));

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -8,6 +8,7 @@ static bool cyw43_arch_init_flag = false;
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 static bool cyw43_arch_connected = false;
 #endif
 
@@ -26,6 +27,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     cyw43_arch_init_flag = false;
 #ifdef USE_WIFI
     cyw43_arch_sta_mode_enabled = false;
+    cyw43_arch_ap_mode_enabled = false;
     cyw43_arch_connected = false;
 #endif
   }
@@ -105,6 +107,45 @@ c_CYW43_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
       return;
     }
     cyw43_arch_connected = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_enable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (argc < 2 || 3 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+  const char *ssid = (const char *)GET_STRING_ARG(1);
+  const char *pass = (const char *)GET_STRING_ARG(2);
+  int auth = argc < 3 ? CYW43_CONST_auth_wpa2_aes_psk() : GET_INT_ARG(3);
+  if (!cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_enable_ap_mode(ssid, pass, auth);
+    cyw43_arch_ap_mode_enabled = true;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_disable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
     SET_TRUE_RETURN();
   } else {
     SET_FALSE_RETURN();
@@ -210,6 +251,8 @@ mrbc_cyw43_init(mrbc_vm *vm)
 #ifdef USE_WIFI
   mrbc_define_method(vm, class_CYW43, "enable_sta_mode", c_CYW43_enable_sta_mode);
   mrbc_define_method(vm, class_CYW43, "disable_sta_mode", c_CYW43_disable_sta_mode);
+  mrbc_define_method(vm, class_CYW43, "enable_ap_mode", c_CYW43_enable_ap_mode);
+  mrbc_define_method(vm, class_CYW43, "disable_ap_mode", c_CYW43_disable_ap_mode);
   mrbc_define_method(vm, class_CYW43, "connect_timeout", c_CYW43_connect_timeout);
   mrbc_define_method(vm, class_CYW43, "disconnect", c_CYW43_disconnect);
   mrbc_define_method(vm, class_CYW43, "tcpip_link_status", c_CYW43_tcpip_link_status);

--- a/mrbgems/picoruby-network/sig/network.rbs
+++ b/mrbgems/picoruby-network/sig/network.rbs
@@ -15,6 +15,9 @@ module Network
     def self.ipv4_address: () -> (String | nil)
     def self.ipv4_netmask: () -> (String | nil)
     def self.ipv4_gateway: () -> (String | nil)
+    def self.ap_ipv4_address: () -> (String | nil)
+    def self.ap_ipv4_netmask: () -> (String | nil)
+    def self.ap_ipv4_gateway: () -> (String | nil)
     def self.dhcp_supplied?: () -> bool
   end
 end

--- a/mrbgems/picoruby-shell/shell_executables/ifconfig.rb
+++ b/mrbgems/picoruby-shell/shell_executables/ifconfig.rb
@@ -14,16 +14,30 @@ end
 
 puts "Link: WiFi"
 
+puts "  Station:"
 if Network::WiFi.link_connected?
-  puts "  Status: UP (#{Network::WiFi.tcpip_link_status_name})"
+  puts "    Status: UP (#{Network::WiFi.tcpip_link_status_name})"
   if Network::WiFi.dhcp_supplied?
-    puts "  DHCP: Active"
-    puts "  IP Address: #{Network::WiFi.ipv4_address || 'unassigned'}"
-    puts "  Netmask:    #{Network::WiFi.ipv4_netmask || 'unassigned'}"
-    puts "  Gateway:    #{Network::WiFi.ipv4_gateway || 'unassigned'}"
+    puts "    DHCP: Active"
+    puts "    IP Address: #{Network::WiFi.ipv4_address || 'unassigned'}"
+    puts "    Netmask:    #{Network::WiFi.ipv4_netmask || 'unassigned'}"
+    puts "    Gateway:    #{Network::WiFi.ipv4_gateway || 'unassigned'}"
   else
-    puts "  DHCP: Inactive"
+    puts "    DHCP: Inactive"
   end
 else
-  puts "  Status: DOWN"
+  puts "    Status: DOWN"
+end
+
+puts "  Access Point:"
+ap_ip = Network::WiFi.ap_ipv4_address
+ap_netmask = Network::WiFi.ap_ipv4_netmask
+ap_gateway = Network::WiFi.ap_ipv4_gateway
+if ap_ip || ap_netmask || ap_gateway
+  puts "    Status: UP"
+  puts "    IP Address: #{ap_ip || 'unassigned'}"
+  puts "    Netmask:    #{ap_netmask || 'unassigned'}"
+  puts "    Gateway:    #{ap_gateway || 'unassigned'}"
+else
+  puts "    Status: DOWN"
 end


### PR DESCRIPTION
## Summary

This draft PR makes CYW43 AP mode practically testable from PicoRuby by starting a minimal built-in DHCP server when AP mode is enabled.

It also keeps the experimental AP + HTTP sample and updates the documentation to match the new behavior.

With this change, a client can join the PicoRuby AP, get an address on the default `192.168.4.0/24` network, and reach a tiny `TCPServer` sample from a browser.

## Background

A previous step added:

- `CYW43.enable_ap_mode`
- `CYW43.disable_ap_mode`

That was enough to make the SSID visible, but not enough to reliably complete client-side connection tests in practice.

This branch keeps the sample small, but adds the missing DHCP piece needed to actually validate AP + HTTP behavior on hardware.

## What changed

- added a minimal AP-side DHCP server for Pico W / Pico 2 W
- start the DHCP server from `CYW43_arch_enable_ap_mode`
- stop the DHCP server from `CYW43_arch_disable_ap_mode`
- kept the AP-side default network aligned with the SDK defaults:
  - AP IP: `192.168.4.1`
  - subnet: `255.255.255.0`
- updated the experimental AP + HTTP sample comments
- updated the CYW43 README to describe the new AP behavior

## Files

- `mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.c`
- `mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.h`
- `mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c`
- `mrbgems/picoruby-cyw43/example/pico_w_ap_http_experimental.rb`
- `mrbgems/picoruby-cyw43/README.md`

## Example

```ruby
require "cyw43"
require "socket"

CYW43.init("JP")
CYW43.enable_ap_mode("PICO-TIMER", "12345678")

puts "AP IP: #{CYW43.ap_ipv4_address}"

server = TCPServer.new("0.0.0.0", 80)

loop do
  client = server.accept
  begin
    client.gets
    client.write "HTTP/1.1 200 OK\r\n"
    client.write "Content-Type: text/plain\r\n"
    client.write "Connection: close\r\n"
    client.write "\r\n"
    client.write "Hello from PicoRuby AP mode\n"
  ensure
    client.close
  end
end
