### PR TITLE
Improve picoruby-psg with Sequencer

### DIFF
--- a/build_config/r2p2-femtoruby-pico.rb
+++ b/build_config/r2p2-femtoruby-pico.rb
@@ -45,5 +45,6 @@ MRuby::CrossBuild.new("r2p2-femtoruby-pico") do |conf|
   conf.gembox "shell"
   conf.gembox "peripherals"
   conf.gembox "peripheral_utils"
+  conf.gem core: 'picoruby-psg'
   conf.gem core: 'picoruby-keyboard'
 end

--- a/mrbgems/picoruby-mruby/sig/task.rbs
+++ b/mrbgems/picoruby-mruby/sig/task.rbs
@@ -1,4 +1,6 @@
 class Task
+  class Error < StandardError
+  end
   def self.new: (?name: String, ?priority: Integer) {() -> void} -> Task
   def self.create: (String bytecode) -> Task
   def self.stat: () -> Task::Stat
@@ -8,6 +10,7 @@ class Task
   def self.list: () -> Array[Task]
   def self.pass: () -> nil
   def self.tick: () -> Integer
+  def self.run: () -> bool
   def status: () -> String
   def name: () -> (String | nil)
   def name=: (String name) -> String

--- a/mrbgems/picoruby-mruby/sig/task.rbs
+++ b/mrbgems/picoruby-mruby/sig/task.rbs
@@ -29,6 +29,9 @@ class Task
 
   class Queue
     def self.new: () -> Task::Queue
+    def __push: (untyped obj) -> void
+    def __pop_try: (?bool non_block) -> untyped
+    def __retry?: (untyped obj) -> bool
     def push: (untyped obj) -> self
     alias enq push
     alias << push

--- a/mrbgems/picoruby-psg/README.md
+++ b/mrbgems/picoruby-psg/README.md
@@ -32,6 +32,32 @@ environment variable is not set, R2P2 passes
 When changing this option, check normal playback, stop/restart playback, a
 longer song, and any tempo-changing or live-control use cases.
 
+## PWM DMA output
+
+For PWM output on R2P2, the DMA path is also enabled by default. It lets core1
+render audio in blocks and feed the PWM compare register by DMA instead of
+updating PWM levels from the audio timer callback.
+
+Build normally to use the DMA path:
+
+```sh
+rake r2p2:picoruby:pico2:prod
+```
+
+To use the legacy timer callback path, disable DMA explicitly:
+
+```sh
+PICORUBY_PSG_PWM_DMA=off rake r2p2:picoruby:pico2:prod
+```
+
+Accepted false values are `0`, `off`, `false`, `no`, and `n`. If the
+environment variable is not set, R2P2 passes `PICORUBY_PSG_PWM_DMA=ON` to
+CMake.
+
+PWM DMA is paced by the PWM wrap DREQ, so the PWM carrier follows the PSG sample
+rate. When changing this option, check normal playback, stop/restart playback,
+and high-frequency noise character on the target speaker or filter circuit.
+
 ## Wiring (RP2040 and RP2350)
 
 ### MCP492x --- 12bit DAC (SPI)

--- a/mrbgems/picoruby-psg/README.md
+++ b/mrbgems/picoruby-psg/README.md
@@ -7,6 +7,31 @@ PSG (Programmable Sound Generator) emulator for PicoRuby.
 Use the **prod** build when running PSG on R2P2 for Raspberry Pi Pico.
 The debug build is too slow for real-time audio playback and can cause severe audio dropouts.
 
+## MCP4922 DMA output
+
+For MCP4922 output on R2P2, the DMA path is enabled by default. It lets core1
+render audio in blocks and feed the MCP4922 PIO TX FIFO by DMA instead of
+writing one sample at a time from the audio timer callback.
+
+Build normally to use the DMA path:
+
+```sh
+rake r2p2:picoruby:pico2:prod
+```
+
+To use the legacy blocking PIO write path, disable DMA explicitly:
+
+```sh
+PICORUBY_PSG_MCP4922_DMA=off rake r2p2:picoruby:pico2:prod
+```
+
+Accepted false values are `0`, `off`, `false`, `no`, and `n`. If the
+environment variable is not set, R2P2 passes
+`PICORUBY_PSG_MCP4922_DMA=ON` to CMake.
+
+When changing this option, check normal playback, stop/restart playback, a
+longer song, and any tempo-changing or live-control use cases.
+
 ## Wiring (RP2040 and RP2350)
 
 ### MCP492x --- 12bit DAC (SPI)

--- a/mrbgems/picoruby-psg/README.md
+++ b/mrbgems/picoruby-psg/README.md
@@ -2,6 +2,11 @@
 
 PSG (Programmable Sound Generator) emulator for PicoRuby.
 
+## Build note for Raspberry Pi Pico
+
+Use the **prod** build when running PSG on R2P2 for Raspberry Pi Pico.
+The debug build is too slow for real-time audio playback and can cause severe audio dropouts.
+
 ## Wiring (RP2040 and RP2350)
 
 ### MCP492x --- 12bit DAC (SPI)
@@ -72,13 +77,13 @@ You can choose a GPIO combination as follows:
 For stereo output, you must choose a PWM pair that shares the same slice.
 This ensures that both left and right channels are updated simultaneously.
 
-|Slice|PWM A|PWM B|
-|-----|-----|-----|
-|PWM0 |GPIO0|GPIO1|
-|PWM1 |GPIO2|GPIO3|
-|PWM2 |GPIO4|GPIO5|
-|PWM3 |GPIO6|GPIO7|
-|PWM4 |GPIO8|GPIO9|
+|Slice|PWM A |PWM B |
+|-----|------|------|
+|PWM0 |GPIO0 |GPIO1 |
+|PWM1 |GPIO2 |GPIO3 |
+|PWM2 |GPIO4 |GPIO5 |
+|PWM3 |GPIO6 |GPIO7 |
+|PWM4 |GPIO8 |GPIO9 |
 |PWM5 |GPIO10|GPIO11|
 |PWM6 |GPIO12|GPIO13|
 |PWM7 |GPIO14|GPIO15|
@@ -89,3 +94,7 @@ This ensures that both left and right channels are updated simultaneously.
 |PWM4 |GPIO24|GPIO25|
 |PWM5 |GPIO26|GPIO27|
 |PWM6 |GPIO28|GPIO29|
+
+## Usage
+
+See README_MML.md

--- a/mrbgems/picoruby-psg/README_MML.md
+++ b/mrbgems/picoruby-psg/README_MML.md
@@ -63,31 +63,31 @@ playback.queue << [:mute, 0, 0]
 
 ## 🎼 Supported MML Commands
 
-| Command         | Description                                                     |
-|-----------------|-----------------------------------------------------------------|
-| `a`..`g`        | Notes. `+`(`#`) or `-` for sharp and flat. eg: `c+`, `a#`, `d-` |
-| `r`             | Rest                                                            |
-| `tN`            | Tempo in BPM. eg: `t120`                                        |
-| `oN`            | Octave number. eg: `o4` = 4th octave                            |
-| `lN`            | Default note length. eg: `l4` = quarter note, `l8` = eighth note|
-| `qN`            | Gate time (1–8). `q8` = full length, `q4` = 50%                 |
-| `<`             | Decrease octave by 1                                            |
-| `>`             | Increase octave by 1                                            |
-| `pN`            | Pan: `p1` = left, `p8` = center, `p15` = right. `p0` = undefined|
-| `vN`            | Volume: `v0`..`v15`.                                            |
-| `sN`            | Envelope shape: `s0`..`s15`. Volume will be ignored             |
-| `mN`            | Envelope period: `m0`..`m65535`                                 |
-| `{ ... }`       | Legato section: `c<{ba#a}` (portamento from "Do" to "La")       |
-| `xN`            | Mixer: `x0` = Tone, `x1` = Noise, `x2` = Tone\|Noise            |
-| `yN`            | Noise period: `y0`..`y31`                                       |
-| `zN`            | Detune: `z0`..`z128`. `z128` lowers one octave                  |
-| `@N`            | Timbre: `i0` = Square, `i1` = Triangle, `i2` = Sawtooth, `i3` = Inverse sawtooth |
-| `k+N` / `k-N`   | Transpose up or down `N` semitones                              |
-| `jD,R`          | Vibrato (LFO): depth `D` (halftones), rate `R` (in 0.1Hz units) |
-| `.`             | Dotted note. Adds 1/2 length (`l4.` = x1.5, `l4..` = x1.75)     |
-| `[ ... ]N`      | Repeat enclosed block `N` times (supports nesting)              |
-| `$`             | Segno. Loop start position                                      |
-| `\|`            | Barline (purely visual; ignored by parser)                      |
+| Command       | Description                                                     |
+|---------------|-----------------------------------------------------------------|
+| `a`..`g`      | Notes. `+`(`#`) or `-` for sharp and flat. eg: `c+`, `a#`, `d-` |
+| `r`           | Rest                                                            |
+| `tN`          | Tempo in BPM. eg: `t120`                                        |
+| `oN`          | Octave number. eg: `o4` = 4th octave                            |
+| `lN`          | Default note length. eg: `l4` = quarter note, `l8` = eighth note|
+| `qN`          | Gate time (1–8). `q8` = full length, `q4` = 50%                |
+| `<`           | Decrease octave by 1                                            |
+| `>`           | Increase octave by 1                                            |
+| `pN`          | Pan: `p1` = left, `p8` = center, `p15` = right. `p0` = undefined|
+| `vN`          | Volume: `v0`..`v15`.                                            |
+| `sN`          | Envelope shape: `s0`..`s15`. Volume will be ignored             |
+| `mN`          | Envelope period: `m0`..`m65535`                                 |
+| `{ ... }`     | Legato section: `c<{ba#a}` (portamento from "Do" to "La")       |
+| `xN`          | Mixer: `x0` = Tone, `x1` = Noise, `x2` = Tone\|Noise            |
+| `yN`          | Noise period: `y0`..`y31`                                       |
+| `zN`          | Detune: `z0`..`z128`. `z128` lowers one octave                  |
+| `@N`          | Timbre: `i0` = Square, `i1` = Triangle, `i2` = Sawtooth, `i3` = Inverse sawtooth |
+| `k+N` / `k-N` | Transpose up or down `N` semitones                              |
+| `jD,R`        | Vibrato (LFO): depth `D` (halftones), rate `R` (in 0.1Hz units) |
+| `.`           | Dotted note. Adds 1/2 length (`l4.` = x1.5, `l4..` = x1.75)     |
+| `[ ... ]N`    | Repeat enclosed block `N` times (supports nesting)              |
+| `$`           | Segno. Loop start position                                      |
+| `\|`          | Barline (purely visual; ignored by parser)                      |
 
 
 ### 🔁 Loop Examples

