### PR TITLE
Protect the GATT profile (ATT DB) from GC

### DIFF
--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -124,7 +124,7 @@ mrb__init(mrb_state *mrb, mrb_value self)
 
   if (mrb_string_p(profile)) {
     /* Protect profile_data from GC */
-    //mrbc_incref(&v[1]);
+    mrb_gc_register(mrb, profile);
     profile_data = (const uint8_t *)RSTRING_PTR(profile);
   } else if (mrb_nil_p(profile)) {
     profile_data = NULL;


### PR DESCRIPTION
`BLE._init` hands btstack the raw RSTRING_PTR of the GATT profile String and keeps using it for the whole connection, but never pinned the String.
Under allocation pressure mruby's GC reclaims it, the ATT DB pointer dangles, att_find_handle stops resolving the characteristic handles, and incoming central->peripheral writes silently stop being delivered to the app.