### PR TITLE
Allow setting source filename when compiling in Sandbox

### DIFF
--- a/mrbgems/picoruby-sandbox/mrblib/sandbox.rb
+++ b/mrbgems/picoruby-sandbox/mrblib/sandbox.rb
@@ -21,7 +21,7 @@ class Sandbox
         if rb.start_with?("RITE") # not valid RITE version
           raise RuntimeError, "#{path}: invalid RITE version: #{rb.byteslice(0, 8)}"
         end
-        unless compile(rb)
+        unless compile(rb, filename: path)
           raise RuntimeError, "#{path}: compile failed"
         end
         execute

--- a/mrbgems/picoruby-sandbox/sig/sandbox.rbs
+++ b/mrbgems/picoruby-sandbox/sig/sandbox.rbs
@@ -8,7 +8,7 @@ class Sandbox
   attr_accessor error: Exception?
 
   def self.new: (?String name) -> Sandbox
-  def compile: (String script, ?remove_lv: bool) -> bool
+  def compile: (String script, ?remove_lv: bool, ?filename: String?) -> bool
   def compile_from_memory: (Integer address, Integer size, ?remove_lv: bool) -> bool
   def resume: () -> bool
   def suspend: () -> bool

--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -303,7 +303,7 @@ mrb_picoruby_sandbox_gem_init(mrb_state *mrb)
   MRB_SET_INSTANCE_TT(class_Sandbox, MRB_TT_CDATA);
 
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(initialize), mrb_sandbox_initialize, MRB_ARGS_OPT(1));
-  mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile), mrb_sandbox_compile, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(2,1));
+  mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile), mrb_sandbox_compile, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(2,0));
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile_from_memory), mrb_sandbox_compile_from_memory, MRB_ARGS_REQ(2)|MRB_ARGS_KEY(1,1));
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(resume), mrb_sandbox_resume, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(execute), mrb_sandbox_execute, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -61,11 +61,12 @@ mrb_sandbox_initialize(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_bool
-sandbox_compile_sub(mrb_state *mrb, SandboxState *ss, const uint8_t *script, const size_t size, mrb_value remove_lv)
+sandbox_compile_sub(mrb_state *mrb, SandboxState *ss, const uint8_t *script, const size_t size, mrb_value remove_lv, const char *filename)
 {
   free_ccontext(ss);
   init_options(ss->options);
   ss->cc = mrc_ccontext_new(mrb);
+  if (filename) mrc_ccontext_filename(ss->cc, filename);
   ss->cc->options = ss->options;
   // TODO: Ask Matz
   if (ss->irep) mrb_irep_decref(mrb, (struct mrb_irep *)ss->irep);
@@ -91,16 +92,24 @@ mrb_sandbox_compile(mrb_state *mrb, mrb_value self)
   const char *script;
   mrb_int script_len;
 
-  uint32_t kw_num = 1;
+  uint32_t kw_num = 2;
   uint32_t kw_required = 0;
-  mrb_sym kw_names[] = { MRB_SYM(remove_lv) };
+  mrb_sym kw_names[] = { MRB_SYM(remove_lv), MRB_SYM(filename) };
   mrb_value kw_values[kw_num];
   mrb_kwargs kwargs = { kw_num, kw_required, kw_names, kw_values, NULL };
 
   mrb_get_args(mrb, "s:", &script, &script_len, &kwargs);
   if (mrb_undef_p(kw_values[0])) { kw_values[0] = mrb_false_value(); }
 
-  if (!sandbox_compile_sub(mrb, ss, (const uint8_t *)script, (const size_t)script_len, kw_values[0])) {
+  const char *filename = NULL;
+  if (!mrb_undef_p(kw_values[1]) && !mrb_nil_p(kw_values[1])) {
+    filename = mrb_string_cstr(mrb, kw_values[1]);
+    if (strlen(filename) >= UINT16_MAX) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "filename too long");
+    }
+  }
+
+  if (!sandbox_compile_sub(mrb, ss, (const uint8_t *)script, (const size_t)script_len, kw_values[0], filename)) {
     return mrb_false_value();
   }
   return mrb_true_value();
@@ -128,7 +137,7 @@ mrb_sandbox_compile_from_memory(mrb_state *mrb, mrb_value self)
   }
   if (mrb_undef_p(kw_values[0])) { kw_values[0] = mrb_false_value(); }
 
-  if (!sandbox_compile_sub(mrb, ss, (const uint8_t *)(uintptr_t)address, size, kw_values[0])) {
+  if (!sandbox_compile_sub(mrb, ss, (const uint8_t *)(uintptr_t)address, size, kw_values[0], NULL)) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to compile script");
   }
   return mrb_true_value();
