### PR TITLE
Revert "Bound per-read request in PicoModem.read_exact to keep small-stack builds safe"

### DIFF
--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -37,8 +37,6 @@ module PicoModem
 
   CHUNK_SIZE = 480
   TIMEOUT_MS = 5000
-  # Cap per-call read_nonblock so io-console's caller-sized stack VLA stays small on ESP32/mruby-c.
-  READ_NONBLOCK_MAX = 64
 
   # Run a PicoModem session: read frames, dispatch commands, return to shell
   def self.session(io_in, io_out)
@@ -134,9 +132,7 @@ module PicoModem
     buf = ""
     waited = 0
     while buf.bytesize < n
-      want = n - buf.bytesize
-      want = READ_NONBLOCK_MAX if READ_NONBLOCK_MAX < want
-      chunk = io.read_nonblock(want)
+      chunk = io.read_nonblock(n - buf.bytesize)
       if chunk
         buf << chunk
         waited = 0

--- a/mrbgems/picoruby-picomodem/sig/picomodem.rbs
+++ b/mrbgems/picoruby-picomodem/sig/picomodem.rbs
@@ -19,7 +19,6 @@ module PicoModem
 
   CHUNK_SIZE: Integer
   TIMEOUT_MS: Integer
-  READ_NONBLOCK_MAX: Integer
 
   def self.session: (IO io_in, IO io_out) -> void
   def self.recv_frame: (IO io) -> [Integer, String]?


### PR DESCRIPTION
Reverts picoruby/picoruby#426

After some follow-up checking, I found that this change isn't needed for uploads to work.

R2P2-ESP32 [0.2.19](https://github.com/picoruby/R2P2-ESP32/releases/tag/0.2.19) pins picoruby [906e37f](https://github.com/picoruby/picoruby/commit/906e37f1e13d32d31e954b8e62f549396d78a562), which is older than #426 and does not include `READ_NONBLOCK_MAX`. RuntimeGems uploads succeed on that build too (once you give it some time after connecting). So uploads work without the cap.

Since this wasn't actually fixing uploads, I'd like to revert it for now and propose it again with a clearer goal if it turns out to be genuinely needed.

I'm sorry for the unnecessary back-and-forth, and I appreciate the time you spent reviewing the original change!