### PR TITLE
UART#putc

### DIFF
--- a/mrbgems/picoruby-uart/README.md
+++ b/mrbgems/picoruby-uart/README.md
@@ -46,9 +46,11 @@ uart.clear_tx_buffer
 ### Methods
 
 - `UART.new(unit:, txd_pin:, rxd_pin:, baudrate: 115200, data_bits: 8, stop_bits: 1, parity: PARITY_NONE, flow_control: FLOW_CONTROL_NONE, rx_buffer_size: nil)` - Initialize UART
-- `write(string)` - Write string to UART
+- `write(string)` - Write string to TX
+- `putc(ch)` - Write the low 8 bits of an Integer or the first character of a String
 - `puts(string)` - Write string with line ending
-- `read(length = nil)` - Read data from UART
+- `getbyte()` - Read 1 byte from RX
+- `read(length = nil)` - Read data from RX
 - `gets()` - Read line (until line ending)
 - `readpartial(maxlen)` - Read available data up to maxlen
 - `bytes_available()` - Return number of bytes in RX buffer

--- a/mrbgems/picoruby-uart/sig/uart.rbs
+++ b/mrbgems/picoruby-uart/sig/uart.rbs
@@ -64,6 +64,7 @@ class UART
   def puts: (String str) -> nil
   def gets: () -> String?
   def write: (String str) -> Integer
+  def putc: ((Integer | String) ch) -> (Integer | String)
   def flush: () -> self
   def clear_tx_buffer: () -> self
   def clear_rx_buffer: () -> self

--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -5,6 +5,7 @@
 #include <mruby/string.h>
 #include <mruby/data.h>
 #include <mruby/class.h>
+#include <mruby/internal.h>
 #include <mruby/variable.h>
 
 static void
@@ -175,6 +176,36 @@ mrb_write(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_putc(mrb_state *mrb, mrb_value self)
+{
+  mrb_value ch;
+  mrb_get_args(mrb, "o", &ch);
+
+  int unit_num = mrb_fixnum(mrb_iv_get(mrb, self, MRB_IVSYM(unit_num)));
+  if (mrb_integer_p(ch)) {
+    uint8_t byte = (uint8_t)(mrb_integer(ch) & 0xff);
+    UART_write_blocking(unit_num, &byte, 1);
+    return ch;
+  }
+  if (!mrb_string_p(ch)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "wrong argument type (expected Integer or String)");
+  }
+
+  const char *ptr = RSTRING_PTR(ch);
+  mrb_int len = RSTRING_LEN(ch);
+  if (len == 0) {
+    return ch;
+  }
+#ifdef MRB_UTF8_STRING
+  len = mrb_utf8len(ptr, ptr + len);
+#else
+  len = 1;
+#endif
+  UART_write_blocking(unit_num, (const uint8_t *)ptr, len);
+  return ch;
+}
+
+static mrb_value
 mrb_gets(mrb_state *mrb, mrb_value self)
 {
   RingBuffer *rx = (RingBuffer *)mrb_data_get_ptr(mrb, self, &mrb_uart_rx_buffer_type);
@@ -262,6 +293,7 @@ mrb_picoruby_uart_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_UART, MRB_SYM(ungetbyte), mrb_ungetbyte, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(bytes_available), mrb_bytes_available, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_UART, MRB_SYM(write), mrb_write, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_UART, MRB_SYM(putc), mrb_putc, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_UART, MRB_SYM(gets), mrb_gets, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_UART, MRB_SYM(flush), mrb_flush, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_UART, MRB_SYM(clear_tx_buffer), mrb_clear_tx_buffer, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-uart/src/mrubyc/uart.c
+++ b/mrbgems/picoruby-uart/src/mrubyc/uart.c
@@ -177,6 +177,57 @@ c_write(mrbc_vm *vm, mrbc_value v[], int argc)
   SET_INT_RETURN(len);
 }
 
