### PR TITLE
Bound per-read request in PicoModem.read_exact to keep small-stack builds safe

### DIFF
--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -37,6 +37,8 @@ module PicoModem
 
   CHUNK_SIZE = 480
   TIMEOUT_MS = 5000
+  # Cap per-call read_nonblock so io-console's caller-sized stack VLA stays small on ESP32/mruby-c.
+  READ_NONBLOCK_MAX = 64
 
   # Run a PicoModem session: read frames, dispatch commands, return to shell
   def self.session(io_in, io_out)
@@ -132,7 +134,9 @@ module PicoModem
     buf = ""
     waited = 0
     while buf.bytesize < n
-      chunk = io.read_nonblock(n - buf.bytesize)
+      want = n - buf.bytesize
+      want = READ_NONBLOCK_MAX if READ_NONBLOCK_MAX < want
+      chunk = io.read_nonblock(want)
       if chunk
         buf << chunk
         waited = 0

--- a/mrbgems/picoruby-picomodem/sig/picomodem.rbs
+++ b/mrbgems/picoruby-picomodem/sig/picomodem.rbs
@@ -19,6 +19,7 @@ module PicoModem
 
   CHUNK_SIZE: Integer
   TIMEOUT_MS: Integer
+  READ_NONBLOCK_MAX: Integer
 
   def self.session: (IO io_in, IO io_out) -> void
   def self.recv_frame: (IO io) -> [Integer, String]?


### PR DESCRIPTION
## Summary

On small-stack builds (ESP32/Xtensa, mruby/c) a 480 B `CHUNK` upload fails (silent "Timeout at offset 0"): `recv_frame` requests the whole frame in one `read_nonblock(length + 2)` call, and `read_nonblock` allocates a caller-sized stack VLA (`char buf[maxlen + 1]`, ~484 B). RP2040/RP2350 have more stack headroom and upload 480 B fine; capping the request fixes ESP32 — consistent with the per-read allocation exceeding the task stack.

This PR caps the per-call request in `read_exact` to `READ_NONBLOCK_MAX = 64`. `CHUNK_SIZE` and the on-wire chunk stay 480 B; only the per-read granularity changes, and `read_exact` still reassembles the full frame.

## Verification

RuntimeGems `.mrb` upload (CRC32-verified + `require` => true): ESP32/AtomMatrix (mruby/c) now passes; RP2040 (mruby/c) and Pico2W (mruby) unchanged.

---

Note: more broadly, `read_nonblock` sizes a stack VLA (`char buf[maxlen + 1]` in `picoruby-io-console/src/{mruby,mrubyc}/io-console.c`) by the caller's `maxlen` with no upper bound, so a large request can cause a stack overflow on small-stack builds. Bounding it there would cover every caller, but as it spans both VMs I'd rather raise it for discussion than change it here.