--- a/mrbgems/picoruby-psg/README_MML.md
+++ b/mrbgems/picoruby-psg/README_MML.md
@@ -28,6 +28,39 @@ driver.play_mml(tracks)
 
 ```
 
+## Playback model
+
+`PSG::Driver#play_mml` keeps the historical synchronous API. Internally it
+uses two tasks and a `Task::Queue`:
+
+```text
+Sequencer task -> Task::Queue -> Sound task -> PSG ring buffer
+```
+
+The sequencer parses MML incrementally and sleeps for each delta in real time
+before pushing immediate PSG commands into the queue. The sound task blocks on
+`queue.pop`, writes the command to PSG registers as soon as it receives one,
+and then immediately waits for the next command.
+
+For asynchronous playback, use `start_mml`:
+
+```ruby
+playback = driver.start_mml(tracks)
+playback.tempo_scale = 1.25
+playback.pause
+playback.resume
+playback.stop
+```
+
+`playback.queue` is public so application tasks can enqueue short live-play or
+sound-effect commands. Commands are arrays:
+
+```ruby
+playback.queue << [:send_reg, 0, period & 0xff]
+playback.queue << [:send_reg, 1, period >> 8]
+playback.queue << [:mute, 0, 0]
+```
+
 ## 🎼 Supported MML Commands
 
 | Command         | Description                                                     |
@@ -70,12 +103,24 @@ driver.play_mml(tracks)
 The `MML#compile_multi` method yields timed events in the following form:
 
 ```ruby
-yield(delta_ms, channel, pitch, duration_ms, pan, volume, env_shape, env_period, lfo_depth, lfo_rate)
+yield(delta_ms, track, command, arg0, arg1 = 0)
 ```
-Additionally, control events are emitted when state changes occur:
 
-- `[:lfo, depth, rate]` : Vibrato (LFO) settings updated
-- `[:env, shape, period]` : Envelope settings updated
+Commands include:
 
-Use the delta_ms value to determine when to trigger each event.
+- `:play` : `arg0` is the tone period, `arg1` is sustain duration in ms
+- `:mute` : `arg0` is 1 to mute or 0 to unmute
+- `:volume` : `arg0` is the channel volume register value
+- `:env_period` : `arg0` is the 16-bit envelope period
+- `:env_shape` : `arg0` is the envelope shape
+- `:legato` : `arg0` is 1 to keep envelope state or 0 to reset on tone update
+- `:timbre` : `arg0` is the timbre index
+- `:pan` : `arg0` is the pan value
+- `:lfo` : `arg0` is depth and `arg1` is rate
+- `:mixer` : `arg0` selects tone/noise mode
+- `:noise` : `arg0` is the noise period
+- `:segno` : loop marker handled by the MML parser
 
+Use `delta_ms` to determine when to trigger each event. `PSG::Playback`
+consumes that delta in the sequencer task rather than precomputing all event
+times up front.

--- a/mrbgems/picoruby-psg/example/keyboard_pwm.rb
+++ b/mrbgems/picoruby-psg/example/keyboard_pwm.rb
@@ -1,0 +1,18 @@
+require 'psg'
+
+channel = 2
+driver = PSG::Driver.new(:pwm, left: 10, right: 11)
+
+driver.set_timbre(channel, PSG::Driver::TIMBRES[:square], 0)
+driver.set_pan(channel, 8, 0)
+driver.send_reg(channel + 8, 12, 0)
+driver.mute(channel, 1, 0)
+
+keyboard = PSG::Keyboard.new(driver, channel: channel)
+
+begin
+  keyboard.start
+ensure
+  keyboard.note_off
+  driver.join
+end

