### PR TITLE
Fix picorb_hal_idle_cpu signature for mruby/mrubyc compatibility

### DIFF
--- a/mrbgems/picoruby-machine/ports/esp32/machine.c
+++ b/mrbgems/picoruby-machine/ports/esp32/machine.c
@@ -147,7 +147,11 @@ picorb_hal_disable_irq(void)
 }
 
 void
-picorb_hal_idle_cpu(void)
+#if defined(PICORB_VM_MRUBYC)
+picorb_hal_idle_cpu()
+#elif defined(PICORB_VM_MRUBY)
+picorb_hal_idle_cpu(mrb_state *mrb)
+#endif
 {
   vTaskDelay(1);
 }


### PR DESCRIPTION
Add preprocessor guards to picorb_hal_idle_cpu() so it takes mrb_state *mrb parameter for mruby and no argument for mrubyc, consistent with other HAL functions.