@@ -294,7 +303,7 @@ mrb_picoruby_sandbox_gem_init(mrb_state *mrb)
   MRB_SET_INSTANCE_TT(class_Sandbox, MRB_TT_CDATA);
 
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(initialize), mrb_sandbox_initialize, MRB_ARGS_OPT(1));
-  mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile), mrb_sandbox_compile, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(1,1));
+  mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile), mrb_sandbox_compile, MRB_ARGS_REQ(1)|MRB_ARGS_KEY(2,1));
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(compile_from_memory), mrb_sandbox_compile_from_memory, MRB_ARGS_REQ(2)|MRB_ARGS_KEY(1,1));
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(resume), mrb_sandbox_resume, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_Sandbox, MRB_SYM(execute), mrb_sandbox_execute, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-sandbox/src/mrubyc/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mrubyc/sandbox.c
@@ -93,12 +93,13 @@ c_sandbox_suspend(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
-sandbox_compile_sub(mrbc_vm *vm, mrbc_value *v, uint8_t *script, size_t size)
+sandbox_compile_sub(mrbc_vm *vm, mrbc_value *v, uint8_t *script, size_t size, const char *filename)
 {
   SS();
   free_ccontext(ss);
   init_options(ss->options);
   ss->cc = mrc_ccontext_new(NULL);
+  if (filename) mrc_ccontext_filename(ss->cc, filename);
   ss->cc->options = ss->options;
   ss->irep = mrc_load_string_cxt(ss->cc, (const uint8_t **)&script, size);
   if (ss->irep) mrc_irep_remove_lv(ss->cc, ss->irep);
@@ -125,7 +126,24 @@ c_sandbox_compile(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   uint8_t *script = GET_STRING_ARG(1);
   size_t size = strlen((const char *)script);
-  sandbox_compile_sub(vm, v, script, size);
+
+  MRBC_KW_ARG(filename);
+  const char *fn = NULL;
+  if (MRBC_KW_ISVALID(filename)) {
+    if (mrbc_type(filename) != MRBC_TT_STRING) {
+      MRBC_KW_DELETE(filename);
+      mrbc_raise(vm, MRBC_CLASS(TypeError), "filename must be String");
+      return;
+    }
+    fn = (const char *)mrbc_string_cstr(&filename);
+    if (strlen(fn) >= UINT16_MAX) {
+      MRBC_KW_DELETE(filename);
+      mrbc_raise(vm, MRBC_CLASS(ArgumentError), "filename too long");
+      return;
+    }
+  }
+  sandbox_compile_sub(vm, v, script, size, fn);
+  MRBC_KW_DELETE(filename);
 }
 
 static void
@@ -133,7 +151,7 @@ c_sandbox_compile_from_memory(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   uint8_t *script = (uint8_t *)(intptr_t)GET_INT_ARG(1);
   size_t size = GET_INT_ARG(2);
-  sandbox_compile_sub(vm, v, script, size);
+  sandbox_compile_sub(vm, v, script, size, NULL);
 }
 
 static void

--- a/mrbgems/picoruby-sandbox/test/sandbox_test.rb
+++ b/mrbgems/picoruby-sandbox/test/sandbox_test.rb
@@ -1,4 +1,35 @@
 class SandboxTest < Picotest::Test
+  def test_compile_with_filename
+    sandbox = Sandbox.new
+    sandbox.compile("__FILE__", filename: "/myscript.rb")
+    sandbox.execute
+    sandbox.wait(timeout: nil)
+    assert_equal "/myscript.rb", sandbox.result
+  end
+
+  class FileDouble
+    def initialize(content)
+      @content = content
+    end
+
+    def read
+      r = @content
+      @content = nil
+      r
+    end
+
+    def close
+    end
+  end
+
+  def test_load_file
+    stub(File).open { FileDouble.new("__FILE__") }
+    sandbox = Sandbox.new
+    sandbox.load_file("/myscript.rb")
+    assert_nil sandbox.error
+    assert_equal "/myscript.rb", sandbox.result
+  end
+
   # Regression test for sandbox re-running the previous script
   # when its task was suspended inside a method call.
   def test_execute_runs_new_script_after_suspend_in_method

--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -482,7 +482,7 @@ class Shell
         when "quit", "exit"
           break
         else
-          if buffer.lines[-1][-1] == "\\" || !sandbox.compile("begin; _ = (#{script}); rescue Exception => _; end; _")
+          if buffer.lines[-1][-1] == "\\" || !sandbox.compile("begin; _ = (#{script}); rescue Exception => _; end; _", filename: "(irb)")
             buffer.put :ENTER
           else
             editor.feed_at_bottom


### PR DESCRIPTION
Add a `filename:` keyword to `Sandbox#compile` so that the file name can be
set through `mrc_ccontext_filename` at compile time. With this, `__FILE__`
and backtraces in the compiled script reflect the actual source path
instead of the compiler default (`"-e"`).

Changes:

- `Sandbox#compile(script, filename: path)` accepts a filename
- `Sandbox#load_file` forwards the file path as `filename:` to `compile`
- `Shell#run_irb` passes `filename: "(irb)"` so the IRB error backtrace
  shows `(irb):N:in '...'` like CRuby's IRB
- Add a UINT16_MAX length guard matching the filename handling in
  `picoruby-eval`