### PR TITLE
picoruby-numeric-ext: Add Integer/Float sign predicates

### DIFF
--- a/mrbgems/picoruby-numeric-ext/src/mrubyc/numeric_ext.c
+++ b/mrbgems/picoruby-numeric-ext/src/mrubyc/numeric_ext.c
@@ -111,6 +111,56 @@ c_flo_mod(struct VM *vm, mrbc_value v[], int argc)
   SET_FLOAT_RETURN(mod);
 }
 
+/* Sign predicates shared by Integer and Float */
+
+static mrbc_int_t
+c_num_sign(mrbc_value *v)
+{
+  if (mrbc_type(*v) == MRBC_TT_FLOAT) {
+    mrbc_float_t f = mrbc_float(*v);
+    return (f > 0.0) - (f < 0.0);
+  }
+  mrbc_int_t i = mrbc_integer(*v);
+  return (i > 0) - (i < 0);
+}
+
+static void
+c_num_zero_p(struct VM *vm, mrbc_value v[], int argc)
+{
+  SET_BOOL_RETURN(c_num_sign(&v[0]) == 0);
+}
+
+static void
+c_num_nonzero_p(struct VM *vm, mrbc_value v[], int argc)
+{
+  if (c_num_sign(&v[0]) == 0) {
+    SET_NIL_RETURN();
+  } else {
+    SET_RETURN(v[0]);
+  }
+}
+
+static void
+c_num_positive_p(struct VM *vm, mrbc_value v[], int argc)
+{
+  SET_BOOL_RETURN(c_num_sign(&v[0]) > 0);
+}
+
+static void
+c_num_negative_p(struct VM *vm, mrbc_value v[], int argc)
+{
+  SET_BOOL_RETURN(c_num_sign(&v[0]) < 0);
+}
+
+static void
+define_sign_predicates(mrbc_vm *vm, mrbc_class *cls)
+{
+  mrbc_define_method(vm, cls, "zero?",     c_num_zero_p);
+  mrbc_define_method(vm, cls, "nonzero?",  c_num_nonzero_p);
+  mrbc_define_method(vm, cls, "positive?", c_num_positive_p);
+  mrbc_define_method(vm, cls, "negative?", c_num_negative_p);
+}
+
 void
 mrbc_numeric_ext_init(mrbc_vm *vm)
 {
@@ -119,4 +169,7 @@ mrbc_numeric_ext_init(mrbc_vm *vm)
   mrbc_define_method(vm, fl, "floor", c_flo_floor);
   mrbc_define_method(vm, fl, "ceil",  c_flo_ceil);
   mrbc_define_method(vm, fl, "%",     c_flo_mod);
+
+  define_sign_predicates(vm, fl);
+  define_sign_predicates(vm, mrbc_get_class_by_name("Integer"));
 }

--- a/mrbgems/picoruby-numeric-ext/test/numeric_ext_test.rb
+++ b/mrbgems/picoruby-numeric-ext/test/numeric_ext_test.rb
@@ -113,4 +113,50 @@ class NumericExtTest < Picotest::Test
   def test_mod_zero_division_float
     assert_raise(ZeroDivisionError) { 1.0 % 0.0 }
   end
+
+  # Sign predicates (Integer)
+  def test_integer_zero?
+    assert_equal true, 0.zero?
+    assert_equal false, 1.zero?
+  end
+
+  def test_integer_nonzero?
+    assert_equal nil, 0.nonzero?
+    assert_equal 7, 7.nonzero?
+  end
+
+  def test_integer_positive?
+    assert_equal true, 1.positive?
+    assert_equal false, 0.positive?
+    assert_equal false, (-1).positive?
+  end
+
+  def test_integer_negative?
+    assert_equal true, (-1).negative?
+    assert_equal false, 0.negative?
+    assert_equal false, 1.negative?
+  end
+
+  # Sign predicates (Float)
+  def test_float_zero?
+    assert_equal true, 0.0.zero?
+    assert_equal false, 0.1.zero?
+  end
+
+  def test_float_nonzero?
+    assert_equal nil, 0.0.nonzero?
+    assert_equal 2.5, 2.5.nonzero?
+  end
+
+  def test_float_positive?
+    assert_equal true, 0.1.positive?
+    assert_equal false, 0.0.positive?
+    assert_equal false, (-0.1).positive?
+  end
+
+  def test_float_negative?
+    assert_equal true, (-0.1).negative?
+    assert_equal false, 0.0.negative?
+    assert_equal false, 0.1.negative?
+  end
 end

--- a/mrbgems/stdlib.gembox
+++ b/mrbgems/stdlib.gembox
@@ -24,6 +24,7 @@ MRuby::GemBox.new do |conf|
   elsif vm_mruby?
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-toplevel-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-object-ext"
+    conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-numeric-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-kernel-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-string-ext"
     conf.gem gemdir: "picoruby-mruby/lib/mruby/mrbgems/mruby-array-ext"


### PR DESCRIPTION
## Problem

`Integer`/`Float` lack `zero?` / `nonzero?` / `positive?` / `negative?` on the
mruby-backed runtime (incl. the wasm build), so a bare `0.zero?` raises
`NoMethodError` at runtime. These are standard Ruby predicates.

Root cause is twofold:
- **mruby/wasm**: `mruby-numeric-ext` (which already implements all four predicates
  on `Numeric`) was never added to the `vm_mruby?` branch of `stdlib.gembox`.
- **mrubyc**: `picoruby-numeric-ext` only defined `Float#round/floor/ceil/%`.

## Fix

- Add `mruby-numeric-ext` to the `vm_mruby?` branch of `stdlib.gembox`
  (mirrors the adjacent `mruby-object-ext` / `mruby-string-ext` entries).
- Implement `zero?` / `nonzero?` / `positive?` / `negative?` for `Integer` and
  `Float` in `picoruby-numeric-ext/src/mrubyc/numeric_ext.c` via a shared sign helper.

## Verification

- Host mruby build: `0.zero? #=> true`, `(-1).negative? #=> true`,
  `7.nonzero? #=> 7`, `0.nonzero? #=> nil`, Float variants all correct.
- `rake 'test:gems:femtoruby[picoruby-numeric-ext]'`: 50 examples, 0 failures
  (16 new predicate tests added for Integer and Float).