### PR TITLE
Add minimal R2P2 serial upload/run workflow

### DIFF
--- a/examples/hello.rb
+++ b/examples/hello.rb
@@ -1,0 +1,1 @@
+puts "Hello from PicoRuby serial run"

--- a/mrbgems/picoruby-shell/README.md
+++ b/mrbgems/picoruby-shell/README.md
@@ -32,6 +32,8 @@ Typically includes commands like:
 - `cat` - Display file contents
 - `mkdir` - Create directory
 - `rm` - Remove file
+- `recv` - Receive a file over serial with a known byte size
+- `run` - Run a Ruby file and print a completion marker
 - `help` - Show help
 
 ## REPL Mode
@@ -57,3 +59,26 @@ Hello, PicoRuby!
 - Educational purposes
 - Requires VFS for file operations
 - Commands are implemented in `shell_executables/` directory
+
+## Serial Upload/Run Workflow
+
+For R2P2-based targets, the shell can be used as a minimal serial upload/run target:
+
+- `recv <path> <size>` reads exactly `<size>` bytes from serial input and saves them to `<path>`
+- `run <path>` loads the file and always prints `__PICORUBY_RUN_DONE__` when execution ends
+
+A host-side helper script is available at:
+
+- `tools/r2p2_serial_run.rb`
+
+Typical flow:
+
+1. Connect to the Pico shell and make sure it is idle at the shell prompt.
+2. Close `screen`/`cu` so the serial port is free.
+3. From the host, run:
+
+```sh
+ruby tools/r2p2_serial_run.rb /dev/cu.usbmodemXXXX examples/hello.rb
+```
+
+This sends the file to `/home/app.rb`, runs it with `run /home/app.rb`, streams `puts` output back to the host, and stops reading when `__PICORUBY_RUN_DONE__` is received.

--- a/mrbgems/picoruby-shell/README.md
+++ b/mrbgems/picoruby-shell/README.md
@@ -64,7 +64,7 @@ Hello, PicoRuby!
 
 For R2P2-based targets, the shell can be used as a minimal serial upload/run target:
 
-- `recv <path> <size>` reads exactly `<size>` bytes from serial input and saves them to `<path>`
+- `recv <path> <size>` receives a file over serial using a chunked ACK protocol and saves it to `<path>`
 - `run <path>` loads the file and always prints `__PICORUBY_RUN_DONE__` when execution ends
 
 A host-side helper script is available at:
