### PR TITLE
Fix Sandbox#execute re-running previous script after suspend in method

### DIFF
--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -149,8 +149,8 @@ mrb_sandbox_execute(mrb_state *mrb, mrb_value self)
   mrc_resolve_intern(ss->cc, ss->irep);
   struct RProc *proc = mrb_proc_new(mrb, (const mrb_irep *)ss->irep);
   proc->e.target_class = mrb->object_class;
-  mrb_task_proc_set(mrb, ss->task, proc);
   mrb_task_reset_context(mrb, ss->task);
+  mrb_task_proc_set(mrb, ss->task, proc);
 
   mrb_resume_task(mrb, ss->task);
   return mrb_true_value();

--- a/mrbgems/picoruby-sandbox/test/sandbox_test.rb
+++ b/mrbgems/picoruby-sandbox/test/sandbox_test.rb
@@ -1,0 +1,25 @@
+class SandboxTest < Picotest::Test
+  # Regression test for sandbox re-running the previous script
+  # when its task was suspended inside a method call.
+  def test_execute_runs_new_script_after_suspend_in_method
+    sandbox = Sandbox.new
+
+    assert sandbox.compile <<~RUBY
+      def suspend_in_method
+        Task.current.suspend
+      end
+      suspend_in_method
+      :old
+    RUBY
+    sandbox.execute
+    sandbox.wait(timeout: nil)
+
+    assert sandbox.compile <<~RUBY
+      :new
+    RUBY
+    sandbox.execute
+    sandbox.wait(timeout: nil)
+
+    assert_equal :new, sandbox.result
+  end
+end


### PR DESCRIPTION
## Summary

Fix `Sandbox#execute` so that, after the previous script suspended inside a method call, the next execute runs the newly compiled script instead of re-running the previous one.

## Problem

When a task is suspended while inside a nested method call, the next script is silently ignored and the previous one runs again. This typically happens via Ctrl-C during IRB.

Here is the minimum code that reproduces the problem:

```ruby
sandbox = Sandbox.new
sandbox.compile <<~RUBY
  def suspend_in_method
    Task.current.suspend
  end
  suspend_in_method
  :old
RUBY
sandbox.execute
sandbox.wait(timeout: nil)

sandbox.compile ":new"
sandbox.execute
sandbox.wait(timeout: nil)

sandbox.result  # => :old (expected :new)
```

This problem affects only PicoRuby (mruby), not FemtoRuby (mruby/c).

## Cause

In `mrb_sandbox_execute`, the previous implementation called:

```c
mrb_task_proc_set(mrb, ss->task, proc);
mrb_task_reset_context(mrb, ss->task);
```

- `mrb_task_proc_set` writes the proc onto the task's current call frame (`c.ci`).
- `mrb_task_reset_context` moves `c.ci` to `cibase`.

When the previous run suspended inside a method call, `c.ci` is not at `cibase` but in a nested call frame. The new proc lands on that nested frame, and `reset_context` then moves `c.ci` back to `cibase`. Since `cibase` still holds the previous proc and entry PC, the scheduler resumes the task with the old code.

## Fix

Swap `mrb_task_proc_set` and `mrb_task_reset_context` so `reset_context` places `c.ci` on `cibase` first, then `proc_set` writes to `cibase`.

## Alternative considered

mruby/c uses `mrbc_load_mrb` + `reset_vm`, where `reset_vm` explicitly re-points `cur_irep` to `top_irep`.

In contrast, `mrb_task_reset_context` does not reset the call stack. Aligning mruby with mruby/c would require storing the top proc in the task struct.

This PR is the minimal fix. I'm happy to take the mruby-task modification approach if preferred.
