### PR TITLE
Fix dangling pointer of BLE profile

### DIFF
--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -119,16 +119,11 @@ mrb__init(mrb_state *mrb, mrb_value self)
   mrb_gc_register(mrb, read_values);
 
   mrb_value profile;
-  const uint8_t *profile_data;
+  mrb_value profile_copy = mrb_nil_value();
+  const uint8_t *profile_data = NULL;
   mrb_get_args(mrb, "o", &profile);
 
-  if (mrb_string_p(profile)) {
-    /* Protect profile_data from GC */
-    //mrbc_incref(&v[1]);
-    profile_data = (const uint8_t *)RSTRING_PTR(profile);
-  } else if (mrb_nil_p(profile)) {
-    profile_data = NULL;
-  } else {
+  if (!mrb_string_p(profile) && !mrb_nil_p(profile)) {
     mrb_raise(mrb, E_TYPE_ERROR, "BLE._init: wrong argument type");
   }
   int ble_role;
@@ -149,8 +144,16 @@ mrb__init(mrb_state *mrb, mrb_value self)
     default:
       mrb_raise(mrb, E_TYPE_ERROR, "BLE._init: wrong role type");
   }
+  if (ble_role == BLE_ROLE_PERIPHERAL && mrb_string_p(profile)) {
+    profile_copy = mrb_str_dup(mrb, profile);
+    profile_data = (const uint8_t *)RSTRING_PTR(profile_copy);
+  }
   if (BLE_init(profile_data, ble_role) < 0) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "BLE init failed");
+  }
+  if (!mrb_nil_p(profile_copy)) {
+    /* BTstack keeps profile_data by pointer after BLE_init(). */
+    mrb_gc_register(mrb, profile_copy);
   }
   return self;
 }

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -124,14 +124,9 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
   write_values = mrbc_hash_new(vm, 0);
   read_values = mrbc_hash_new(vm, 0);
 
-  const uint8_t *profile_data;
-  if (GET_TT_ARG(1) == MRBC_TT_STRING) {
-    /* Protect profile_data from GC */
-    mrbc_incref(&v[1]);
-    profile_data = GET_STRING_ARG(1);
-  } else if (GET_TT_ARG(1) == MRBC_TT_NIL) {
-    profile_data = NULL;
-  } else {
+  mrbc_value profile_copy = mrbc_nil_value();
+  const uint8_t *profile_data = NULL;
+  if (GET_TT_ARG(1) != MRBC_TT_STRING && GET_TT_ARG(1) != MRBC_TT_NIL) {
     mrbc_raise(vm, MRBC_CLASS(TypeError), "BLE._init: wrong argument type");
     return;
   }
@@ -149,11 +144,19 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     mrbc_raise(vm, MRBC_CLASS(TypeError), "BLE._init: wrong role type");
     return;
   }
+  if (ble_role == BLE_ROLE_PERIPHERAL && GET_TT_ARG(1) == MRBC_TT_STRING) {
+    profile_copy = mrbc_string_dup(vm, &v[1]);
+    profile_data = mrbc_string_cstr(&profile_copy);
+  }
   Machine_tud_task();
   if (BLE_init(profile_data, ble_role) < 0) {
+    if (profile_copy.tt == MRBC_TT_STRING) {
+      mrbc_decref(&profile_copy);
+    }
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "BLE init failed");
     return;
   }
+  /* Keep profile_copy's initial reference count for BTstack's profile_data pointer. */
   Machine_tud_task();
 }
 


### PR DESCRIPTION
- Copy the profile object if role is BLE_ROLE_PERIPHERAL
- Pass it to BLE_init()
- If successful, save the copy from GC
- (FemtoRuby) Unless, decref it and raise an error

close #428