### PR TITLE
Use get_rand_32() instead of hand-rolling ROSC-based RNG

### DIFF
--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -156,6 +156,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   pico_stdio
   pico_stdio_uart
   pico_bootsel_via_double_reset
+  pico_rand
   tinyusb_device
   tinyusb_board
   hardware_flash

--- a/mrbgems/picoruby-rng/ports/rp2040/rng.c
+++ b/mrbgems/picoruby-rng/ports/rp2040/rng.c
@@ -1,20 +1,9 @@
 #include "../../include/rng.h"
-#include "hardware/structs/rosc.h"
-#include "pico/time.h"
+#include "pico/rand.h"
 
-uint8_t rng_random_byte_impl(void)
+uint8_t
+rng_random_byte_impl(void)
 {
-  uint32_t random = 0;
-  uint32_t bit = 0;
-  for (int i = 0; i < 8; i++) {
-    while (true) {
-      bit = rosc_hw->randombit;
-      sleep_us(5);
-      if (bit != rosc_hw->randombit)
-        break;
-    }
-    random = (random << 1) | bit;
-    sleep_us(5);
-  }
+  uint32_t random = get_rand_32();
   return (uint8_t) random;
 }


### PR DESCRIPTION
This modifies the RNG picogem so that it uses get_rand_32() instead of the hand-written ring-oscillator-based RNG.

- In RP2040, this compiles into almost the same ROSC-based code.
- In RP2350, this compiles to using TRNG supported by the hardware. Not only does this make it more secure, this eliminates the need for `sleep_us(5)` on every bit.