### PR TITLE
Skip to load wifi_connect.rb when wifi_config file is absent

### DIFF
--- a/mrbgems/picoruby-shell/shell_executables/r2p2.rb
+++ b/mrbgems/picoruby-shell/shell_executables/r2p2.rb
@@ -2,9 +2,12 @@ if Machine.wifi_available?
   if Shell.get_device(:gpio, 'TRIGGER_NMBLE')&.low?
     load "/bin/nmble"
   end
-  ARGV[0] = "--check-auto-connect"
-  load "/bin/wifi_connect"
-  ARGV.clear
+  wifi_config_path = ENV['WIFI_CONFIG_PATH'] || ENV_DEFAULT_WIFI_CONFIG_PATH
+  if File.file?(wifi_config_path)
+    ARGV[0] = "--check-auto-connect"
+    load "/bin/wifi_connect"
+    ARGV.clear
+  end
 end
 
 begin


### PR DESCRIPTION
## Summary

When the WiFi config file (`/etc/network/wifi.yml`) does not exist, skip loading `/bin/wifi_connect`.


Currently, wifi_connect.rb itself early-returns when the config is missing. However, even if it returned on line 1, simply loading the file allocates ~25KB of ephemeral and ~11KB of permanent heap per boot. This PR avoids those allocations by skipping the load entirely when the config is absent.

Behavior on boards with a valid wifi.yml is unchanged.

## Measurement

Added the following logging to `mrbgems/picoruby-shell/shell_executables/r2p2.rb`:

```ruby
puts "[BOOT R0] r2p2.rb start: #{PicoRubyVM.memory_statistics}"
if Machine.wifi_available?
  # ... wifi handling (load "/bin/wifi_connect" or skip)
  puts "[BOOT R1] ...: #{PicoRubyVM.memory_statistics}"
  GC.start
  puts "[BOOT R2] r2p2.rb end: #{PicoRubyVM.memory_statistics}"
end
```

Test environment: Pico 2 W (RP2350). No `/etc/network/wifi.yml`.

## Results

Median of 5 runs:

| | R0 used | R1 used | R1 frag | R2 used | R2 frag |
| --- | --- | --- | --- | --- | --- |
| Before | 303 KB | 333 KB | 1 | 262 KB | 365 |
| After  | 303 KB | 308 KB | 1 | 251 KB | 327 |

## Alternative considered

Moving the `require` statements in wifi_connect.rb to after the config check was also considered. Measurements show that this approach saves only ~3KB (compared to ~11KB for this PR). This is presumably because mrbgems are built into the firmware so the cost of `require` is small, and the dominant cost is parsing and compiling wifi_connect.rb itself.