--- a/mrbgems/picoruby-psg/example/twinkle_1.rb
+++ b/mrbgems/picoruby-psg/example/twinkle_1.rb
@@ -1,3 +1,5 @@
+require 'psg'
+
 tracks = [
   '@0 T120 S0 M800 L4 O5 f  f >c   c |  d    d   c2    |<b-  b-  a  a | g  g f2|>c  c <b- b-| a  a  g2     |>c   c  <b- b- | a  a g2        |f  f> c   c |  d    d   c2    | <b- b-  a  a | g  g f2',
   '@0 T120 S0      L4 O4 a >c  f   f |  f    f   g   f | e   c   f  c |<b- b-a2|>a  a  g  g | f  f  e2     | g   f   d  e  | c  f e8d8c8<b-8|a >c  f   f |  f    f   g   f |  e  c   f  c |<b- b-a2',

--- a/mrbgems/picoruby-psg/example/twinkle_2.rb
+++ b/mrbgems/picoruby-psg/example/twinkle_2.rb
@@ -1,3 +1,5 @@
+require 'psg'
+
 tracks = [
   '@0 T120 S0 M800 L4 O5 f  f >c   c |  d    d   c2    |<b-  b-  a  a | g  g f2|>c  c <b- b-| a  a  g2     |>c   c  <b- b- | a  a g2        |f  f> c   c |  d    d   c2    | <b- b-  a  a | g  g f2',
   '@0 T120 S0      L4 O4 a >c  f   f |  f    f   g   f | e   c   f  c |<b- b-a2|>a  a  g  g | f  f  e2     | g   f   d  e  | c  f e8d8c8<b-8|a >c  f   f |  f    f   g   f |  e  c   f  c |<b- b-a2',

--- a/mrbgems/picoruby-psg/include/psg.h
+++ b/mrbgems/picoruby-psg/include/psg.h
@@ -199,6 +199,13 @@ extern const psg_output_api_t psg_drv_mcp4922;
 /* Audio sampling buffer */
 #define BUF_SAMPLES   256
 #define BUF_MASK      (BUF_SAMPLES - 1)
+#ifndef PSG_BUFFER_OUTPUT_SAMPLES
+#if defined(PICO_RP2350)
+#define PSG_BUFFER_OUTPUT_SAMPLES (BUF_SAMPLES / 4)
+#else
+#define PSG_BUFFER_OUTPUT_SAMPLES (BUF_SAMPLES / 2)
+#endif
+#endif
 extern uint32_t pcm_buf[BUF_SAMPLES]; // 32-bit stereo samples
 extern volatile uint32_t wr_idx; // only core0 writes
 extern volatile uint32_t rd_idx; // only core1 writes

--- a/mrbgems/picoruby-psg/include/psg.h
+++ b/mrbgems/picoruby-psg/include/psg.h
@@ -186,6 +186,7 @@ typedef struct {
   void (*start)(void);
   void (*stop)(void);
   void (*write)(uint16_t l, uint16_t r);
+  bool (*write_buffer)(const uint32_t *samples, uint32_t count);
 } psg_output_api_t;
 
 /* one global pointer, switched at runtime */

--- a/mrbgems/picoruby-psg/mrblib/driver.rb
+++ b/mrbgems/picoruby-psg/mrblib/driver.rb
@@ -1,10 +1,234 @@
 module PSG
+  class Playback
+
+    WAIT_RETRY_MS = 1
+    WAIT_SLICE_MS = 10
+
+    attr_reader :queue, :tracks
+    attr_accessor :tempo_scale
+
+    def initialize(driver, tracks, loop: true, terminate: false)
+      @driver = driver
+      @tracks = tracks
+      @loop = loop
+      @terminate = terminate
+      @queue = Task::Queue.new
+      @tempo_scale = 1.0
+      @stopped = false
+      @paused = false
+      @replay_requested = false
+      @mixer = 0b111000
+      @sequencer_task = nil
+      @sound_task = nil
+    end
+
+    def start
+      playback = self
+      @sound_task = Task.new { playback.__sound_loop }
+      @sequencer_task = Task.new { playback.__sequencer_loop }
+      self
+    end
+
+    def join
+      begin
+        @sequencer_task&.join
+        @sound_task&.join
+      rescue RuntimeError
+        Task.run
+      end
+      @driver.join if @terminate
+      self
+    end
+
+    def stop
+      @stopped = true
+      silence_direct
+      @queue.clear unless @queue.closed?
+      @queue.close unless @queue.closed?
+      @driver.buffer_flush
+      self
+    end
+
+    def pause
+      @paused = true
+      silence_direct
+      @driver.buffer_flush
+      self
+    end
+
+    def resume
+      @paused = false
+      self
+    end
+
+    def paused?
+      @paused
+    end
+
+    def stopped?
+      @stopped
+    end
+
+    def replay
+      @replay_requested = true
+      self
+    end
+
+    def __sound_loop
+      while true
+        command = @queue.pop
+        break if command.nil?
+        __write_command(command)
+      end
+    rescue => e
+      puts "Error during PSG sound task: #{e.message}"
+      silence_direct
+    end
+
+    def __sequencer_loop
+      while !@stopped
+        @replay_requested = false
+        @mixer = 0b111000
+        @tracks.size.times { |tr| __enqueue([:mute, tr, 0]) }
+
+        MML.compile_multi(@tracks, loop: @loop) do |delta, tr, command, arg0, arg1 = 0|
+          break if @stopped || @replay_requested
+          __wait_delta(delta)
+          break if @stopped || @replay_requested
+          __enqueue_mml_event(tr, command, arg0, arg1)
+        end
+
+        __enqueue_silence
+        break unless @replay_requested
+      end
+    rescue => e
+      puts "Error during PSG sequencer task: #{e.message}"
+      silence_direct
+    ensure
+      @queue.close unless @queue.closed?
+    end
+
+    def __wait_delta(delta)
+      remaining = delta.to_f
+      while 0 < remaining && !@stopped && !@replay_requested
+        while @paused && !@stopped && !@replay_requested
+          sleep_ms WAIT_SLICE_MS
+        end
+        break if @stopped || @replay_requested
+
+        scale = @tempo_scale || 1.0
+        scale = 0.01 if scale <= 0
+        score_slice = WAIT_SLICE_MS * scale
+        if remaining < score_slice
+          wall_ms = (remaining / scale).to_i
+          wall_ms = 1 if wall_ms < 1
+        else
+          wall_ms = WAIT_SLICE_MS
+        end
+        sleep_ms wall_ms
+        remaining -= wall_ms * scale
+      end
+    end
+
+    def __enqueue_mml_event(tr, command, arg0, arg1)
+      case command
+      when :segno
+        # MML handles the loop point internally.
+      when :mute
+        __enqueue([:mute, tr, arg0])
+      when :play
+        __enqueue([:send_reg, tr * 2, arg0 & 0xFF])
+        __enqueue([:send_reg, tr * 2 + 1, (arg0 >> 8) & 0x0F])
+      when :volume
+        __enqueue([:send_reg, tr + 8, arg0])
+      when :env_period
+        __enqueue([:send_reg, 11, arg0 & 0xFF])
+        __enqueue([:send_reg, 12, arg0 >> 8])
+      when :env_shape
+        __enqueue([:send_reg, 13, arg0])
+      when :legato
+        __enqueue([:set_legato, tr, arg0])
+      when :timbre
+        __enqueue([:set_timbre, tr, arg0])
+      when :pan
+        __enqueue([:set_pan, tr, arg0])
+      when :lfo
+        __enqueue([:set_lfo, tr, arg0, arg1])
+      when :mixer
+        case arg0
+        when 0 # Tone on, Noise off
+          @mixer |= (1 << (tr + 3))
+          @mixer &= ~(1 << tr)
+        when 1 # Tone off, Noise on
+          @mixer &= ~(1 << (tr + 3))
+          @mixer |= (1 << tr)
+        when 2 # Tone on, Noise on
+          @mixer &= ~(1 << tr)
+          @mixer &= ~(1 << (tr + 3))
+        end
+        __enqueue([:send_reg, 7, @mixer])
+      when :noise
+        __enqueue([:send_reg, 6, arg0])
+      end
+    end
+
+    def __enqueue_silence
+      @tracks.size.times do |tr|
+        __enqueue([:send_reg, tr + 8, 0])
+        __enqueue([:mute, tr, 1])
+      end
+    end
+
+    def __enqueue(command)
+      return false if @stopped || @queue.closed?
+      @queue.push(command)
+      true
+    rescue Task::Error
+      false
+    end
+
+    def __write_command(command)
+      while !@stopped
+        pushed = case command[0]
+        when :send_reg
+          @driver.send_reg(command[1], command[2], 0)
+        when :mute
+          @driver.mute(command[1], command[2], 0)
+        when :set_pan
+          @driver.set_pan(command[1], command[2], 0)
+        when :set_timbre
+          @driver.set_timbre(command[1], command[2], 0)
+        when :set_legato
+          @driver.set_legato(command[1], command[2], 0)
+        when :set_lfo
+          @driver.set_lfo(command[1], command[2], command[3], 0)
+        else
+          true
+        end
+        return if pushed
+        GC.start
+        sleep_ms WAIT_RETRY_MS
+      end
+    end
+
+    def silence_direct
+      tr = 0
+      while tr < @tracks.size
+        @driver.write_reg_direct(tr + 8, 0)
+        @driver.mute_direct(tr, 1)
+        tr += 1
+      end
+    end
+  end
+
   class Driver
 
     WAIT_MS = 500
 
     def initialize(type, **opt)
       @mml_request = nil
+      @mml_playback = nil
+      @bgm_playback = nil
       case type
       when :pwm
         if opt[:left].nil? || opt[:right].nil?
@@ -36,96 +260,37 @@ module PSG
     end
 
     def replay
+      @mml_playback&.replay
       @mml_request = :replay
     end
 
     def stop_mml
+      @mml_playback&.stop
+      @bgm_playback = nil if @bgm_playback.equal?(@mml_playback)
+      @mml_playback = nil
       @mml_request = :stop
     end
 
-    def play_mml(tracks, terminate: true)
+    def start_mml(tracks, loop: true, terminate: false)
+      stop_mml
       trap
+      @mml_request = nil
+      @mml_playback = Playback.new(self, tracks, loop: loop, terminate: terminate)
+      # @type ivar @mml_playback: Playback
+      @mml_playback.start
+    end
 
-      while true
-        # Wait if stopped (initial stop_mml before first play, or after game over)
-        if @mml_request == :stop
-          @mml_request = nil
-          sleep_ms(100) while @mml_request.nil?
-          break if @mml_request == :quit
-        end
-        break if @mml_request == :quit
-        @mml_request = nil
-
-        mixer = 0b111000 # Noise all off, Tone all on
-        # Give the ring buffer time to fill with some amount of packets
-        tracks.size.times { |tr| invoke :mute, tr, 0, WAIT_MS }
-        MML.compile_multi(tracks, loop: true) do |delta, tr, command, arg0, arg1 = 0|
-          break unless @mml_request.nil?
-          case command
-          when :segno
-            # Ignore. MML takes care of `$` macro
-          when :mute
-            invoke :mute, tr, arg0, delta
-          when :play
-            invoke :send_reg, tr * 2    , arg0 & 0xFF       , delta
-            invoke :send_reg, tr * 2 + 1, (arg0 >> 8) & 0x0F, 0
-          when :volume
-            invoke :send_reg, tr + 8, arg0, delta
-          when :env_period
-            invoke :send_reg, 11, arg0 & 0xFF, delta
-            invoke :send_reg, 12, arg0 >> 8  , 0
-          when :env_shape
-            invoke :send_reg, 13, arg0, delta
-          when :legato
-            invoke :set_legato, tr, arg0, delta
-          when :timbre
-            invoke :set_timbre, tr, arg0, delta
-          when :pan
-            invoke :set_pan, tr, arg0, delta
-          when :lfo
-            invoke :set_lfo, tr, arg0, arg1, delta
-          when :mixer
-            case arg0
-            when 0 # Tone on, Noise off
-              mixer |= (1 << (tr + 3))  # Set noise bit (off)
-              mixer &= ~(1 << tr)       # Clear tone bit (on)
-            when 1 # Tone off, Noise on
-              mixer &= ~(1 << (tr + 3)) # Clear noise bit (on)
-              mixer |= (1 << tr)        # Set tone bit (off)
-            when 2 # Tone on, Noise on
-              mixer &= ~(1 << tr)       # Clear tone bit (on)
-              mixer &= ~(1 << (tr + 3)) # Clear noise bit (on)
-            end
-            invoke :send_reg, 7, mixer, delta
-          when :noise
-            invoke :send_reg, 6, arg0, delta
-          end
-        end
-
-        # Silence all channels used by tracks
-        tracks.size.times do |tr|
-          write_reg_direct(tr + 8, 0)
-          mute_direct(tr, 1)
-        end
-        buffer_flush
-        GC.start
-
-        if @mml_request == :replay
-          next # restart from beginning
-        elsif @mml_request == :stop
-          next # will enter wait state at top of loop
-        else
-          break # natural end (non-looping MML finished)
-        end
-      end
-
-      join if terminate
-      return self
+    def play_mml(tracks, terminate: true)
+      playback = start_mml(tracks, loop: true, terminate: terminate)
+      playback.join
+      self
     rescue => e
       puts "Error during MML playback: #{e.message}"
-      tracks.size.times { |tr| invoke :mute, tr, 1, 0 }
+      tracks.size.times { |tr| mute_direct(tr, 1) }
       deinit
       return self
+    ensure
+      @mml_playback = nil if @mml_playback.equal?(playback)
     end
 
     def play_prs(filename, terminate: true)
@@ -180,44 +345,19 @@ module PSG
       file&.close
     end
 
-    # Start BGM playback in a background Task.
-    # mruby/c: Task.new does not forward blocks to initialize,
-    #          so we compile a script string and use Task.create.
-    # mruby:   Task.new with block works normally.
-    # Uses terminate: false so the task does not call deinit on exit.
+    # Start BGM playback in background PSG tasks.
     def start_bgm(tracks)
       stop_bgm
-      stop_mml
-      if RUBY_ENGINE == "mruby/c"
-        $__psg_bgm_tracks = tracks
-        $__psg_driver = self
-        mrb = PicoRubyVM::InstructionSequence.compile(
-          '$__psg_driver.play_mml($__psg_bgm_tracks, terminate: false)'
-        ).to_binary
-        @bgm_task = Task.create(mrb)
-        if @bgm_task.nil?
-          raise "Failed to create BGM task"
-        end
-        @bgm_task&.run
-      else
-        psg = self
-        @bgm_task = Task.new { psg.play_mml(tracks, terminate: false) }
-      end
+      @bgm_playback = start_mml(tracks, loop: true, terminate: false)
     end
 
     # Stop the BGM task and silence all channels.
     def stop_bgm
-      return unless @bgm_task
-      @mml_request = :quit
-      @bgm_task&.join
-      tr = 0
-      while tr < 3
-        write_reg_direct(tr + 8, 0)
-        mute_direct(tr, 1)
-        tr += 1
-      end
-      buffer_flush
-      @bgm_task = nil
+      return unless @bgm_playback
+      # @type ivar @bgm_playback: Playback
+      @bgm_playback.stop
+      @mml_playback = nil if @mml_playback.equal?(@bgm_playback)
+      @bgm_playback = nil
       @mml_request = nil
     end
 
@@ -234,6 +374,7 @@ module PSG
         # Do NOT call deinit here: the BGM task is still alive and would
         # access the freed ring buffer, corrupting the heap.
         # play_mml will call join -> deinit when it gets scheduled.
+        @mml_playback&.stop
         @mml_request = :quit
         Signal.trap(:INT, "DEFAULT")
       end

--- a/mrbgems/picoruby-psg/mrblib/driver.rb
+++ b/mrbgems/picoruby-psg/mrblib/driver.rb
@@ -8,20 +8,29 @@ module PSG
     attr_accessor :tempo_scale
 
     def self.__register(playback)
-      @__registry ||= {}
-      @__next_id ||= 0
-      @__next_id += 1
-      @__registry[@__next_id] = playback
-      @__next_id
+      registry = @__registry
+      unless registry
+        registry = {} #: Hash[Integer, PSG::Playback]
+        @__registry = registry
+      end
+
+      next_id = @__next_id || 0
+      next_id += 1
+      @__next_id = next_id
+      registry[next_id] = playback
+      next_id
     end
 
     def self.__fetch(id)
-      return nil unless @__registry
-      @__registry[id]
+      registry = @__registry
+      return nil unless registry
+      registry[id]
     end
 
     def self.__unregister(id)
-      @__registry.delete(id) if @__registry
+      return unless id
+      registry = @__registry
+      registry.delete(id) if registry
     end
 
     def self.__run_task(id, kind)
@@ -79,7 +88,7 @@ module PSG
     end
 
     def __create_task(kind)
-      id = @registry_id
+      id = @registry_id || raise("playback is not registered")
       if Task.respond_to?(:create)
         source = "PSG::Playback.__run_task(#{id}, :#{kind})"
         binary = PicoRubyVM::InstructionSequence.compile(source).to_binary

--- a/mrbgems/picoruby-psg/mrblib/driver.rb
+++ b/mrbgems/picoruby-psg/mrblib/driver.rb
@@ -266,7 +266,7 @@ module PSG
 
     def stop_mml
       @mml_playback&.stop
-      @bgm_playback = nil if @bgm_playback.equal?(@mml_playback)
+      @bgm_playback = nil if @bgm_playback == @mml_playback
       @mml_playback = nil
       @mml_request = :stop
     end
@@ -290,7 +290,7 @@ module PSG
       deinit
       return self
     ensure
-      @mml_playback = nil if @mml_playback.equal?(playback)
+      @mml_playback = nil if @mml_playback == playback
     end
 
     def play_prs(filename, terminate: true)
@@ -356,7 +356,7 @@ module PSG
       return unless @bgm_playback
       # @type ivar @bgm_playback: Playback
       @bgm_playback.stop
-      @mml_playback = nil if @mml_playback.equal?(@bgm_playback)
+      @mml_playback = nil if @mml_playback == @bgm_playback
       @bgm_playback = nil
       @mml_request = nil
     end

--- a/mrbgems/picoruby-psg/mrblib/driver.rb
+++ b/mrbgems/picoruby-psg/mrblib/driver.rb
@@ -7,6 +7,36 @@ module PSG
     attr_reader :queue, :tracks
     attr_accessor :tempo_scale
 
+    def self.__register(playback)
+      @__registry ||= {}
+      @__next_id ||= 0
+      @__next_id += 1
+      @__registry[@__next_id] = playback
+      @__next_id
+    end
+
+    def self.__fetch(id)
+      return nil unless @__registry
+      @__registry[id]
+    end
+
+    def self.__unregister(id)
+      @__registry.delete(id) if @__registry
+    end
+
+    def self.__run_task(id, kind)
+      playback = __fetch(id)
+      return unless playback
+
+      if kind == :sound
+        playback.__sound_loop
+      else
+        playback.__sequencer_loop
+      end
+    ensure
+      playback.__task_finished if playback
+    end
+
     def initialize(driver, tracks, loop: true, terminate: false)
       @driver = driver
       @tracks = tracks
@@ -20,13 +50,21 @@ module PSG
       @mixer = 0b111000
       @sequencer_task = nil
       @sound_task = nil
+      @registry_id = nil
+      @running_tasks = 0
     end
 
     def start
-      playback = self
-      @sound_task = Task.new { playback.__sound_loop }
-      @sequencer_task = Task.new { playback.__sequencer_loop }
+      @registry_id = self.class.__register(self)
+      @running_tasks = 2
+      @sound_task = __create_task(:sound)
+      @sequencer_task = __create_task(:sequencer)
       self
+    rescue
+      self.class.__unregister(@registry_id) if @registry_id
+      @registry_id = nil
+      @running_tasks = 0
+      raise
     end
 
     def join
@@ -38,6 +76,28 @@ module PSG
       end
       @driver.join if @terminate
       self
+    end
+
+    def __create_task(kind)
+      id = @registry_id
+      if Task.respond_to?(:create)
+        source = "PSG::Playback.__run_task(#{id}, :#{kind})"
+        binary = PicoRubyVM::InstructionSequence.compile(source).to_binary
+        task = Task.create(binary)
+        task.run
+        task
+      else
+        Task.new { PSG::Playback.__run_task(id, kind) }
+      end
+    end
+
+    def __task_finished
+      return unless @registry_id
+      @running_tasks -= 1 if 0 < @running_tasks
+      return unless @running_tasks == 0
+
+      self.class.__unregister(@registry_id)
+      @registry_id = nil
     end
 
     def stop

--- a/mrbgems/picoruby-psg/mrblib/keyboard.rb
+++ b/mrbgems/picoruby-psg/mrblib/keyboard.rb
@@ -5,7 +5,7 @@ module PSG
       (TONE_K / freq + 0.5).to_i
     end
 
-    TONE_K = PSG::Driver::SAMPLE_RATE / 32.0 # clock factor
+    TONE_K = PSG::Driver::CHIP_CLOCK / 32.0 # clock factor
     KEY2PERIOD = {
        97 => note_to_period(60), # 'a' => (C4)
       119 => note_to_period(61), # 'w' => (C#4)
@@ -25,35 +25,35 @@ module PSG
 
     def initialize(driver, channel: CH)
       @driver = driver
+      @channel = channel
       @ch_reg = channel * 2
     end
 
     def note_on(period)
-      @driver.send_reg(@ch_reg,     period & 0xFF, 0)
-      @driver.send_reg(@ch_reg + 1, period >> 8, 0)
+      ok = @driver.send_reg(@ch_reg,     period & 0xFF, 0)
+      ok = @driver.send_reg(@ch_reg + 1, period >> 8, 0) && ok
+      @driver.mute(@channel, 0, 0) && ok
     end
 
     def note_off
-      @driver.send_reg(@ch_reg,     0, 0)
-      @driver.send_reg(@ch_reg + 1, 0, 0)
+      @driver.mute(@channel, 1, 0)
     end
 
     def start
       prev_key = nil
       while true
-        key = STDIN.read_nonblock(1)&.ord
-        if key.nil?
-           note_off
-          prev_key = nil
-          next
-        elsif key == 27 # ESC
+        input = STDIN.read_nonblock(1)
+        key = input&.getbyte(0)
+
+        if key == 27 # ESC
           note_off
           break
-        elsif key != prev_key
-          # previous key released
+        elsif key == 32 || key == 13 # Space or Enter
+          note_off if prev_key
+          prev_key = nil
+        elsif key && key != prev_key
           # @type var prev_key: Integer
           note_off if prev_key
-          # new key pressed
           if period = KEY2PERIOD[key]
             note_on(period)
             prev_key = key

--- a/mrbgems/picoruby-psg/mrblib/mml.rb
+++ b/mrbgems/picoruby-psg/mrblib/mml.rb
@@ -45,7 +45,7 @@ class MML # Music Macro Language
       # @type var min_tick: Integer
       delta = min_tick - prev_time
       # @type var min_track: Integer
-      yield(delta, min_track, event[0], event[1])
+      yield(delta, min_track, event[0], event[1], event[2])
       prev_time = min_tick
 
       next_event = parsers[min_track].reduce_next

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
@@ -4,12 +4,22 @@
 #include "hardware/gpio.h"
 #include "hardware/clocks.h"
 
+#ifndef PSG_MCP4922_DMA
+#define PSG_MCP4922_DMA 0
+#endif
+
+#if PSG_MCP4922_DMA
+#include "hardware/dma.h"
+#endif
+
 #include "../../include/psg.h"
 
 
 #include "psg_drv_mcp4922_pio.pio.h"
 
 #define DAC_SPI_BAUD  16000000   /* 16 MHz */
+#define MCP4922_PIO_CYCLES_PER_SAMPLE 151.0f
+#define MCP4922_DMA_SAMPLES (BUF_SAMPLES / 2)
 
 // MCP4922 DAC configuration structure
 typedef struct {
@@ -24,6 +34,12 @@ typedef struct {
 } mcp4922_pio_config_t;
 
 static mcp4922_pio_config_t dac_config;
+
+#if PSG_MCP4922_DMA
+static int dma_chan = -1;
+static dma_channel_config dma_config;
+static uint32_t dma_buf[MCP4922_DMA_SAMPLES];
+#endif
 
 // Initialize MCP4922 PIO DAC
 static inline void
@@ -82,8 +98,29 @@ static void
 psg_mcp4922_init(uint8_t ldac, uint8_t _v)
 {
   (void)_v;
+#if PSG_MCP4922_DMA
+  float clk_div = (float)clock_get_hz(clk_sys) / (SAMPLE_RATE * MCP4922_PIO_CYCLES_PER_SAMPLE);
+#else
   float clk_div = (float)clock_get_hz(clk_sys) / (DAC_SPI_BAUD * 4.0f);
+#endif
   mcp4922_pio_init(&dac_config, pio0, 0, ldac, clk_div);
+
+#if PSG_MCP4922_DMA
+  dma_chan = dma_claim_unused_channel(true);
+  dma_config = dma_channel_get_default_config(dma_chan);
+  channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
+  channel_config_set_read_increment(&dma_config, true);
+  channel_config_set_write_increment(&dma_config, false);
+  channel_config_set_dreq(&dma_config, pio_get_dreq(dac_config.pio, dac_config.sm, true));
+  dma_channel_configure(
+    dma_chan,
+    &dma_config,
+    &dac_config.pio->txf[dac_config.sm],
+    NULL,
+    0,
+    false
+  );
+#endif
 }
 
 void
@@ -94,6 +131,15 @@ psg_mcp4922_start(void)
 void
 psg_mcp4922_stop(void)
 {
+#if PSG_MCP4922_DMA
+  if (dma_chan >= 0) {
+    dma_channel_abort(dma_chan);
+    dma_channel_cleanup(dma_chan);
+    dma_channel_unclaim(dma_chan);
+    dma_chan = -1;
+  }
+#endif
+
   if (dac_config.initialized) {
     // Disable the state machine
     pio_sm_set_enabled(dac_config.pio, dac_config.sm, false);
@@ -110,10 +156,41 @@ psg_mcp4922_write(uint16_t l, uint16_t r)
   mcp4922_pio_write_blocking(&dac_config, l, r);
 }
 
+#if PSG_MCP4922_DMA
+static bool
+psg_mcp4922_write_buffer(const uint32_t *samples, uint32_t count)
+{
+  if (!dac_config.initialized || dma_chan < 0 || count > MCP4922_DMA_SAMPLES) return false;
+  if (dma_channel_is_busy(dma_chan)) return false;
+
+  for (uint32_t i = 0; i < count; i++) {
+    uint16_t left = samples[i] >> 16;
+    uint16_t right = samples[i] & 0x0FFF;
+    uint16_t chA = 0x3000 | (left & 0x0FFF);
+    uint16_t chB = 0xB000 | right;
+    dma_buf[i] = ((uint32_t)chA << 16) | chB;
+  }
+
+  dma_channel_configure(
+    dma_chan,
+    &dma_config,
+    &dac_config.pio->txf[dac_config.sm],
+    dma_buf,
+    count,
+    true
+  );
+  return true;
+}
+#endif
+
 const psg_output_api_t psg_drv_mcp4922 = {
   .init         = psg_mcp4922_init,
   .start        = psg_mcp4922_start,
   .stop         = psg_mcp4922_stop,
   .write        = psg_mcp4922_write,
+#if PSG_MCP4922_DMA
+  .write_buffer = psg_mcp4922_write_buffer
+#else
   .write_buffer = NULL
+#endif
 };

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
@@ -111,9 +111,9 @@ psg_mcp4922_write(uint16_t l, uint16_t r)
 }
 
 const psg_output_api_t psg_drv_mcp4922 = {
-  .init  = psg_mcp4922_init,
-  .start = psg_mcp4922_start,
-  .stop  = psg_mcp4922_stop,
-  .write = psg_mcp4922_write
+  .init         = psg_mcp4922_init,
+  .start        = psg_mcp4922_start,
+  .stop         = psg_mcp4922_stop,
+  .write        = psg_mcp4922_write,
+  .write_buffer = NULL
 };
-

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
@@ -143,6 +143,8 @@ psg_mcp4922_stop(void)
   if (dac_config.initialized) {
     // Disable the state machine
     pio_sm_set_enabled(dac_config.pio, dac_config.sm, false);
+    pio_sm_clear_fifos(dac_config.pio, dac_config.sm);
+    pio_sm_restart(dac_config.pio, dac_config.sm);
     // Remove the program from PIO memory
     pio_remove_program(dac_config.pio, &mcp4922_dual_program, dac_config.offset);
     // Reset the initialized flag

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922.c
@@ -19,7 +19,7 @@
 
 #define DAC_SPI_BAUD  16000000   /* 16 MHz */
 #define MCP4922_PIO_CYCLES_PER_SAMPLE 151.0f
-#define MCP4922_DMA_SAMPLES (BUF_SAMPLES / 2)
+#define MCP4922_DMA_SAMPLES PSG_BUFFER_OUTPUT_SAMPLES
 
 // MCP4922 DAC configuration structure
 typedef struct {

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_pwm.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_pwm.c
@@ -58,8 +58,9 @@ psg_pwm_write(uint16_t l, uint16_t r)
 }
 
 const psg_output_api_t psg_drv_pwm = {
-  .init  = psg_pwm_init,
-  .start = psg_pwm_start,
-  .stop  = psg_pwm_stop,
-  .write = psg_pwm_write
+  .init         = psg_pwm_init,
+  .start        = psg_pwm_start,
+  .stop         = psg_pwm_stop,
+  .write        = psg_pwm_write,
+  .write_buffer = NULL
 };

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_drv_pwm.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_drv_pwm.c
@@ -1,66 +1,167 @@
 #include "pico/stdlib.h"
 #include "hardware/pwm.h"
+
+#ifndef PSG_PWM_DMA
+#define PSG_PWM_DMA 0
+#endif
+
+#if PSG_PWM_DMA
+#include "hardware/clocks.h"
 #include "hardware/dma.h"
+#endif
 
 #include "../../include/psg.h"
 
+#define PWM_STOP_SETTLE_US 50
+
 static uint slice_num;
-static uint chan_l;
-static uint chan_r;
+static bool pwm_initialized = false;
+static bool left_is_a = true;
+
+#if PSG_PWM_DMA
+static int dma_chan = -1;
+static dma_channel_config dma_config;
+static uint32_t dma_buf[PSG_BUFFER_OUTPUT_SAMPLES];
+#endif
+
+static void
+psg_pwm_shutdown(void)
+{
+  if (!pwm_initialized) return;
+
+#if PSG_PWM_DMA
+  if (dma_chan >= 0) {
+    dma_channel_abort(dma_chan);
+    dma_channel_cleanup(dma_chan);
+    dma_channel_unclaim(dma_chan);
+    dma_chan = -1;
+  }
+#endif
+
+  pwm_set_both_levels(slice_num, 0, 0);
+  sleep_us(PWM_STOP_SETTLE_US);
+  pwm_set_enabled(slice_num, false);
+  pwm_initialized = false;
+}
 
 static void
 psg_pwm_init(uint8_t lpin, uint8_t rpin)
 {
   uint l_gpio = (uint)lpin;
   uint r_gpio = (uint)rpin;
+  uint l_slice = pwm_gpio_to_slice_num(l_gpio);
+  uint r_slice = pwm_gpio_to_slice_num(r_gpio);
+
+  psg_pwm_shutdown();
+
+  if (l_slice != r_slice) {
+    // ToDo: Should raise an exception
+    return;
+  }
 
   gpio_set_function(l_gpio, GPIO_FUNC_PWM);
   gpio_set_function(r_gpio, GPIO_FUNC_PWM);
 
-  slice_num = pwm_gpio_to_slice_num(l_gpio);
-  if (slice_num != pwm_gpio_to_slice_num(r_gpio)) {
-    // ToDo: Should raise an exception
-    return;
-  }
-  chan_l = pwm_gpio_to_channel(l_gpio);
-  chan_r = pwm_gpio_to_channel(r_gpio);
+  slice_num = l_slice;
+  left_is_a = (pwm_gpio_to_channel(l_gpio) == PWM_CHAN_A);
 
   /* common settings ------------------------------------------------ */
   pwm_set_wrap(slice_num, MAX_SAMPLE_WIDTH);
 
+#if PSG_PWM_DMA
+  pwm_set_clkdiv(slice_num, (float)clock_get_hz(clk_sys) / (SAMPLE_RATE * (MAX_SAMPLE_WIDTH + 1.0f)));
+#else
   /* optional: div = 1.0 (125 MHz) -> 30.5 kHz carrier @ wrap 4095   */
   pwm_set_clkdiv_int_frac(slice_num, 1, 0);
+#endif
 
   /* start with zero level to avoid pop                               */
   pwm_set_both_levels(slice_num, 0, 0);
 
+#if PSG_PWM_DMA
+  dma_chan = dma_claim_unused_channel(true);
+  dma_config = dma_channel_get_default_config(dma_chan);
+  channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
+  channel_config_set_read_increment(&dma_config, true);
+  channel_config_set_write_increment(&dma_config, false);
+  channel_config_set_dreq(&dma_config, pwm_get_dreq(slice_num));
+  dma_channel_configure(
+    dma_chan,
+    &dma_config,
+    &pwm_hw->slice[slice_num].cc,
+    NULL,
+    0,
+    false
+  );
+#endif
+
   pwm_set_enabled(slice_num, true);
+  pwm_initialized = true;
 }
 
 static void
 psg_pwm_start(void)
 {
+  if (pwm_initialized) pwm_set_enabled(slice_num, true);
 }
 
 static void
 psg_pwm_stop(void)
 {
+  psg_pwm_shutdown();
 }
 
 static void
 psg_pwm_write(uint16_t l, uint16_t r)
 {
-  if (chan_l == PWM_CHAN_A) {
+  if (!pwm_initialized) return;
+
+  if (left_is_a) {
     pwm_set_both_levels(slice_num, l, r);
   } else {
     pwm_set_both_levels(slice_num, r, l);
   }
 }
 
+#if PSG_PWM_DMA
+static inline uint32_t
+psg_pwm_pack_sample(uint32_t sample)
+{
+  uint16_t l = (sample >> 16) & MAX_SAMPLE_WIDTH;
+  uint16_t r = sample & MAX_SAMPLE_WIDTH;
+  return left_is_a ? (((uint32_t)r << 16) | l) : (((uint32_t)l << 16) | r);
+}
+
+static bool
+psg_pwm_write_buffer(const uint32_t *samples, uint32_t count)
+{
+  if (!pwm_initialized || dma_chan < 0 || count > PSG_BUFFER_OUTPUT_SAMPLES) return false;
+  if (dma_channel_is_busy(dma_chan)) return false;
+
+  for (uint32_t i = 0; i < count; i++) {
+    dma_buf[i] = psg_pwm_pack_sample(samples[i]);
+  }
+
+  dma_channel_configure(
+    dma_chan,
+    &dma_config,
+    &pwm_hw->slice[slice_num].cc,
+    dma_buf,
+    count,
+    true
+  );
+  return true;
+}
+#endif
+
 const psg_output_api_t psg_drv_pwm = {
   .init         = psg_pwm_init,
   .start        = psg_pwm_start,
   .stop         = psg_pwm_stop,
   .write        = psg_pwm_write,
+#if PSG_PWM_DMA
+  .write_buffer = psg_pwm_write_buffer
+#else
   .write_buffer = NULL
+#endif
 };

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
@@ -14,10 +14,7 @@
 #include "../../include/psg.h"
 
 // Critical section
-#if defined(PICO_RP2040)
-
-#include "pico/multicore.h"
-#include "hardware/sync.h"
+#if defined(PICO_RP2040) || defined(PICO_RP2350)
 
 static spin_lock_t *psg_spin;
 
@@ -28,44 +25,20 @@ __attribute__((constructor))
 static void
 psg_port_init(void)
 {
-  /* Obtain a free HW spin-lock for inter-core critical sections:
-   *   1) spin_lock_claim_unused(true)  -> find & reserve an unused lock ID (panic if none)
-   *   2) spin_lock_instance(id)        -> convert that ID into a spin_lock_t* handle
-   * Use the handle with spin_lock_blocking()/spin_unlock() to guard shared PSG state. */
+  /* The packet ring buffer and PSG state are shared by core0 and core1. */
   psg_spin = spin_lock_instance(spin_lock_claim_unused(true));
 }
 
 psg_cs_token_t
 PSG_enter_critical(void)
 {
-  uint32_t irq_state = save_and_disable_interrupts();
-  spin_lock_unsafe_blocking(psg_spin);
-  return irq_state; // token = IRQ
+  return spin_lock_blocking(psg_spin);
 }
 
 void
 PSG_exit_critical(psg_cs_token_t token)
 {
   spin_unlock(psg_spin, token);
-}
-
-#elif defined(PICO_RP2350)
-
-#include "cmsis_gcc.h"
-static volatile uint32_t psg_lock = 0;
-
-psg_cs_token_t
-PSG_enter_critical(void)
-{
-  uint32_t irq_state = __get_PRIMASK();
-  __disable_irq();
-  return irq_state;
-}
-
-void
-PSG_exit_critical(psg_cs_token_t token)
-{
-  if (!token) __enable_irq();
 }
 
 #endif
@@ -111,11 +84,27 @@ static volatile bool core1_alive = false;
 // Audio timer (must be declared before psg_core1_main)
 static repeating_timer_t audio_timer;
 
-#if 1
-#define DBG_PIN  5
-#define DBG_TOGGLE()  (sio_hw->gpio_togl = 1u << DBG_PIN)
+#ifndef PSG_DEBUG_AUDIO_PIN
+#define PSG_DEBUG_AUDIO_PIN -1
+#endif
+
+#if PSG_DEBUG_AUDIO_PIN >= 0
+#define DBG_TOGGLE()  (sio_hw->gpio_togl = 1u << PSG_DEBUG_AUDIO_PIN)
+
+static inline void
+debug_audio_pin_init(void)
+{
+  gpio_init(PSG_DEBUG_AUDIO_PIN);
+  gpio_set_dir(PSG_DEBUG_AUDIO_PIN, GPIO_OUT);
+  gpio_put(PSG_DEBUG_AUDIO_PIN, 0);
+}
 #else
-#define DBG_TOGGLE()
+#define DBG_TOGGLE()  ((void)0)
+
+static inline void
+debug_audio_pin_init(void)
+{
+}
 #endif
 
 static bool
@@ -199,11 +188,7 @@ psg_core1_main(void)
 void
 PSG_tick_start_core1(uint8_t p1, uint8_t p2)
 {
-#if 1
-  gpio_init(DBG_PIN);
-  gpio_set_dir(DBG_PIN, GPIO_OUT);
-  gpio_put(DBG_PIN, 0);
-#endif
+  debug_audio_pin_init();
 
   PSG_render_block(pcm_buf, BUF_SAMPLES);
   rd_idx = 0;

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
@@ -151,6 +151,17 @@ psg_core1_main(void)
     assert(false && "Failed to add repeating timer");
   }
 
+  if (!audio_alarm_pool) {
+    audio_alarm_pool = alarm_pool_create(ALARM_AUDIO, 2);
+    assert(audio_alarm_pool && "Failed to create alarm audio_alarm_pool");
+    irq_set_priority(PICORB_IRQ_1, 0);
+  }
+  memset(&audio_timer, 0, sizeof(repeating_timer_t));
+  /* 22.05 kHz */
+  if (!alarm_pool_add_repeating_timer_us(audio_alarm_pool, -1000000 / SAMPLE_RATE, audio_cb, NULL, &audio_timer)) {
+    assert(false && "Failed to add repeating timer");
+  }
+
   multicore_fifo_push_blocking(ACK_CORE1_READY);
 
   for (;;) {
@@ -173,9 +184,20 @@ psg_core1_main(void)
     if (multicore_fifo_rvalid()) {
       uint32_t cmd = multicore_fifo_pop_blocking();
       if (cmd == CMD_CLEANUP) {
-        cancel_repeating_timer(&tick_timer);
-        alarm_pool_destroy(tick_alarm_pool);
-        tick_alarm_pool  = NULL;
+        if (audio_alarm_pool) {
+          cancel_repeating_timer(&audio_timer);
+          alarm_pool_destroy(audio_alarm_pool);
+          audio_alarm_pool = NULL;
+        }
+        if (tick_alarm_pool) {
+          cancel_repeating_timer(&tick_timer);
+          alarm_pool_destroy(tick_alarm_pool);
+          tick_alarm_pool = NULL;
+        }
+        if (psg_drv) {
+          psg_drv->stop();
+          psg_drv = NULL;
+        }
         multicore_fifo_push_blocking(ACK_DONE);
         for (;;) tight_loop_contents();
       }
@@ -206,35 +228,20 @@ PSG_tick_start_core1(uint8_t p1, uint8_t p2)
     core1_alive = true;
   }
 
-  if (!audio_alarm_pool) {
-    audio_alarm_pool = alarm_pool_create(ALARM_AUDIO, 2);
-    assert(audio_alarm_pool && "Failed to create alarm audio_alarm_pool");
-    irq_set_priority(PICORB_IRQ_1, 0);
-  }
-  memset(&audio_timer, 0, sizeof(repeating_timer_t));
-  /* 22.05 kHz */
-  if (!alarm_pool_add_repeating_timer_us(audio_alarm_pool, -1000000 / SAMPLE_RATE, audio_cb, NULL, &audio_timer)) {
-    assert(false && "Failed to add repeating timer");
-  }
 }
 
 void
 PSG_tick_stop_core1(void)
 {
-  if (psg_drv) {
-    psg_drv->stop();
-    psg_drv = NULL;
-  }
   if (core1_alive) {
     multicore_fifo_push_blocking(CMD_CLEANUP);
     while (multicore_fifo_pop_blocking() != ACK_DONE) {
       // wait
     }
     multicore_reset_core1();
-
-    cancel_repeating_timer(&audio_timer);
-    alarm_pool_destroy(audio_alarm_pool);
-    audio_alarm_pool = NULL;
     core1_alive = false;
+  } else if (psg_drv) {
+    psg_drv->stop();
+    psg_drv = NULL;
   }
 }

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
@@ -202,12 +202,12 @@ psg_core1_main(void)
   for (;;) {
     if (use_buffer_output) {
       uint32_t *dst = &pcm_buf[buffer_output_pos];
-      PSG_render_block(dst, BUF_SAMPLES / 2);
-      while (!psg_drv->write_buffer(dst, BUF_SAMPLES / 2)) {
+      PSG_render_block(dst, PSG_BUFFER_OUTPUT_SAMPLES);
+      while (!psg_drv->write_buffer(dst, PSG_BUFFER_OUTPUT_SAMPLES)) {
         tight_loop_contents();
         psg_core1_poll_command();
       }
-      buffer_output_pos ^= BUF_SAMPLES / 2;
+      buffer_output_pos = (buffer_output_pos + PSG_BUFFER_OUTPUT_SAMPLES) & BUF_MASK;
     } else {
       // core1 is responsible for rendering audio samples (heavy load)
       uint32_t used = wr_idx - rd_idx;

--- a/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
+++ b/mrbgems/picoruby-psg/ports/rp2040/psg_port.c
@@ -133,12 +133,43 @@ enum {
 #endif
 
 static void __attribute__((noreturn))
+psg_core1_cleanup(void)
+{
+  if (audio_alarm_pool) {
+    cancel_repeating_timer(&audio_timer);
+    alarm_pool_destroy(audio_alarm_pool);
+    audio_alarm_pool = NULL;
+  }
+  if (tick_alarm_pool) {
+    cancel_repeating_timer(&tick_timer);
+    alarm_pool_destroy(tick_alarm_pool);
+    tick_alarm_pool = NULL;
+  }
+  if (psg_drv) {
+    psg_drv->stop();
+    psg_drv = NULL;
+  }
+  multicore_fifo_push_blocking(ACK_DONE);
+  for (;;) tight_loop_contents();
+}
+
+static inline void
+psg_core1_poll_command(void)
+{
+  if (multicore_fifo_rvalid()) {
+    uint32_t cmd = multicore_fifo_pop_blocking();
+    if (cmd == CMD_CLEANUP) psg_core1_cleanup();
+  }
+}
+
+static void __attribute__((noreturn))
 psg_core1_main(void)
 {
   uint8_t p1 = (uint8_t)multicore_fifo_pop_blocking();
   uint8_t p2 = (uint8_t)multicore_fifo_pop_blocking();
   psg_drv->init(p1, p2); /* init PSG driver */
   psg_drv->start();
+  bool use_buffer_output = psg_drv->write_buffer != NULL;
 
   if (!tick_alarm_pool) {
     tick_alarm_pool = alarm_pool_create(ALARM_TICK, 2);
@@ -151,57 +182,50 @@ psg_core1_main(void)
     assert(false && "Failed to add repeating timer");
   }
 
-  if (!audio_alarm_pool) {
-    audio_alarm_pool = alarm_pool_create(ALARM_AUDIO, 2);
-    assert(audio_alarm_pool && "Failed to create alarm audio_alarm_pool");
-    irq_set_priority(PICORB_IRQ_1, 0);
-  }
-  memset(&audio_timer, 0, sizeof(repeating_timer_t));
-  /* 22.05 kHz */
-  if (!alarm_pool_add_repeating_timer_us(audio_alarm_pool, -1000000 / SAMPLE_RATE, audio_cb, NULL, &audio_timer)) {
-    assert(false && "Failed to add repeating timer");
+  if (!use_buffer_output) {
+    if (!audio_alarm_pool) {
+      audio_alarm_pool = alarm_pool_create(ALARM_AUDIO, 2);
+      assert(audio_alarm_pool && "Failed to create alarm audio_alarm_pool");
+      irq_set_priority(PICORB_IRQ_1, 0);
+    }
+    memset(&audio_timer, 0, sizeof(repeating_timer_t));
+    /* 22.05 kHz */
+    if (!alarm_pool_add_repeating_timer_us(audio_alarm_pool, -1000000 / SAMPLE_RATE, audio_cb, NULL, &audio_timer)) {
+      assert(false && "Failed to add repeating timer");
+    }
   }
 
   multicore_fifo_push_blocking(ACK_CORE1_READY);
 
+  uint32_t buffer_output_pos = 0;
+
   for (;;) {
-    // core1 is responsible for rendering audio samples (heavy load)
-    uint32_t used = wr_idx - rd_idx;
-    if (used <= BUF_SAMPLES / 2) {
-      uint32_t dst_pos = wr_idx & BUF_MASK;  // Start position to write
-      // How many words can we write at the end of the buffer?
-      uint32_t first_len = MIN(BUF_SAMPLES - dst_pos, BUF_SAMPLES / 2);
-      PSG_render_block(&pcm_buf[dst_pos], first_len);
-      // If there are remaining words, write them at the beginning of the buffer
-      if (first_len < BUF_SAMPLES / 2) {
-        PSG_render_block(pcm_buf, BUF_SAMPLES / 2 - first_len);
+    if (use_buffer_output) {
+      uint32_t *dst = &pcm_buf[buffer_output_pos];
+      PSG_render_block(dst, BUF_SAMPLES / 2);
+      while (!psg_drv->write_buffer(dst, BUF_SAMPLES / 2)) {
+        tight_loop_contents();
+        psg_core1_poll_command();
       }
-      wr_idx += BUF_SAMPLES / 2;
+      buffer_output_pos ^= BUF_SAMPLES / 2;
+    } else {
+      // core1 is responsible for rendering audio samples (heavy load)
+      uint32_t used = wr_idx - rd_idx;
+      if (used <= BUF_SAMPLES / 2) {
+        uint32_t dst_pos = wr_idx & BUF_MASK;  // Start position to write
+        // How many words can we write at the end of the buffer?
+        uint32_t first_len = MIN(BUF_SAMPLES - dst_pos, BUF_SAMPLES / 2);
+        PSG_render_block(&pcm_buf[dst_pos], first_len);
+        // If there are remaining words, write them at the beginning of the buffer
+        if (first_len < BUF_SAMPLES / 2) {
+          PSG_render_block(pcm_buf, BUF_SAMPLES / 2 - first_len);
+        }
+        wr_idx += BUF_SAMPLES / 2;
+      }
     }
 
     tight_loop_contents();
-
-    if (multicore_fifo_rvalid()) {
-      uint32_t cmd = multicore_fifo_pop_blocking();
-      if (cmd == CMD_CLEANUP) {
-        if (audio_alarm_pool) {
-          cancel_repeating_timer(&audio_timer);
-          alarm_pool_destroy(audio_alarm_pool);
-          audio_alarm_pool = NULL;
-        }
-        if (tick_alarm_pool) {
-          cancel_repeating_timer(&tick_timer);
-          alarm_pool_destroy(tick_alarm_pool);
-          tick_alarm_pool = NULL;
-        }
-        if (psg_drv) {
-          psg_drv->stop();
-          psg_drv = NULL;
-        }
-        multicore_fifo_push_blocking(ACK_DONE);
-        for (;;) tight_loop_contents();
-      }
-    }
+    psg_core1_poll_command();
   }
 
 }
@@ -212,9 +236,14 @@ PSG_tick_start_core1(uint8_t p1, uint8_t p2)
 {
   debug_audio_pin_init();
 
-  PSG_render_block(pcm_buf, BUF_SAMPLES);
-  rd_idx = 0;
-  wr_idx = BUF_SAMPLES;
+  if (psg_drv && psg_drv->write_buffer) {
+    rd_idx = 0;
+    wr_idx = 0;
+  } else {
+    PSG_render_block(pcm_buf, BUF_SAMPLES);
+    rd_idx = 0;
+    wr_idx = BUF_SAMPLES;
+  }
 
   if (!core1_alive) {
     multicore_launch_core1(psg_core1_main);

--- a/mrbgems/picoruby-psg/sig/psg.rbs
+++ b/mrbgems/picoruby-psg/sig/psg.rbs
@@ -1,13 +1,47 @@
 #$DEBUG: bool
 
 module PSG
+  class Playback
+    WAIT_RETRY_MS: Integer
+    WAIT_SLICE_MS: Integer
+
+    @driver: untyped
+    @tracks: Array[String]
+    @queue: Task::Queue
+    @tempo_scale: Float
+    @stopped: bool
+    @paused: bool
+    @replay_requested: bool
+    @sequencer_task: Task?
+    @sound_task: Task?
+
+    attr_reader queue: Task::Queue
+    attr_reader tracks: Array[String]
+    attr_accessor tempo_scale: Float
+
+    def initialize: (untyped driver, Array[String] tracks, ?loop: bool, ?terminate: bool) -> void
+    def start: () -> self
+    def join: () -> self
+    def stop: () -> self
+    def pause: () -> self
+    def resume: () -> self
+    def paused?: () -> bool
+    def stopped?: () -> bool
+    def replay: () -> self
+    def __sound_loop: () -> void
+    def __sequencer_loop: () -> void
+    def __wait_delta: (Integer | Float delta) -> void
+    def __enqueue_mml_event: (Integer tr, Symbol command, Integer arg0, Integer arg1) -> void
+    def __enqueue_silence: () -> void
+    def __enqueue: (Array[untyped] command) -> bool
+    def __write_command: (Array[untyped] command) -> void
+    def silence_direct: () -> void
+  end
+
   class Driver
     CHIP_CLOCK: Integer
     SAMPLE_RATE: Integer
     TIMBRES: Hash[Symbol, Integer]
-
-    $__psg_bgm_tracks: Array[String]
-    $__psg_driver: ::PSG::Driver
 
     def self.select_pwm: (Integer left, Integer right) -> void
     def self.select_mcp4922: (Integer ldac) -> void
@@ -28,10 +62,12 @@ module PSG
     def mute_direct: (Integer ch, Integer flag) -> nil
 
     WAIT_MS: Integer
-    @bgm_task: Task?
+    @mml_playback: PSG::Playback?
+    @bgm_playback: PSG::Playback?
     def play_mml: (Array[String] tracks, ?terminate: bool) -> self
+    def start_mml: (Array[String] tracks, ?loop: bool, ?terminate: bool) -> PSG::Playback
     def play_prs: (String filename, ?terminate: bool) -> void
-    def start_bgm: (Array[String] tracks) -> void
+    def start_bgm: (Array[String] tracks) -> PSG::Playback
     def stop_bgm: () -> void
     private def trap: () -> void
     private def invoke: (Symbol command, Integer arg1, Integer arg2, Integer arg3, ?Integer arg4) -> void

--- a/mrbgems/picoruby-psg/sig/psg.rbs
+++ b/mrbgems/picoruby-psg/sig/psg.rbs
@@ -90,6 +90,7 @@ module PSG
     TONE_K: Float
     CH: Integer
     @ch_reg: Integer
+    @channel: Integer
     @driver: PSG::Driver
     def self.note_to_period: (Integer note) -> Integer
     def initialize: (PSG::Driver driver, ?channel: Integer) -> void

--- a/mrbgems/picoruby-psg/sig/psg.rbs
+++ b/mrbgems/picoruby-psg/sig/psg.rbs
@@ -5,6 +5,9 @@ module PSG
     WAIT_RETRY_MS: Integer
     WAIT_SLICE_MS: Integer
 
+    self.@__registry: Hash[Integer, PSG::Playback]?
+    self.@__next_id: Integer?
+
     @driver: untyped
     @tracks: Array[String]
     @queue: Task::Queue
@@ -14,14 +17,23 @@ module PSG
     @replay_requested: bool
     @sequencer_task: Task?
     @sound_task: Task?
+    @registry_id: Integer?
+    @running_tasks: Integer
 
     attr_reader queue: Task::Queue
     attr_reader tracks: Array[String]
     attr_accessor tempo_scale: Float
 
+    def self.__register: (PSG::Playback playback) -> Integer
+    def self.__fetch: (Integer id) -> PSG::Playback?
+    def self.__unregister: (Integer? id) -> void
+    def self.__run_task: (Integer id, Symbol kind) -> void
+
     def initialize: (untyped driver, Array[String] tracks, ?loop: bool, ?terminate: bool) -> void
     def start: () -> self
     def join: () -> self
+    def __create_task: (Symbol kind) -> Task
+    def __task_finished: () -> void
     def stop: () -> self
     def pause: () -> self
     def resume: () -> self

--- a/mrbgems/picoruby-psg/test.suspend/playback_test.rb
+++ b/mrbgems/picoruby-psg/test.suspend/playback_test.rb
@@ -1,0 +1,128 @@
+class PSGPlaybackFakeDriver
+  attr_reader :commands, :direct_commands, :flush_count, :join_count
+
+  def initialize(failures: 0)
+    @commands = []
+    @direct_commands = []
+    @flush_count = 0
+    @join_count = 0
+    @failures = failures
+  end
+
+  def push_command(command)
+    if 0 < @failures
+      @failures -= 1
+      return false
+    end
+    @commands << command
+    true
+  end
+
+  def send_reg(reg, val, tick_delay = 0)
+    push_command([:send_reg, reg, val, tick_delay])
+  end
+
+  def mute(ch, flag, tick_delay = 0)
+    push_command([:mute, ch, flag, tick_delay])
+  end
+
+  def set_pan(ch, pan, tick_delay = 0)
+    push_command([:set_pan, ch, pan, tick_delay])
+  end
+
+  def set_timbre(ch, timbre, tick_delay = 0)
+    push_command([:set_timbre, ch, timbre, tick_delay])
+  end
+
+  def set_legato(ch, legato, tick_delay = 0)
+    push_command([:set_legato, ch, legato, tick_delay])
+  end
+
+  def set_lfo(ch, depth, rate, tick_delay = 0)
+    push_command([:set_lfo, ch, depth, rate, tick_delay])
+  end
+
+  def write_reg_direct(reg, val)
+    @direct_commands << [:write_reg_direct, reg, val]
+  end
+
+  def mute_direct(ch, flag)
+    @direct_commands << [:mute_direct, ch, flag]
+  end
+
+  def buffer_flush
+    @flush_count += 1
+  end
+
+  def join
+    @join_count += 1
+  end
+end
+
+class PSGPlaybackTest < Picotest::Test
+  def setup
+    unless Object.const_defined?(:Task) && Task.const_defined?(:Queue)
+      skip "Task::Queue is not available"
+    end
+  end
+
+  def test_enqueue_mml_play_event_as_immediate_register_writes
+    driver = PSGPlaybackFakeDriver.new
+    playback = PSG::Playback.new(driver, ["c"], loop: false)
+
+    playback.__enqueue_mml_event(1, :play, 0x123, 0)
+
+    assert_equal [:send_reg, 2, 0x23], playback.queue.pop(true)
+    assert_equal [:send_reg, 3, 0x01], playback.queue.pop(true)
+  end
+
+  def test_compile_multi_yields_second_event_argument
+    lfo_event = nil
+
+    MML.compile_multi(["j1,7 c"], loop: false) do |_delta, _tr, command, arg0, arg1|
+      lfo_event = [command, arg0, arg1] if command == :lfo
+    end
+
+    assert_equal [:lfo, 100, 7], lfo_event
+  end
+
+  def test_sound_loop_retries_when_driver_buffer_is_full
+    driver = PSGPlaybackFakeDriver.new(failures: 1)
+    playback = PSG::Playback.new(driver, ["c"], loop: false)
+
+    playback.__write_command([:send_reg, 4, 55])
+
+    assert_equal [[:send_reg, 4, 55, 0]], driver.commands
+  end
+
+  def test_playback_runs_mml_through_queue
+    driver = PSGPlaybackFakeDriver.new
+    playback = PSG::Playback.new(driver, ["t60000 l4 c"], loop: false)
+
+    playback.start.join
+
+    assert_true playback.queue.closed?
+    assert_true driver.commands.include?([:mute, 0, 0, 0])
+    assert_true !driver.commands.find { |cmd| cmd[0] == :send_reg && cmd[1] == 0 }.nil?
+    assert_true driver.commands.include?([:send_reg, 8, 0, 0])
+    assert_true driver.commands.include?([:mute, 0, 1, 0])
+  end
+
+  def test_stop_closes_queue_and_silences_directly
+    driver = PSGPlaybackFakeDriver.new
+    playback = PSG::Playback.new(driver, ["t60 l1 c"], loop: false)
+
+    playback.start
+    Task.new do
+      sleep_ms 1
+      playback.stop
+    end
+    Task.run
+
+    assert_true playback.stopped?
+    assert_true playback.queue.closed?
+    assert_equal 1, driver.flush_count
+    assert_true driver.direct_commands.include?([:write_reg_direct, 8, 0])
+    assert_true driver.direct_commands.include?([:mute_direct, 0, 1])
+  end
+end

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -156,7 +156,7 @@ if(PICORUBY_PSG_MCP4922_DMA)
   target_compile_definitions(${PROJECT_NAME} PRIVATE PSG_MCP4922_DMA=1)
 endif()
 
-option(PICORUBY_PSG_PWM_DMA "Use DMA for PSG PWM output" OFF)
+option(PICORUBY_PSG_PWM_DMA "Use DMA for PSG PWM output" ON)
 if(PICORUBY_PSG_PWM_DMA)
   target_compile_definitions(${PROJECT_NAME} PRIVATE PSG_PWM_DMA=1)
 endif()

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -156,6 +156,11 @@ if(PICORUBY_PSG_MCP4922_DMA)
   target_compile_definitions(${PROJECT_NAME} PRIVATE PSG_MCP4922_DMA=1)
 endif()
 
+option(PICORUBY_PSG_PWM_DMA "Use DMA for PSG PWM output" OFF)
+if(PICORUBY_PSG_PWM_DMA)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE PSG_PWM_DMA=1)
+endif()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pico_stdlib
   pico_stdio

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -151,6 +151,11 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
   PICO_HEAP_SIZE=0x0400        # 1KB
 )
 
+option(PICORUBY_PSG_MCP4922_DMA "Use DMA for PSG MCP4922 output" ON)
+if(PICORUBY_PSG_MCP4922_DMA)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE PSG_MCP4922_DMA=1)
+endif()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pico_stdlib
   pico_stdio

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -47,6 +47,12 @@ def r2p2_def_psg_mcp4922_dma
   "-D PICORUBY_PSG_MCP4922_DMA=#{enabled ? 'ON' : 'OFF'}"
 end
 
+def r2p2_def_psg_pwm_dma
+  value = ENV["PICORUBY_PSG_PWM_DMA"]
+  enabled = value && !%w[0 off false no n].include?(value.downcase)
+  "-D PICORUBY_PSG_PWM_DMA=#{enabled ? 'ON' : 'OFF'}"
+end
+
 def r2p2_build_dir(vm, board, mode)
   "#{MRUBY_ROOT}/build/r2p2/#{vm}/#{board}/#{mode}"
 end
@@ -134,7 +140,8 @@ namespace :r2p2 do
                 #{r2p2_def_r2p2_name(vm, board)} \
                 #{r2p2_def_board(board)} \
                 #{r2p2_def_build_type(mode)} \
-                #{r2p2_def_psg_mcp4922_dma}
+                #{r2p2_def_psg_mcp4922_dma} \
+                #{r2p2_def_psg_pwm_dma}
               DEFS
               sh "cmake -S #{R2P2_GEM_DIR}/cmake -B #{dir} #{defs}"
               sh "cmake --build #{dir}"

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -41,6 +41,12 @@ def r2p2_def_picorb_vm(vm)
   vm == 'femtoruby' ? '-D PICORB_VM_MRUBYC=1' : '-D PICORB_VM_MRUBY=1'
 end
 
+def r2p2_def_psg_mcp4922_dma
+  value = ENV["PICORUBY_PSG_MCP4922_DMA"]
+  enabled = !value || !%w[0 off false no n].include?(value.downcase)
+  "-D PICORUBY_PSG_MCP4922_DMA=#{enabled ? 'ON' : 'OFF'}"
+end
+
 def r2p2_build_dir(vm, board, mode)
   "#{MRUBY_ROOT}/build/r2p2/#{vm}/#{board}/#{mode}"
 end
@@ -127,7 +133,8 @@ namespace :r2p2 do
                 #{r2p2_def_picorb_vm(vm)} \
                 #{r2p2_def_r2p2_name(vm, board)} \
                 #{r2p2_def_board(board)} \
-                #{r2p2_def_build_type(mode)}
+                #{r2p2_def_build_type(mode)} \
+                #{r2p2_def_psg_mcp4922_dma}
               DEFS
               sh "cmake -S #{R2P2_GEM_DIR}/cmake -B #{dir} #{defs}"
               sh "cmake --build #{dir}"

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -49,7 +49,7 @@ end
 
 def r2p2_def_psg_pwm_dma
   value = ENV["PICORUBY_PSG_PWM_DMA"]
-  enabled = value && !%w[0 off false no n].include?(value.downcase)
+  enabled = !value || !%w[0 off false no n].include?(value.downcase)
   "-D PICORUBY_PSG_PWM_DMA=#{enabled ? 'ON' : 'OFF'}"
 end
 


### PR DESCRIPTION
This pull request introduces significant improvements to the PSG (Programmable Sound Generator) emulator for PicoRuby, especially targeting Raspberry Pi Pico (R2P2) builds. The main focus is on enabling and documenting DMA-based audio output for both MCP4922 DAC and PWM, improving playback performance, updating the MML playback model, and enhancing the keyboard and task APIs. There are also new usage examples and updates to the documentation.

**DMA Audio Output Enhancements (Performance & Architecture):**
- Enabled DMA-based output for both MCP4922 DAC and PWM by default on R2P2, including new buffer management and DMA channel handling in the C driver, which allows core1 to render and feed audio in blocks for improved real-time playback. [[1]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R7-R22) [[2]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R38-R43) [[3]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R101-R123) [[4]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R134-R147) [[5]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R161-L119) [[6]](diffhunk://#diff-3151fe072ea16300053133cf3057952af6c13b37c99cc69279ca37aeabb6d26bR189) [[7]](diffhunk://#diff-3151fe072ea16300053133cf3057952af6c13b37c99cc69279ca37aeabb6d26bR202-R208)
- Updated build configuration to include the `picoruby-psg` gem for R2P2 builds.

**Documentation Updates:**
- Comprehensive rewrite and rename of the PSG README, describing DMA output modes, build instructions, environment variable controls, and usage notes for both MCP4922 and PWM outputs. [[1]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819R5-R60) [[2]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819L76-R132)
- Added a new section to the MML README explaining the updated playback model, asynchronous playback API, and detailed event/command formats. [[1]](diffhunk://#diff-f50d900a7f49e39af05e5933a8ba087a4b9a6232372660cf211e00bcb80d59b2R31-R67) [[2]](diffhunk://#diff-f50d900a7f49e39af05e5933a8ba087a4b9a6232372660cf211e00bcb80d59b2L73-R126)
- Minor table formatting fixes and new usage section in the PSG README. [[1]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819L76-R132) [[2]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819R148-R151)

**API and Usability Improvements:**
- Enhanced the `Task` and `Task::Queue` RBS signatures with new methods (`run`, `__push`, `__pop_try`, `__retry?`) and error handling. [[1]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR2-R3) [[2]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR13) [[3]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR32-R34)
- Updated the keyboard interface to use the correct chip clock constant, improved note handling logic, and fixed key event processing for more reliable live keyboard input. [[1]](diffhunk://#diff-b518f13814d44bdd841b437d7e3ce4fae5f0099acd364ebb40cbd70a584f0081L8-R8) [[2]](diffhunk://#diff-b518f13814d44bdd841b437d7e3ce4fae5f0099acd364ebb40cbd70a584f0081R28-L56)

**Examples and Tests:**
- Added new example scripts for keyboard PWM and multiple "Twinkle" MML playback scenarios, demonstrating the new APIs and output modes. [[1]](diffhunk://#diff-38301b1edf1cd6ab006655db760ca68e7f9a6aec1b9931bb5122ed7a8bc3b81cR1-R18) [[2]](diffhunk://#diff-f4906599e955c9b1accd065c6aea874e9bf8adde2cfaa9e8f404e5e8b11f2602R1-R2) [[3]](diffhunk://#diff-4533191e28f26458d18cf9224d2a6ef3c7b58c9f2a961307969944b109abb969R1-R2)

**Other Notable Changes:**
- Updated the mrubyc submodule to a newer commit.
- Adjusted the MML event yield signature to include an additional argument for richer command handling.

**References:**
- DMA output and buffer management: [[1]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R7-R22) [[2]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R38-R43) [[3]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R101-R123) [[4]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R134-R147) [[5]](diffhunk://#diff-fbcb7255291fcbe361a9854561b486af396563c85788517d5eae99776e564424R161-L119) [[6]](diffhunk://#diff-3151fe072ea16300053133cf3057952af6c13b37c99cc69279ca37aeabb6d26bR189) [[7]](diffhunk://#diff-3151fe072ea16300053133cf3057952af6c13b37c99cc69279ca37aeabb6d26bR202-R208)
- Build configuration:
- Documentation: [[1]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819R5-R60) [[2]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819L76-R132) [[3]](diffhunk://#diff-d87f327553549c44e275528b012f9d51959bdfb16d506da33695db03292ab819R148-R151) [[4]](diffhunk://#diff-f50d900a7f49e39af05e5933a8ba087a4b9a6232372660cf211e00bcb80d59b2R31-R67) [[5]](diffhunk://#diff-f50d900a7f49e39af05e5933a8ba087a4b9a6232372660cf211e00bcb80d59b2L73-R126)
- Task/Queue API: [[1]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR2-R3) [[2]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR13) [[3]](diffhunk://#diff-38e48d7ef68358a8c44118d837a013a64645c890ad3d6f2551a7c9d1f014e56eR32-R34)
- Keyboard improvements: [[1]](diffhunk://#diff-b518f13814d44bdd841b437d7e3ce4fae5f0099acd364ebb40cbd70a584f0081L8-R8) [[2]](diffhunk://#diff-b518f13814d44bdd841b437d7e3ce4fae5f0099acd364ebb40cbd70a584f0081R28-L56)
- Examples: [[1]](diffhunk://#diff-38301b1edf1cd6ab006655db760ca68e7f9a6aec1b9931bb5122ed7a8bc3b81cR1-R18) [[2]](diffhunk://#diff-f4906599e955c9b1accd065c6aea874e9bf8adde2cfaa9e8f404e5e8b11f2602R1-R2) [[3]](diffhunk://#diff-4533191e28f26458d18cf9224d2a6ef3c7b58c9f2a961307969944b109abb969R1-R2)
- Submodule update:
- MML event signature: