### PR TITLE
Replace CONFIG_ESP_WIFI_ENABLED with USE_WIFI for Wi-Fi feature toggling

### DIFF
--- a/mrbgems/picoruby-esp32/include/esp32.h
+++ b/mrbgems/picoruby-esp32/include/esp32.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_ESP_WIFI_ENABLED)
+#if defined(USE_WIFI)
 int ESP32_WIFI_init();
 int ESP32_WIFI_initialized();
 int ESP32_WIFI_connect_timeout(const char* ssid, const char* password, int auth, int timeout_ms);

--- a/mrbgems/picoruby-esp32/ports/esp32.c
+++ b/mrbgems/picoruby-esp32/ports/esp32.c
@@ -1,4 +1,4 @@
-#if defined(CONFIG_ESP_WIFI_ENABLED)
+#if defined(USE_WIFI)
 
 #include <string.h>
 #include "esp_wifi.h"

--- a/mrbgems/picoruby-esp32/src/mruby/esp32.c
+++ b/mrbgems/picoruby-esp32/src/mruby/esp32.c
@@ -10,7 +10,7 @@ static struct RClass *ConnectTimeout;
 static mrb_value
 c_esp32_wifi_initialized(mrb_state *mrb, mrb_value self)
 {
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   if (ESP32_WIFI_initialized()) {
     return mrb_true_value();
   } else {
@@ -24,7 +24,7 @@ c_esp32_wifi_initialized(mrb_state *mrb, mrb_value self)
 static mrb_value
 c_esp32_wifi_init(mrb_state *mrb, mrb_value self)
 {
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   if (ESP32_WIFI_init() == 0) {
     return mrb_true_value();
   } else {
@@ -35,7 +35,7 @@ c_esp32_wifi_init(mrb_state *mrb, mrb_value self)
   #endif
 }
 
-#if defined(CONFIG_ESP_WIFI_ENABLED)
+#if defined(USE_WIFI)
 
 static mrb_value
 c_esp32_wifi_connect_timeout(mrb_state *mrb, mrb_value self)
@@ -90,7 +90,7 @@ mrb_picoruby_esp32_gem_init(mrb_state *mrb)
   struct RClass *class_WiFi = mrb_define_class_under_id(mrb, class_ESP32, MRB_SYM(WiFi), mrb->object_class);
   mrb_define_class_method_id(mrb, class_WiFi, MRB_SYM(_init), c_esp32_wifi_init, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_WiFi, MRB_SYM_Q(initialized), c_esp32_wifi_initialized, MRB_ARGS_NONE());
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   mrb_define_class_method_id(mrb, class_WiFi, MRB_SYM(connect_timeout), c_esp32_wifi_connect_timeout, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method_id(mrb, class_WiFi, MRB_SYM(disconnect), c_esp32_wifi_disconnect, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_WiFi, MRB_SYM(tcpip_link_status), c_esp32_wifi_tcpip_link_status, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-esp32/src/mrubyc/esp32.c
+++ b/mrbgems/picoruby-esp32/src/mrubyc/esp32.c
@@ -7,7 +7,7 @@ static mrbc_class *ConnectTimeout;
 static void
 c_esp32_wifi_init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   if (ESP32_WIFI_init() == 0) {
     SET_TRUE_RETURN();
   } else {
@@ -21,7 +21,7 @@ c_esp32_wifi_init(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c_esp32_wifi_initialized(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   if (ESP32_WIFI_initialized()) {
     SET_TRUE_RETURN();
   } else {
@@ -32,7 +32,7 @@ c_esp32_wifi_initialized(mrbc_vm *vm, mrbc_value *v, int argc)
   #endif
 }
 
-#if defined(CONFIG_ESP_WIFI_ENABLED)
+#if defined(USE_WIFI)
 
 static void
 c_esp32_wifi_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
@@ -87,7 +87,7 @@ mrbc_esp32_init(mrbc_vm *vm)
   mrbc_class *class_WiFi = mrbc_define_class_under(vm, class_ESP32, "WiFi", mrbc_class_object);
   mrbc_define_method(vm, class_WiFi, "_init", c_esp32_wifi_init);
   mrbc_define_method(vm, class_WiFi, "initialized?", c_esp32_wifi_initialized);
-  #if defined(CONFIG_ESP_WIFI_ENABLED)
+  #if defined(USE_WIFI)
   mrbc_define_method(vm, class_WiFi, "connect_timeout", c_esp32_wifi_connect_timeout);
   mrbc_define_method(vm, class_WiFi, "disconnect", c_esp32_wifi_disconnect);
   mrbc_define_method(vm, class_WiFi, "tcpip_link_status", c_esp32_wifi_tcpip_link_status);


### PR DESCRIPTION
## Summary

`CONFIG_ESP_WIFI_ENABLED` is an ESP-IDF Kconfig symbol that is fixed by the SoC's hardware capabilities. On Wi-Fi-capable chips such as ESP32-S3, it is always set and cannot be disabled by the user. This made it impossible to build a firmware image without Wi-Fi support on those targets.

This PR replaces all occurrences of `CONFIG_ESP_WIFI_ENABLED` with `USE_WIFI` — a user-defined preprocessor flag that follows the same convention already used on RP2040. Wi-Fi support can now be selectively enabled or disabled at build time regardless of the target SoC.

## Changes

- `mrbgems/picoruby-esp32/include/esp32.h` — guard with `USE_WIFI`
- `mrbgems/picoruby-esp32/ports/esp32.c` — guard with `USE_WIFI`
- `mrbgems/picoruby-esp32/src/mruby/esp32.c` — all guards replaced
- `mrbgems/picoruby-esp32/src/mrubyc/esp32.c` — all guards replaced

## Migration

Define `USE_WIFI` in your build system (e.g., via `-DUSE_WIFI` in `CFLAGS` or the equivalent CMake variable) to enable Wi-Fi support. Omit it to build without Wi-Fi, even on SoCs that have Wi-Fi hardware.
