### PR TITLE
UART#getbyte and UART#ungetbyte

### DIFF
--- a/mrbgems/picoruby-machine/include/ringbuffer.h
+++ b/mrbgems/picoruby-machine/include/ringbuffer.h
@@ -78,6 +78,17 @@ RingBuffer_pop(RingBuffer *rb, uint8_t *out)
 }
 
 static inline bool
+RingBuffer_unshift(RingBuffer *rb, uint8_t ch)
+{
+  if (RingBuffer_free_size(rb) <= 1) {
+    return false;
+  }
+  rb->head = (rb->head - 1) & rb->mask;
+  rb->data[rb->head] = ch;
+  return true;
+}
+
+static inline bool
 RingBuffer_pop_n(RingBuffer *rb, uint8_t *out, size_t len)
 {
   if (len > rb->size) {

--- a/mrbgems/picoruby-uart/sig/uart.rbs
+++ b/mrbgems/picoruby-uart/sig/uart.rbs
@@ -57,6 +57,8 @@ class UART
   private def _set_format: (Integer data_bits, Integer stop_bits, Integer parity) -> void
   def read: (?Integer len) -> (String | nil)
   def readpartial: (Integer maxlen) -> String
+  def getbyte: () -> (Integer | nil)
+  def ungetbyte: (Integer byte) -> nil
   def bytes_available: () -> Integer
   def line_ending=: (("\n"|"\r\n"|"\r") line_ending) -> void
   def puts: (String str) -> nil

--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -133,6 +133,30 @@ mrb_readpartial(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_getbyte(mrb_state *mrb, mrb_value self)
+{
+  RingBuffer *rx = (RingBuffer *)mrb_data_get_ptr(mrb, self, &mrb_uart_rx_buffer_type);
+  uint8_t byte;
+  if (!RingBuffer_pop(rx, &byte)) {
+    return mrb_nil_value();
+  }
+  return mrb_fixnum_value(byte);
+}
+
+static mrb_value
+mrb_ungetbyte(mrb_state *mrb, mrb_value self)
+{
+  mrb_int value;
+  mrb_get_args(mrb, "i", &value);
+  RingBuffer *rx = (RingBuffer *)mrb_data_get_ptr(mrb, self, &mrb_uart_rx_buffer_type);
+  if (!RingBuffer_unshift(rx, (uint8_t)(value & 0xff))) {
+    struct RClass *IOError = mrb_exc_get_id(mrb, MRB_SYM(IOError));
+    mrb_raise(mrb, IOError, "UART: rx buffer is full");
+  }
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_bytes_available(mrb_state *mrb, mrb_value self)
 {
   RingBuffer *rx = (RingBuffer *)mrb_data_get_ptr(mrb, self, &mrb_uart_rx_buffer_type);
@@ -234,6 +258,8 @@ mrb_picoruby_uart_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_UART, MRB_SYM(_set_function), mrb__set_function, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(read), mrb_read, MRB_ARGS_OPT(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(readpartial), mrb_readpartial, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_UART, MRB_SYM(getbyte), mrb_getbyte, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_UART, MRB_SYM(ungetbyte), mrb_ungetbyte, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(bytes_available), mrb_bytes_available, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_UART, MRB_SYM(write), mrb_write, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(gets), mrb_gets, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-uart/src/mrubyc/uart.c
+++ b/mrbgems/picoruby-uart/src/mrubyc/uart.c
@@ -119,6 +119,41 @@ c_readpartial(mrbc_vm *vm, mrbc_value v[], int argc)
 }
 
 static void
+c_getbyte(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  if (0 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments. expected 0");
+    return;
+  }
+  RingBuffer *rx = (RingBuffer *)GETIV(rx_buffer).instance->data;
+  uint8_t byte;
+  if (!RingBuffer_pop(rx, &byte)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_INT_RETURN(byte);
+}
+
+static void
+c_ungetbyte(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  if (argc != 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments. expected 1");
+    return;
+  }
+  if (v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type (expected Integer)");
+    return;
+  }
+  RingBuffer *rx = (RingBuffer *)GETIV(rx_buffer).instance->data;
+  if (!RingBuffer_unshift(rx, (uint8_t)(GET_INT_ARG(1) & 0xff))) {
+    mrbc_raise(vm, MRBC_CLASS(IOError), "UART: rx buffer is full");
+    return;
+  }
+  SET_NIL_RETURN();
+}
+
+static void
 c_bytes_available(mrbc_vm *vm, mrbc_value v[], int argc)
 {
   RingBuffer *rx = (RingBuffer *)GETIV(rx_buffer).instance->data;
@@ -231,6 +266,8 @@ mrbc_uart_init(mrbc_vm *vm)
   mrbc_define_method(vm, mrbc_class_UART, "_set_function", c__set_function);
   mrbc_define_method(vm, mrbc_class_UART, "read", c_read);
   mrbc_define_method(vm, mrbc_class_UART, "readpartial", c_readpartial);
+  mrbc_define_method(vm, mrbc_class_UART, "getbyte", c_getbyte);
+  mrbc_define_method(vm, mrbc_class_UART, "ungetbyte", c_ungetbyte);
   mrbc_define_method(vm, mrbc_class_UART, "bytes_available", c_bytes_available);
   mrbc_define_method(vm, mrbc_class_UART, "write", c_write);
   mrbc_define_method(vm, mrbc_class_UART, "gets", c_gets);

--- a/mrbgems/picoruby-uart/test/uart_test.rb
+++ b/mrbgems/picoruby-uart/test/uart_test.rb
@@ -11,4 +11,14 @@ class UARTTest < Picotest::Test
   def test_puts
     assert_equal nil, @uart.puts("Hello, UART!")
   end
+
+  def test_getbyte_returns_nil_when_rx_buffer_is_empty
+    assert_nil @uart.getbyte
+  end
+
+  def test_ungetbyte
+    assert_nil @uart.ungetbyte(0x141)
+    assert_equal 0x41, @uart.getbyte
+    assert_nil @uart.getbyte
+  end
 end


### PR DESCRIPTION
This pull request adds support for single-byte read and "un-read" operations to the UART class, introducing `getbyte` and `ungetbyte` methods in both mruby and mrubyc environments. These methods allow reading a single byte from the UART receive buffer and pushing a byte back to the buffer, respectively. The implementation also includes corresponding tests and type signatures.

### UART API Enhancements

* Added `getbyte` and `ungetbyte` methods to the `UART` class, allowing users to read a single byte from the receive buffer or push a byte back to the buffer. Both methods are available in mruby and mrubyc environments. (`mrbgems/picoruby-uart/sig/uart.rbs`, `mrbgems/picoruby-uart/src/mruby/uart.c`, `mrbgems/picoruby-uart/src/mrubyc/uart.c`, [[1]](diffhunk://#diff-002a3049f1991dabedbd96a9374045d416452965ec7e7ab45de81eaed18f5fb4R60-R61) [[2]](diffhunk://#diff-dc772858a175cafbfe82b22322f36c88b29896804af52ae4a712e146637fdc01R135-R158) [[3]](diffhunk://#diff-8c039dde2cc1470d011b3ae53f5002d2b48c80cb4b88bd01a3c21085637e43faR121-R155) [[4]](diffhunk://#diff-8c039dde2cc1470d011b3ae53f5002d2b48c80cb4b88bd01a3c21085637e43faR269-R270)

### RingBuffer Utility

* Implemented the `RingBuffer_unshift` function to support pushing a byte back to the head of the ring buffer, used by the new `ungetbyte` method. (`mrbgems/picoruby-machine/include/ringbuffer.h`, [mrbgems/picoruby-machine/include/ringbuffer.hR80-R90](diffhunk://#diff-d7ee0e35d65349a869e5f6438887ba19cc1e524ea08308d5a3f06bbd29187324R80-R90))

### Testing

* Added tests for `getbyte` and `ungetbyte` to verify correct behavior, including handling of empty buffers and byte masking. (`mrbgems/picoruby-uart/test/uart_test.rb`, [mrbgems/picoruby-uart/test/uart_test.rbR14-R23](diffhunk://#diff-dde6bcb94e1757e3f843c88937c16a94e9c2116cee93394b15129cdaa3be4c9cR14-R23))