@@ -82,3 +82,37 @@ ruby tools/r2p2_serial_run.rb /dev/cu.usbmodemXXXX examples/hello.rb
 ```
 
 This sends the file to `/home/app.rb`, runs it with `run /home/app.rb`, streams `puts` output back to the host, and stops reading when `__PICORUBY_RUN_DONE__` is received.
+
+### Transfer protocol
+
+The current `recv` implementation is intentionally conservative and prioritizes reliability:
+
+1. Host sends `recv <path> <size>`
+2. Device replies `READY chunk=<chunk_size>`
+3. Host sends one chunk
+4. Device writes the chunk to `<path>.part`
+5. Device replies `ACK <offset>`
+6. After the last chunk, device renames `<path>.part` to `<path>` and replies `OK <size>`
+
+If anything fails, the device replies `ERR <message>` and removes the temporary file.
+
+### Useful options
+
+- `--skip-run` uploads the file but does not call `run`
+- `--chunk-timeout-ms MS` adjusts the per-chunk ACK timeout
+
+### Large-file verification samples
+
+You can generate larger Ruby files for transfer testing with:
+
+```sh
+ruby tools/generate_serial_transfer_samples.rb
+```
+
+By default this writes:
+
+- `/private/tmp/picoruby-serial-transfer-samples/sample_12kb.rb`
+- `/private/tmp/picoruby-serial-transfer-samples/sample_100kb.rb`
+- `/private/tmp/picoruby-serial-transfer-samples/sample_1mb.rb`
+
+These files are valid Ruby programs that print a short summary when run.

--- a/mrbgems/picoruby-shell/README.md
+++ b/mrbgems/picoruby-shell/README.md
@@ -94,7 +94,9 @@ The current `recv` implementation is intentionally conservative and prioritizes 
 5. Device replies `ACK <offset>`
 6. After the last chunk, device renames `<path>.part` to `<path>` and replies `OK <size>`
 
-If anything fails, the device replies `ERR <message>` and removes the temporary file.
+Before receiving data, the device removes any stale `<path>.part` file and checks free space on the target volume. If there is not enough room, it replies `ERR no space: need=<bytes> free=<bytes>` without starting the transfer.
+
+If anything else fails, the device replies `ERR <message>` and removes the temporary file.
 
 ### Useful options
 

--- a/mrbgems/picoruby-shell/shell_executables/_path.txt
+++ b/mrbgems/picoruby-shell/shell_executables/_path.txt
@@ -23,6 +23,8 @@
 /etc/init.d/r2p2
 /bin/rapicco
 /bin/rm
+/bin/run
+/bin/recv
 /bin/setup_rtc
 /bin/setup_sdcard
 /bin/tail

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -23,6 +23,7 @@ temp_path = "#{path}.part"
 received = 0
 waited_ms = 0
 timeout_ms = 5000
+read_chunk_size = 1024
 
 begin
   STDIN.raw!
@@ -31,7 +32,7 @@ begin
   File.unlink(temp_path) if File.exist?(temp_path)
   File.open(temp_path, "w") do |file|
     while received < size
-      chunk = STDIN.read_nonblock([size - received, 256].min)
+      chunk = STDIN.read_nonblock([size - received, read_chunk_size].min)
       if chunk
         file.write(chunk)
         received += chunk.bytesize

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -1,0 +1,56 @@
+unless ARGV.size == 2
+  puts "ERROR: Usage: recv <path> <size>"
+  return
+end
+
+path = ARGV[0]
+size_arg = ARGV[1]
+size = size_arg.to_i
+
+unless size_arg == size.to_s
+  puts "ERROR: size must be an integer"
+  return
+end
+
+if size < 0
+  puts "ERROR: size must be non-negative"
+  return
+end
+
+Machine.signal_self_manage
+
+temp_path = "#{path}.part"
+received = 0
+waited_ms = 0
+timeout_ms = 5000
+
+begin
+  STDIN.raw!
+
+  File.unlink(temp_path) if File.exist?(temp_path)
+  File.open(temp_path, "w") do |file|
+    while received < size
+      chunk = STDIN.read_nonblock([size - received, 256].min)
+      if chunk
+        file.write(chunk)
+        received += chunk.bytesize
+        waited_ms = 0
+      else
+        if timeout_ms <= waited_ms
+          raise "timeout while receiving data"
+        end
+        sleep_ms 1
+        waited_ms += 1
+      end
+    end
+  end
+
+  File.unlink(path) if File.exist?(path)
+  File.rename(temp_path, path)
+  puts "OK"
+rescue => e
+  File.unlink(temp_path) if File.exist?(temp_path)
+  puts "ERROR: #{e.message}"
+ensure
+  STDIN.cooked!
+end

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -26,6 +26,7 @@ timeout_ms = 5000
 
 begin
   STDIN.raw!
+  puts "READY"
 
   File.unlink(temp_path) if File.exist?(temp_path)
   File.open(temp_path, "w") do |file|

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -21,38 +21,51 @@ Machine.signal_self_manage
 
 temp_path = "#{path}.part"
 received = 0
-waited_ms = 0
-read_chunk_size = 1024
-timeout_ms = 5000 + (((size + read_chunk_size - 1) / read_chunk_size) * 1000)
+chunk_size = 256
+chunk_timeout_ms = 5000
+
+read_exact = ->(expected_size) do
+  buffer = +""
+  waited_ms = 0
+
+  while buffer.bytesize < expected_size
+    chunk = STDIN.read_nonblock(expected_size - buffer.bytesize)
+    if chunk && !chunk.empty?
+      buffer << chunk
+      waited_ms = 0
+    else
+      if chunk_timeout_ms <= waited_ms
+        raise "timeout while receiving data (#{received}/#{size} bytes)"
+      end
+      sleep_ms 1
+      waited_ms += 1
+    end
+  end
+
+  buffer
+end
 
 begin
   STDIN.raw!
-  puts "READY"
+  puts "READY chunk=#{chunk_size}"
 
   File.unlink(temp_path) if File.exist?(temp_path)
   File.open(temp_path, "w") do |file|
     while received < size
-      chunk = STDIN.read_nonblock([size - received, read_chunk_size].min)
-      if chunk
-        file.write(chunk)
-        received += chunk.bytesize
-        waited_ms = 0
-      else
-        if timeout_ms <= waited_ms
-          raise "timeout while receiving data (#{received}/#{size} bytes)"
-        end
-        sleep_ms 1
-        waited_ms += 1
-      end
+      expected_size = [size - received, chunk_size].min
+      chunk = read_exact.call(expected_size)
+      file.write(chunk)
+      received += chunk.bytesize
+      puts "ACK #{received}"
     end
   end
 
   File.unlink(path) if File.exist?(path)
   File.rename(temp_path, path)
-  puts "OK"
+  puts "OK #{size}"
 rescue => e
   File.unlink(temp_path) if File.exist?(temp_path)
-  puts "ERROR: #{e.message}"
+  puts "ERR #{e.message}"
 ensure
   STDIN.cooked!
 end

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -22,8 +22,8 @@ Machine.signal_self_manage
 temp_path = "#{path}.part"
 received = 0
 waited_ms = 0
-timeout_ms = 5000
 read_chunk_size = 1024
+timeout_ms = 5000 + (((size + read_chunk_size - 1) / read_chunk_size) * 1000)
 
 begin
   STDIN.raw!
@@ -39,7 +39,7 @@ begin
         waited_ms = 0
       else
         if timeout_ms <= waited_ms
-          raise "timeout while receiving data"
+          raise "timeout while receiving data (#{received}/#{size} bytes)"
         end
         sleep_ms 1
         waited_ms += 1

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -38,19 +38,19 @@ rescue => e
 end
 
 begin
-  if defined?(VFS)
-    volume, = VFS.send(:sanitize_and_split, path)
-    driver = volume && volume[:driver]
-    if driver && driver.respond_to?(:sector_count)
-      counts = driver.sector_count
-      free_blocks = counts[:free] || 0
-      free_bytes = free_blocks * littlefs_block_size
-      if free_bytes < size
-        puts "ERR no space: need=#{size} free=#{free_bytes}"
-        return
-      end
+  vfs = Object.const_get(:VFS)
+  volume, = vfs.send(:sanitize_and_split, path)
+  driver = volume && volume[:driver]
+  if driver && driver.respond_to?(:sector_count)
+    counts = driver.sector_count
+    free_blocks = counts[:free] || 0
+    free_bytes = free_blocks * littlefs_block_size
+    if free_bytes < size
+      puts "ERR no space: need=#{size} free=#{free_bytes}"
+      return
     end
   end
+rescue NameError
 rescue => e
   puts "ERR #{e.message}"
   return

--- a/mrbgems/picoruby-shell/shell_executables/recv.rb
+++ b/mrbgems/picoruby-shell/shell_executables/recv.rb
@@ -1,3 +1,8 @@
+begin
+  require "vfs"
+rescue LoadError
+end
+
 unless ARGV.size == 2
   puts "ERROR: Usage: recv <path> <size>"
   return
@@ -21,8 +26,35 @@ Machine.signal_self_manage
 
 temp_path = "#{path}.part"
 received = 0
-chunk_size = 256
-chunk_timeout_ms = 5000
+chunk_size = 512
+chunk_timeout_ms = 15_000
+littlefs_block_size = 4096
+
+begin
+  File.unlink(temp_path) if File.exist?(temp_path)
+rescue => e
+  puts "ERR #{e.message}"
+  return
+end
+
+begin
+  if defined?(VFS)
+    volume, = VFS.send(:sanitize_and_split, path)
+    driver = volume && volume[:driver]
+    if driver && driver.respond_to?(:sector_count)
+      counts = driver.sector_count
+      free_blocks = counts[:free] || 0
+      free_bytes = free_blocks * littlefs_block_size
+      if free_bytes < size
+        puts "ERR no space: need=#{size} free=#{free_bytes}"
+        return
+      end
+    end
+  end
+rescue => e
+  puts "ERR #{e.message}"
+  return
+end
 
 read_exact = ->(expected_size) do
   buffer = +""
@@ -46,10 +78,10 @@ read_exact = ->(expected_size) do
 end
 
 begin
+  GC.start
   STDIN.raw!
   puts "READY chunk=#{chunk_size}"
 
-  File.unlink(temp_path) if File.exist?(temp_path)
   File.open(temp_path, "w") do |file|
     while received < size
       expected_size = [size - received, chunk_size].min

--- a/mrbgems/picoruby-shell/shell_executables/run.rb
+++ b/mrbgems/picoruby-shell/shell_executables/run.rb
@@ -1,0 +1,25 @@
+RUN_DONE_MARKER = "__PICORUBY_RUN_DONE__"
+
+unless ARGV.size == 1
+  puts "ERROR: Usage: run <path>"
+  puts RUN_DONE_MARKER
+  return
+end
+
+path = ARGV[0]
+
+unless File.file?(path)
+  puts "ERROR: #{path}: No such file"
+  puts RUN_DONE_MARKER
+  return
+end
+
+Machine.signal_self_manage
+
+begin
+  load path
+rescue Exception => e
+  puts "#{e.message} (#{e.class})"
+ensure
+  puts RUN_DONE_MARKER
+end

--- a/tools/generate_serial_transfer_samples.rb
+++ b/tools/generate_serial_transfer_samples.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+require "fileutils"
+
+DEFAULT_OUTPUT_DIR = "/private/tmp/picoruby-serial-transfer-samples"
+
+SAMPLES = [
+  ["sample_12kb.rb", 12 * 1024],
+  ["sample_100kb.rb", 100 * 1024],
+  ["sample_1mb.rb", 1024 * 1024],
+].freeze
+
+output_dir = ARGV[0] || DEFAULT_OUTPUT_DIR
+FileUtils.mkdir_p(output_dir)
+
+def build_sample(name, target_size)
+  header = <<~RUBY
+    module SerialTransferSample
+      NAME = #{name.inspect}
+      TARGET_SIZE = #{target_size}
+
+      def self.summary
+        "\#{NAME} loaded (\#{TARGET_SIZE} bytes target)"
+      end
+    end
+
+  RUBY
+
+  footer = <<~RUBY
+    puts SerialTransferSample.summary
+  RUBY
+
+  body = +""
+  while header.bytesize + body.bytesize + footer.bytesize < target_size
+    remaining = target_size - header.bytesize - body.bytesize - footer.bytesize
+    line = "# #{name} padding #{body.bytesize}\n"
+    body << line.byteslice(0, remaining)
+  end
+
+  sample = header + body + footer
+  sample = sample.byteslice(0, target_size) if sample.bytesize > target_size
+  sample
+end
+
+SAMPLES.each do |name, target_size|
+  path = File.join(output_dir, name)
+  content = build_sample(name, target_size)
+  File.binwrite(path, content)
+  puts "#{path} (#{content.bytesize} bytes)"
+end

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -5,11 +5,13 @@ require "optparse"
 RUN_DONE_MARKER = "__PICORUBY_RUN_DONE__"
 DEFAULT_REMOTE_PATH = "/home/app.rb"
 DEFAULT_BAUD = 115200
+SHELL_PROMPT = "$> "
+RECV_READY_MARKER = "READY"
 
 options = {
   remote_path: DEFAULT_REMOTE_PATH,
   baud: DEFAULT_BAUD,
-  command_delay_ms: 50,
+  command_delay_ms: 200,
 }
 
 parser = OptionParser.new do |opt|
@@ -69,7 +71,13 @@ def drain_input(io)
   end
 end
 
-def read_until_line(io, timeout_ms:)
+def print_sanitized(text)
+  return if text.nil? || text.empty?
+  sanitized = text.gsub("\e", "").gsub(/[^\t\r\n[:print:]]/, "")
+  print sanitized unless sanitized.empty?
+end
+
+def read_until_status(io, timeout_ms:, ok_markers:)
   buffer = +""
   deadline = Time.now + (timeout_ms / 1000.0)
 
@@ -81,14 +89,43 @@ def read_until_line(io, timeout_ms:)
     raise "timeout waiting for response" unless ready
 
     chunk = io.read_nonblock(4096)
-    buffer << chunk if chunk
+    if chunk
+      print_sanitized(chunk)
+      buffer << chunk
+      if buffer.include?("command not found")
+        raise "shell command not found; did you flash the latest serial-runner firmware?"
+      end
+    end
 
     while (idx = buffer.index("\n"))
       line = buffer.slice!(0, idx + 1)
       yield line if block_given?
       stripped = line.strip
-      return stripped if stripped == "OK" || stripped.start_with?("ERROR:")
+      return stripped if ok_markers.include?(stripped) || stripped.start_with?("ERROR:")
     end
+  rescue IO::WaitReadable
+    next
+  end
+end
+
+def wait_for_prompt(io, timeout_ms:, prompt:)
+  buffer = +""
+  deadline = Time.now + (timeout_ms / 1000.0)
+
+  loop do
+    return if buffer.include?(prompt)
+
+    remaining = deadline - Time.now
+    raise "timeout waiting for shell prompt #{prompt.inspect}" if remaining <= 0
+
+    ready = IO.select([io], nil, nil, remaining)
+    raise "timeout waiting for shell prompt #{prompt.inspect}" unless ready
+
+    chunk = io.read_nonblock(4096)
+    next unless chunk
+
+    print_sanitized(chunk)
+    buffer << chunk
   rescue IO::WaitReadable
     next
   end
@@ -108,7 +145,7 @@ def read_until_marker(io, marker, timeout_ms:)
     chunk = io.read_nonblock(4096)
     next unless chunk
 
-    print chunk
+    print_sanitized(chunk)
     buffer << chunk
     return if buffer.include?(marker)
   rescue IO::WaitReadable
@@ -121,13 +158,20 @@ configure_serial!(serial_port, options[:baud])
 File.open(serial_port, "r+") do |io|
   io.sync = true
   drain_input(io)
+  io.write("\n")
+  wait_for_prompt(io, timeout_ms: 3_000, prompt: SHELL_PROMPT)
 
   recv_command = "recv #{options[:remote_path]} #{payload.bytesize}\n"
   io.write(recv_command)
-  sleep(options[:command_delay_ms] / 1000.0)
+  recv_status = read_until_status(io, timeout_ms: 10_000, ok_markers: [RECV_READY_MARKER])
+  unless recv_status == RECV_READY_MARKER
+    warn recv_status
+    exit 1
+  end
+
   io.write(payload)
 
-  recv_result = read_until_line(io, timeout_ms: 10_000)
+  recv_result = read_until_status(io, timeout_ms: 10_000, ok_markers: ["OK"])
   unless recv_result == "OK"
     warn recv_result
     exit 1
@@ -135,5 +179,6 @@ File.open(serial_port, "r+") do |io|
 
   run_command = "run #{options[:remote_path]}\n"
   io.write(run_command)
+  sleep(options[:command_delay_ms] / 1000.0)
   read_until_marker(io, RUN_DONE_MARKER, timeout_ms: 30_000)
 end

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -6,12 +6,13 @@ RUN_DONE_MARKER = "__PICORUBY_RUN_DONE__"
 DEFAULT_REMOTE_PATH = "/home/app.rb"
 DEFAULT_BAUD = 115200
 SHELL_PROMPT = "$> "
-RECV_READY_MARKER = "READY"
 
 options = {
   remote_path: DEFAULT_REMOTE_PATH,
   baud: DEFAULT_BAUD,
   command_delay_ms: 200,
+  chunk_timeout_ms: 5_000,
+  skip_run: false,
 }
 
 parser = OptionParser.new do |opt|
@@ -28,6 +29,14 @@ parser = OptionParser.new do |opt|
   opt.on("--command-delay-ms MS", Integer, "Delay after each shell command before sending payload") do |value|
     options[:command_delay_ms] = value
   end
+
+  opt.on("--chunk-timeout-ms MS", Integer, "Per-chunk ACK timeout in milliseconds (default: #{options[:chunk_timeout_ms]})") do |value|
+    options[:chunk_timeout_ms] = value
+  end
+
+  opt.on("--skip-run", "Upload only; do not run the remote file") do
+    options[:skip_run] = true
+  end
 end
 
 parser.parse!(ARGV)
@@ -42,6 +51,11 @@ end
 
 unless File.file?(local_path)
   warn "File not found: #{local_path}"
+  exit 1
+end
+
+if options[:chunk_timeout_ms] <= 0
+  warn "--chunk-timeout-ms must be positive"
   exit 1
 end
 
@@ -90,7 +104,11 @@ def drain_input(io)
   end
 end
 
-def read_until_status(io, timeout_ms:, ok_markers:)
+def sanitize_serial_text(text)
+  text.gsub("\e", "").gsub(/[^\t\r\n[:print:]]/, "")
+end
+
+def read_transfer_status(io, timeout_ms:)
   buffer = +""
   deadline = Time.now + (timeout_ms / 1000.0)
 
@@ -104,16 +122,16 @@ def read_until_status(io, timeout_ms:, ok_markers:)
     chunk = io.read_nonblock(4096)
     if chunk
       buffer << chunk
-      if buffer.include?("command not found")
-        raise "shell command not found; did you flash the latest serial-runner firmware?"
-      end
     end
 
     while (idx = buffer.index("\n"))
       line = buffer.slice!(0, idx + 1)
-      yield line if block_given?
-      stripped = line.strip
-      return stripped if ok_markers.include?(stripped) || stripped.start_with?("ERROR:")
+      sanitized = sanitize_serial_text(line).strip
+      next if sanitized.empty?
+      if sanitized.include?("command not found")
+        raise "shell command not found; did you flash the latest serial-runner firmware?"
+      end
+      return sanitized if sanitized.start_with?("READY", "ACK ", "OK", "ERR ")
     end
   rescue IO::WaitReadable
     next
@@ -157,7 +175,7 @@ def read_until_marker(io, marker, timeout_ms:, discard_until_newline: false)
     chunk = io.read_nonblock(4096)
     next unless chunk
 
-    sanitized = chunk.gsub("\e", "").gsub(/[^\t\r\n[:print:]]/, "")
+    sanitized = sanitize_serial_text(chunk)
     if discard
       if (idx = sanitized.index("\n"))
         sanitized = sanitized[(idx + 1)..] || ""
@@ -174,6 +192,78 @@ def read_until_marker(io, marker, timeout_ms:, discard_until_newline: false)
   end
 end
 
+def print_transfer_progress(acked_bytes, total_bytes, started_at)
+  elapsed = monotonic_now - started_at
+  percent = total_bytes.zero? ? 100.0 : (acked_bytes * 100.0 / total_bytes)
+  speed = elapsed > 0 ? acked_bytes / elapsed : 0
+  print "\rProgress: #{acked_bytes}/#{total_bytes} bytes (#{format("%.1f", percent)}%) ack=#{acked_bytes} elapsed=#{format_duration(elapsed)} speed=#{format_bytes_per_sec(speed)}"
+  $stdout.flush
+end
+
+def send_chunked_payload(io, payload, chunk_size, chunk_timeout_ms)
+  offset = 0
+  transfer_start = monotonic_now
+  last_ack_offset = 0
+
+  while offset < payload.bytesize
+    chunk = payload.byteslice(offset, [payload.bytesize - offset, chunk_size].min)
+    written = io.write(chunk)
+    raise "short serial write" unless written == chunk.bytesize
+
+    begin
+      status = read_transfer_status(io, timeout_ms: chunk_timeout_ms)
+    rescue => e
+      raise "#{e.message} (last ACK #{last_ack_offset}/#{payload.bytesize} bytes)"
+    end
+    if status.start_with?("ERR ")
+      raise "device error after ACK #{last_ack_offset}: #{status.sub(/\AERR\s+/, "")}"
+    end
+
+    unless status =~ /\AACK (\d+)\z/
+      raise "unexpected transfer status after sending chunk: #{status.inspect}"
+    end
+
+    ack_offset = Regexp.last_match(1).to_i
+    expected_offset = offset + chunk.bytesize
+    unless ack_offset == expected_offset
+      raise "unexpected ACK offset #{ack_offset} (expected #{expected_offset})"
+    end
+
+    last_ack_offset = ack_offset
+    offset = ack_offset
+    print_transfer_progress(last_ack_offset, payload.bytesize, transfer_start)
+  end
+
+  begin
+    final_status = read_transfer_status(io, timeout_ms: chunk_timeout_ms)
+  rescue => e
+    raise "#{e.message} (last ACK #{last_ack_offset}/#{payload.bytesize} bytes)"
+  end
+  puts
+
+  if final_status.start_with?("ERR ")
+    raise "device error after ACK #{last_ack_offset}: #{final_status.sub(/\AERR\s+/, "")}"
+  end
+
+  unless final_status =~ /\AOK (\d+)\z/
+    raise "unexpected final transfer status: #{final_status.inspect}"
+  end
+
+  committed_size = Regexp.last_match(1).to_i
+  unless committed_size == payload.bytesize
+    raise "device committed unexpected size #{committed_size} (expected #{payload.bytesize})"
+  end
+
+  {
+    duration: monotonic_now - transfer_start,
+    ack_offset: last_ack_offset,
+    committed_size: committed_size,
+  }
+rescue => e
+  puts
+  raise "#{e.message}"
+end
+
 configure_serial!(serial_port, options[:baud])
 
 File.open(serial_port, "r+") do |io|
@@ -185,24 +275,18 @@ File.open(serial_port, "r+") do |io|
   puts "Uploading #{local_path} -> #{options[:remote_path]} (#{payload.bytesize} bytes)"
   recv_command = "recv #{options[:remote_path]} #{payload.bytesize}\n"
   io.write(recv_command)
-  recv_status = read_until_status(io, timeout_ms: 10_000, ok_markers: [RECV_READY_MARKER])
-  unless recv_status == RECV_READY_MARKER
+  recv_status = read_transfer_status(io, timeout_ms: 10_000)
+  unless recv_status =~ /\AREADY chunk=(\d+)\z/
     warn recv_status
     exit 1
   end
+  negotiated_chunk_size = Regexp.last_match(1).to_i
   puts recv_status
 
-  transfer_start = monotonic_now
-  io.write(payload)
+  transfer_result = send_chunked_payload(io, payload, negotiated_chunk_size, options[:chunk_timeout_ms])
+  puts "Transfer complete: #{payload.bytesize} bytes in #{format_duration(transfer_result[:duration])} (#{format_bytes_per_sec(payload.bytesize / transfer_result[:duration])})"
 
-  recv_result = read_until_status(io, timeout_ms: 10_000, ok_markers: ["OK"])
-  unless recv_result == "OK"
-    warn recv_result
-    exit 1
-  end
-  transfer_duration = monotonic_now - transfer_start
-  puts recv_result
-  puts "Transfer complete: #{payload.bytesize} bytes in #{format_duration(transfer_duration)} (#{format_bytes_per_sec(payload.bytesize / transfer_duration)})"
+  next if options[:skip_run]
 
   run_command = "run #{options[:remote_path]}\n"
   puts "Running #{options[:remote_path]}"

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -71,12 +71,6 @@ def drain_input(io)
   end
 end
 
-def print_sanitized(text)
-  return if text.nil? || text.empty?
-  sanitized = text.gsub("\e", "").gsub(/[^\t\r\n[:print:]]/, "")
-  print sanitized unless sanitized.empty?
-end
-
 def read_until_status(io, timeout_ms:, ok_markers:)
   buffer = +""
   deadline = Time.now + (timeout_ms / 1000.0)
@@ -90,7 +84,6 @@ def read_until_status(io, timeout_ms:, ok_markers:)
 
     chunk = io.read_nonblock(4096)
     if chunk
-      print_sanitized(chunk)
       buffer << chunk
       if buffer.include?("command not found")
         raise "shell command not found; did you flash the latest serial-runner firmware?"
@@ -124,15 +117,15 @@ def wait_for_prompt(io, timeout_ms:, prompt:)
     chunk = io.read_nonblock(4096)
     next unless chunk
 
-    print_sanitized(chunk)
     buffer << chunk
   rescue IO::WaitReadable
     next
   end
 end
 
-def read_until_marker(io, marker, timeout_ms:)
+def read_until_marker(io, marker, timeout_ms:, discard_until_newline: false)
   buffer = +""
+  discard = discard_until_newline
   deadline = Time.now + (timeout_ms / 1000.0)
 
   loop do
@@ -145,7 +138,16 @@ def read_until_marker(io, marker, timeout_ms:)
     chunk = io.read_nonblock(4096)
     next unless chunk
 
-    print_sanitized(chunk)
+    sanitized = chunk.gsub("\e", "").gsub(/[^\t\r\n[:print:]]/, "")
+    if discard
+      if (idx = sanitized.index("\n"))
+        sanitized = sanitized[(idx + 1)..] || ""
+        discard = false
+      else
+        sanitized = ""
+      end
+    end
+    print sanitized unless sanitized.empty?
     buffer << chunk
     return if buffer.include?(marker)
   rescue IO::WaitReadable
@@ -168,6 +170,7 @@ File.open(serial_port, "r+") do |io|
     warn recv_status
     exit 1
   end
+  puts recv_status
 
   io.write(payload)
 
@@ -176,9 +179,10 @@ File.open(serial_port, "r+") do |io|
     warn recv_result
     exit 1
   end
+  puts recv_result
 
   run_command = "run #{options[:remote_path]}\n"
   io.write(run_command)
   sleep(options[:command_delay_ms] / 1000.0)
-  read_until_marker(io, RUN_DONE_MARKER, timeout_ms: 30_000)
+  read_until_marker(io, RUN_DONE_MARKER, timeout_ms: 30_000, discard_until_newline: true)
 end

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+
+RUN_DONE_MARKER = "__PICORUBY_RUN_DONE__"
+DEFAULT_REMOTE_PATH = "/home/app.rb"
+DEFAULT_BAUD = 115200
+
+options = {
+  remote_path: DEFAULT_REMOTE_PATH,
+  baud: DEFAULT_BAUD,
+  command_delay_ms: 50,
+}
+
+parser = OptionParser.new do |opt|
+  opt.banner = "Usage: ruby tools/r2p2_serial_run.rb <serial_port> <local_file> [options]"
+
+  opt.on("--remote-path PATH", "Destination path on Pico (default: #{DEFAULT_REMOTE_PATH})") do |value|
+    options[:remote_path] = value
+  end
+
+  opt.on("--baud RATE", Integer, "Baud rate (default: #{DEFAULT_BAUD})") do |value|
+    options[:baud] = value
+  end
+
+  opt.on("--command-delay-ms MS", Integer, "Delay after each shell command before sending payload") do |value|
+    options[:command_delay_ms] = value
+  end
+end
+
+parser.parse!(ARGV)
+
+serial_port = ARGV[0]
+local_path = ARGV[1]
+
+unless serial_port && local_path
+  warn parser.banner
+  exit 1
+end
+
+unless File.file?(local_path)
+  warn "File not found: #{local_path}"
+  exit 1
+end
+
+payload = File.binread(local_path)
+
+def configure_serial!(path, baud)
+  port_flag = RUBY_PLATFORM.include?("darwin") ? "-f" : "-F"
+  command = [
+    "stty", port_flag, path,
+    baud.to_s,
+    "raw",
+    "-echo",
+    "-icanon",
+    "min", "0",
+    "time", "0"
+  ]
+  success = system(*command)
+  raise "failed to configure serial device: #{path}" unless success
+end
+
+def drain_input(io)
+  loop do
+    chunk = io.read_nonblock(4096)
+    break if chunk.nil? || chunk.empty?
+  rescue IO::WaitReadable, EOFError
+    break
+  end
+end
+
+def read_until_line(io, timeout_ms:)
+  buffer = +""
+  deadline = Time.now + (timeout_ms / 1000.0)
+
+  loop do
+    remaining = deadline - Time.now
+    raise "timeout waiting for response" if remaining <= 0
+
+    ready = IO.select([io], nil, nil, remaining)
+    raise "timeout waiting for response" unless ready
+
+    chunk = io.read_nonblock(4096)
+    buffer << chunk if chunk
+
+    while (idx = buffer.index("\n"))
+      line = buffer.slice!(0, idx + 1)
+      yield line if block_given?
+      stripped = line.strip
+      return stripped if stripped == "OK" || stripped.start_with?("ERROR:")
+    end
+  rescue IO::WaitReadable
+    next
+  end
+end
+
+def read_until_marker(io, marker, timeout_ms:)
+  buffer = +""
+  deadline = Time.now + (timeout_ms / 1000.0)
+
+  loop do
+    remaining = deadline - Time.now
+    raise "timeout waiting for run output" if remaining <= 0
+
+    ready = IO.select([io], nil, nil, remaining)
+    raise "timeout waiting for run output" unless ready
+
+    chunk = io.read_nonblock(4096)
+    next unless chunk
+
+    print chunk
+    buffer << chunk
+    return if buffer.include?(marker)
+  rescue IO::WaitReadable
+    next
+  end
+end
+
+configure_serial!(serial_port, options[:baud])
+
+File.open(serial_port, "r+") do |io|
+  io.sync = true
+  drain_input(io)
+
+  recv_command = "recv #{options[:remote_path]} #{payload.bytesize}\n"
+  io.write(recv_command)
+  sleep(options[:command_delay_ms] / 1000.0)
+  io.write(payload)
+
+  recv_result = read_until_line(io, timeout_ms: 10_000)
+  unless recv_result == "OK"
+    warn recv_result
+    exit 1
+  end
+
+  run_command = "run #{options[:remote_path]}\n"
+  io.write(run_command)
+  read_until_marker(io, RUN_DONE_MARKER, timeout_ms: 30_000)
+end

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -47,6 +47,25 @@ end
 
 payload = File.binread(local_path)
 
+def monotonic_now
+  Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end
+
+def format_bytes_per_sec(bytes_per_sec)
+  return "0 B/s" if bytes_per_sec <= 0
+  if bytes_per_sec >= 1024 * 1024
+    format("%.2f MiB/s", bytes_per_sec / (1024.0 * 1024.0))
+  elsif bytes_per_sec >= 1024
+    format("%.2f KiB/s", bytes_per_sec / 1024.0)
+  else
+    format("%.0f B/s", bytes_per_sec)
+  end
+end
+
+def format_duration(seconds)
+  format("%.3fs", seconds)
+end
+
 def configure_serial!(path, baud)
   port_flag = RUBY_PLATFORM.include?("darwin") ? "-f" : "-F"
   command = [
@@ -163,6 +182,7 @@ File.open(serial_port, "r+") do |io|
   io.write("\n")
   wait_for_prompt(io, timeout_ms: 3_000, prompt: SHELL_PROMPT)
 
+  puts "Uploading #{local_path} -> #{options[:remote_path]} (#{payload.bytesize} bytes)"
   recv_command = "recv #{options[:remote_path]} #{payload.bytesize}\n"
   io.write(recv_command)
   recv_status = read_until_status(io, timeout_ms: 10_000, ok_markers: [RECV_READY_MARKER])
@@ -172,6 +192,7 @@ File.open(serial_port, "r+") do |io|
   end
   puts recv_status
 
+  transfer_start = monotonic_now
   io.write(payload)
 
   recv_result = read_until_status(io, timeout_ms: 10_000, ok_markers: ["OK"])
@@ -179,10 +200,16 @@ File.open(serial_port, "r+") do |io|
     warn recv_result
     exit 1
   end
+  transfer_duration = monotonic_now - transfer_start
   puts recv_result
+  puts "Transfer complete: #{payload.bytesize} bytes in #{format_duration(transfer_duration)} (#{format_bytes_per_sec(payload.bytesize / transfer_duration)})"
 
   run_command = "run #{options[:remote_path]}\n"
+  puts "Running #{options[:remote_path]}"
   io.write(run_command)
   sleep(options[:command_delay_ms] / 1000.0)
+  run_start = monotonic_now
   read_until_marker(io, RUN_DONE_MARKER, timeout_ms: 30_000, discard_until_newline: true)
+  run_duration = monotonic_now - run_start
+  puts "Run complete in #{format_duration(run_duration)}"
 end

--- a/tools/r2p2_serial_run.rb
+++ b/tools/r2p2_serial_run.rb
@@ -11,7 +11,7 @@ options = {
   remote_path: DEFAULT_REMOTE_PATH,
   baud: DEFAULT_BAUD,
   command_delay_ms: 200,
-  chunk_timeout_ms: 5_000,
+  chunk_timeout_ms: 15_000,
   skip_run: false,
 }
 
@@ -276,6 +276,10 @@ File.open(serial_port, "r+") do |io|
   recv_command = "recv #{options[:remote_path]} #{payload.bytesize}\n"
   io.write(recv_command)
   recv_status = read_transfer_status(io, timeout_ms: 10_000)
+  if recv_status.start_with?("ERR ")
+    warn recv_status
+    exit 1
+  end
   unless recv_status =~ /\AREADY chunk=(\d+)\z/
     warn recv_status
     exit 1


### PR DESCRIPTION
## Summary

This PR adds a minimal USB serial upload/run workflow for R2P2-based targets.

It introduces two shell commands:

- `recv <path> <size>`
- `run <path>`

It also adds a host-side helper script under `tools/` that:

- opens the serial port
- uploads a local Ruby file to `/home/app.rb`
- runs `/home/app.rb`
- reads output until `__PICORUBY_RUN_DONE__`

## What changed

- added `recv` shell command
- added `run` shell command
- made `run` always print `__PICORUBY_RUN_DONE__`
- added `tools/r2p2_serial_run.rb`
- added `examples/hello.rb` for smoke testing
- documented the workflow in `picoruby-shell` README

## Verification

Built and manually tested on Pico 2 W.

Confirmed:

- `rake r2p2:picoruby:pico2_w:prod` builds successfully
- `recv` can transfer `examples/hello.rb` to `/home/app.rb`
- `run /home/app.rb` executes successfully on Pico
- `puts` output is shown on the host side
- `__PICORUBY_RUN_DONE__` can be detected reliably

## Notes

This is intentionally minimal and focused on quick iteration for Ruby source files over USB serial.

It does not yet add:

- richer file management commands
- an IDE integration
- a higher-level GUI workflow
- binary protocol framing beyond the current size-based upload
