### PR TITLE
Fix wasm:build_picorbc task (picorbc -> mrbc-prism rename)

### DIFF
--- a/mrbgems/picoruby-wasm/.gitignore
+++ b/mrbgems/picoruby-wasm/.gitignore
@@ -11,5 +11,9 @@ npm/picorbc/dist/picorbc.js
 npm/picorbc/dist/picorbc.wasm
 npm/picorbc/debug/picorbc.js
 npm/picorbc/debug/picorbc.wasm
+npm/picorbc/dist/mrbc-prism.js
+npm/picorbc/dist/mrbc-prism.wasm
+npm/picorbc/debug/mrbc-prism.js
+npm/picorbc/debug/mrbc-prism.wasm
 npm/picorbc/package.json
 npm/**/*.tgz

--- a/tasks/picoruby/wasm.rake
+++ b/tasks/picoruby/wasm.rake
@@ -60,10 +60,10 @@ namespace :wasm do
     sh "CONFIG=picorbc-wasm PICORB_DEBUG=1 rake"
     FileUtils.mkdir_p("#{picorbc_npm_dir}/debug")
     FileUtils.mkdir_p("#{picorbc_npm_dir}/dist")
-    sh "cp build/picorbc-wasm/bin/picorbc.js #{picorbc_npm_dir}/debug/"
-    sh "cp build/picorbc-wasm/bin/picorbc.wasm #{picorbc_npm_dir}/debug/"
-    sh "cp build/picorbc-wasm/bin/picorbc.js #{picorbc_npm_dir}/dist/"
-    sh "cp build/picorbc-wasm/bin/picorbc.wasm #{picorbc_npm_dir}/dist/"
+    sh "cp build/picorbc-wasm/bin/mrbc-prism.js #{picorbc_npm_dir}/debug/"
+    sh "cp build/picorbc-wasm/bin/mrbc-prism.wasm #{picorbc_npm_dir}/debug/"
+    sh "cp build/picorbc-wasm/bin/mrbc-prism.js #{picorbc_npm_dir}/dist/"
+    sh "cp build/picorbc-wasm/bin/mrbc-prism.wasm #{picorbc_npm_dir}/dist/"
   end
 
   desc "Build debug PicoRuby WASM into npm/picoruby/debug and picorbc WASM"


### PR DESCRIPTION
With the rename of picorbc to mrbc-prism in #437, the names of the JS and WASM files when building picorbc-wasm also changed. Update the paths in the `wasm:build_picorbc` task to match (currently this task fails due to the referenced files being missing).

This PR assumes you would like to keep the new file names - in case you would rather keep the old JS and WASM file names instead, this PR can be closed. (I haven't checked if/how changing the name would affect the picorbc npm package for example). Thanks!