+#if MRBC_USE_STRING_UTF8
+static size_t
+first_character_size(const uint8_t *str, size_t len)
+{
+  size_t char_len = mrbc_string_utf8_size((const char *)str);
+  if (char_len == 0 || len < char_len) {
+    return 1;
+  }
+  for (size_t i = 1; i < char_len; i++) {
+    if ((str[i] & 0xc0) != 0x80) {
+      return 1;
+    }
+  }
+  return char_len;
+}
+#endif
+
+static void
+c_putc(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  if (argc != 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments. expected 1");
+    return;
+  }
+
+  int unit_num = GETIV(unit_num).i;
+  if (v[1].tt == MRBC_TT_INTEGER) {
+    uint8_t byte = (uint8_t)(GET_INT_ARG(1) & 0xff);
+    UART_write_blocking(unit_num, &byte, 1);
+    mrbc_incref(&v[1]);
+    SET_RETURN(v[1]);
+    return;
+  }
+  if (v[1].tt != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "wrong argument type (expected Integer or String)");
+    return;
+  }
+
+  size_t len = v[1].string->size;
+  if (0 < len) {
+#if MRBC_USE_STRING_UTF8
+    len = first_character_size(v[1].string->data, len);
+#else
+    len = 1;
+#endif
+    UART_write_blocking(unit_num, (const uint8_t *)v[1].string->data, len);
+  }
+  mrbc_incref(&v[1]);
+  SET_RETURN(v[1]);
+}
+
 static void
 c_gets(mrbc_vm *vm, mrbc_value v[], int argc)
 {
@@ -270,6 +321,7 @@ mrbc_uart_init(mrbc_vm *vm)
   mrbc_define_method(vm, mrbc_class_UART, "ungetbyte", c_ungetbyte);
   mrbc_define_method(vm, mrbc_class_UART, "bytes_available", c_bytes_available);
   mrbc_define_method(vm, mrbc_class_UART, "write", c_write);
+  mrbc_define_method(vm, mrbc_class_UART, "putc", c_putc);
   mrbc_define_method(vm, mrbc_class_UART, "gets", c_gets);
   mrbc_define_method(vm, mrbc_class_UART, "flush", c_flush);
   mrbc_define_method(vm, mrbc_class_UART, "clear_tx_buffer", c_clear_tx_buffer);

--- a/mrbgems/picoruby-uart/test/uart_test.rb
+++ b/mrbgems/picoruby-uart/test/uart_test.rb
@@ -21,4 +21,15 @@ class UARTTest < Picotest::Test
     assert_equal 0x41, @uart.getbyte
     assert_nil @uart.getbyte
   end
+
+  def test_putc
+    assert_equal 0x141, @uart.putc(0x141)
+    assert_equal "ABC", @uart.putc("ABC")
+    assert_equal "あいう", @uart.putc("あいう")
+    assert_equal "", @uart.putc("")
+  end
+
+  def test_putc_rejects_other_types
+    assert_raise(TypeError) { @uart.putc(nil) }
+  end
 end


### PR DESCRIPTION
This pull request adds a new `putc` method to the `UART` class, allowing users to write either a single byte (from an Integer) or the first character of a String to the UART TX buffer. The method is implemented for both mruby and mrubyc, with appropriate type checks and UTF-8 handling. Documentation and type signatures are updated, and tests are added to ensure correct behavior and error handling.

**New UART API:**

* Added the `putc` method to the `UART` class, which writes the low 8 bits of an Integer or the first character of a String to the TX buffer. This is now available in both mruby and mrubyc implementations. [[1]](diffhunk://#diff-dc772858a175cafbfe82b22322f36c88b29896804af52ae4a712e146637fdc01R178-R207) [[2]](diffhunk://#diff-8c039dde2cc1470d011b3ae53f5002d2b48c80cb4b88bd01a3c21085637e43faR180-R230) [[3]](diffhunk://#diff-dc772858a175cafbfe82b22322f36c88b29896804af52ae4a712e146637fdc01R296) [[4]](diffhunk://#diff-8c039dde2cc1470d011b3ae53f5002d2b48c80cb4b88bd01a3c21085637e43faR324) [[5]](diffhunk://#diff-002a3049f1991dabedbd96a9374045d416452965ec7e7ab45de81eaed18f5fb4R67)
* Updated the documentation in `README.md` to describe the new `putc` method and clarify the behavior of `write` and `read` methods.
* Updated the RBS type signature file to include the new `putc` method and its argument/return types.

**Testing and Validation:**

* Added unit tests for `putc`, including tests for writing integers, strings, empty strings, and ensuring that invalid argument types raise a `TypeError`.

**Internal Improvements:**

* Added UTF-8 character handling for the `putc` method in both mruby and mrubyc implementations, ensuring correct behavior when writing multibyte characters. [[1]](diffhunk://#diff-dc772858a175cafbfe82b22322f36c88b29896804af52ae4a712e146637fdc01R178-R207) [[2]](diffhunk://#diff-8c039dde2cc1470d011b3ae53f5002d2b48c80cb4b88bd01a3c21085637e43faR180-R230)
* Included a missing `#include <mruby/internal.h>` in the C source for mruby UART to support new functionality.