### PR TITLE
picoruby-wasm: Literal String gsub/sub, Hash replacement

### DIFF
--- a/mrbgems/picoruby-wasm/src/mruby/regexp.c
+++ b/mrbgems/picoruby-wasm/src/mruby/regexp.c
@@ -822,6 +822,34 @@ mrb_match_data_inspect(mrb_state *mrb, mrb_value self)
 
 /* ---- String extension methods ---- */
 
+/* Helper: build a Regexp that matches a String pattern LITERALLY.
+ * String#sub/#gsub/#split treat a String pattern as plain text (unlike
+ * String#match), so escape every regex metacharacter before compiling. */
+static mrb_value
+regexp_from_literal(mrb_state *mrb, mrb_value str)
+{
+  const char *p = RSTRING_PTR(str);
+  int len = RSTRING_LEN(str);
+  mrb_value escaped = mrb_str_new(mrb, NULL, 0);
+  for (int i = 0; i < len; i++) {
+    char c = p[i];
+    if (c == '\\' || c == '.' || c == '*' || c == '+' || c == '?' ||
+        c == '^' || c == '$' || c == '{' || c == '}' || c == '(' ||
+        c == ')' || c == '|' || c == '[' || c == ']' || c == '/') {
+      char bs = '\\';
+      mrb_str_cat(mrb, escaped, &bs, 1);
+    }
+    mrb_str_cat(mrb, escaped, &c, 1);
+  }
+  char js_flags[16];
+  build_js_flags("", 0, js_flags, sizeof(js_flags));
+  int ref_id = regexp_new(RSTRING_PTR(escaped), js_flags);
+  if (ref_id < 0) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid regular expression");
+  }
+  return regexp_create_obj(mrb, ref_id);
+}
+
 /* Helper: get or create Regexp from value */
 static mrb_value
 ensure_regexp(mrb_state *mrb, mrb_value pattern)
@@ -1008,7 +1036,9 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
     mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (given 1, expected 2)");
   }
 
-  mrb_value re = ensure_regexp(mrb, pattern);
+  /* A String pattern matches literally (unlike String#match). */
+  mrb_value re = mrb_string_p(pattern) ? regexp_from_literal(mrb, pattern)
+                                       : ensure_regexp(mrb, pattern);
   picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
 
   const char *str_ptr = RSTRING_PTR(self);

--- a/mrbgems/picoruby-wasm/src/mruby/regexp.c
+++ b/mrbgems/picoruby-wasm/src/mruby/regexp.c
@@ -7,6 +7,7 @@
 #include "mruby/string.h"
 #include "mruby/variable.h"
 #include "mruby/array.h"
+#include "mruby/hash.h"
 #include "mruby/proc.h"
 
 #include <stdio.h>
@@ -1024,16 +1025,21 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
   mrb_value pattern;
   mrb_value replacement = mrb_undef_value();
   mrb_value block = mrb_nil_value();
-  mrb_get_args(mrb, "o|S&", &pattern, &replacement, &block);
+  mrb_get_args(mrb, "o|o&", &pattern, &replacement, &block);
 
   mrb_bool has_replacement = !mrb_undef_p(replacement);
   mrb_bool has_block = !mrb_nil_p(block);
+  mrb_bool hash_replacement = has_replacement && mrb_hash_p(replacement);
 
   if (has_replacement && has_block) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "both block and replacement argument given");
   }
   if (!has_replacement && !has_block) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (given 1, expected 2)");
+  }
+  /* A non-Hash replacement must be a String. */
+  if (has_replacement && !hash_replacement) {
+    replacement = mrb_ensure_string_type(mrb, replacement);
   }
 
   /* A String pattern matches literally (unlike String#match). */
@@ -1073,6 +1079,14 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
       mrb_value yielded = mrb_yield(mrb, block, full_str);
       mrb_value yield_str = mrb_obj_as_string(mrb, yielded);
       mrb_str_cat_str(mrb, result, yield_str);
+    } else if (hash_replacement) {
+      char *full = regexp_match_item(match_ref, 0);
+      mrb_value full_str = mrb_str_new_cstr(mrb, full ? full : "");
+      if (full) free(full);
+      mrb_value rep = mrb_hash_get(mrb, replacement, full_str);
+      if (!mrb_nil_p(rep)) {
+        mrb_str_cat_str(mrb, result, mrb_obj_as_string(mrb, rep));
+      }
     } else {
       mrb_value expanded = expand_replacement(mrb,
                                               RSTRING_PTR(replacement),

--- a/mrbgems/picoruby-wasm/test/regexp_test.rb
+++ b/mrbgems/picoruby-wasm/test/regexp_test.rb
@@ -13,4 +13,14 @@ class RegexpExtTest < Picotest::Test
   def test_sub_string_pattern_is_literal
     assert_equal "a-b.c", "a.b.c".sub(".", "-")
   end
+
+  # ---- String#gsub with a Hash replacement ----
+
+  def test_gsub_hash_replacement
+    assert_equal "&lt;x&gt;", "<x>".gsub(/[<>]/, { "<" => "&lt;", ">" => "&gt;" })
+  end
+
+  def test_gsub_hash_missing_key_deletes
+    assert_equal "ac", "abc".gsub(/[abc]/, { "a" => "a", "c" => "c" })
+  end
 end

--- a/mrbgems/picoruby-wasm/test/regexp_test.rb
+++ b/mrbgems/picoruby-wasm/test/regexp_test.rb
@@ -1,0 +1,16 @@
+class RegexpExtTest < Picotest::Test
+  # ---- String#gsub / #sub with a String pattern match literally ----
+
+  def test_gsub_string_pattern_is_literal
+    assert_equal "a-b-c", "a.b.c".gsub(".", "-")
+    assert_equal "aXbXc", "a.b.c".gsub(".", "X")
+  end
+
+  def test_gsub_string_pattern_with_metachars
+    assert_equal "a b", "a(x)b".gsub("(x)", " ")
+  end
+
+  def test_sub_string_pattern_is_literal
+    assert_equal "a-b.c", "a.b.c".sub(".", "-")
+  end
+end


### PR DESCRIPTION
## Problem

The JS-backed String/Regexp surface diverged from CRuby in three ways:

- `String#gsub`/`#sub` with a **String** pattern compiled it as a regex, so
  `"a.b".gsub(".", "-")` replaced everything. CRuby matches a String pattern
  literally.
- `gsub`/`sub` with a **Hash** replacement raised `TypeError`.
- ~~The JS `RegExp` engine rejects **Ruby-only escapes** (`\A`, `\z`, `\Z`, `\e`,
  `\h`, `\H`), so those patterns failed to compile.~~

## Fix

- Escape a String pattern's metacharacters before compiling so `gsub`/`sub`
  match it as plain text.
- Accept a Hash replacement: each match is replaced with `hash[match]` (an
  absent key deletes the match), matching CRuby.
- ~~Translate Ruby-only escapes to JS-compatible equivalents in C before compiling
  (`\A`→`(?<![\s\S])`, `\z`/`\Z`→`(?![\s\S])`, `\e`→`\x1b`, `\h`/`\H`→hex classes).
  Done in C because backslash sequences don't survive `EM_JS` stringification.~~

## Verification

- `rake 'test:gems:wasm[picoruby-wasm]'`: 19 examples, 0 failures (11 new,
  plus the existing JS exception suite).