### PR TITLE
Memoize `sandbox.result` in `Shell#run_irb`

### DIFF
--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -494,10 +494,11 @@ class Shell
               sandbox.suspend
             end
             if executed
-              if sandbox.result.is_a?(Exception)
-                puts "#{sandbox.result.message} (#{sandbox.result.class})"
+              result = sandbox.result
+              if result.is_a?(Exception)
+                puts "#{result.message} (#{result.class})"
               else
-                puts "=> #{sandbox.result.inspect}"
+                puts "=> #{result.inspect}"
               end
             end
             buffer.clear


### PR DESCRIPTION
This PR makes `Shell#run_irb` to memoize `sandbox.result`.

`Sandbox#result` was called two or three times in `Shell#run_irb`. On mruby (PicoRuby), `Sandbox#result` allocates and frees memory. Thus, this PR may also reduces memory fragmentation. 