### PR TITLE
Fix receiver mutation during block-form String substitution

### DIFF
--- a/mrbgems/picoruby-wasm/src/mruby/regexp.c
+++ b/mrbgems/picoruby-wasm/src/mruby/regexp.c
@@ -1011,8 +1011,11 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
   mrb_value re = ensure_regexp(mrb, pattern);
   picorb_regexp *re_data = (picorb_regexp *)DATA_PTR(re);
 
-  const char *str_ptr = RSTRING_PTR(self);
-  int str_len = RSTRING_LEN(self);
+  /* Keep a stable snapshot while a replacement block runs arbitrary Ruby.
+   * The block must not be allowed to invalidate the buffer being scanned. */
+  mrb_value source = has_block ? mrb_str_dup(mrb, self) : self;
+  const char *str_ptr = RSTRING_PTR(source);
+  int str_len = RSTRING_LEN(source);
 
   mrb_value result = mrb_str_new(mrb, NULL, 0);
   int byte_pos = 0;
@@ -1040,8 +1043,13 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
       char *full = regexp_match_item(match_ref, 0);
       mrb_value full_str = mrb_str_new_cstr(mrb, full ? full : "");
       if (full) free(full);
+      regexp_release_ref(match_ref);
+      match_ref = -1;
       mrb_value yielded = mrb_yield(mrb, block, full_str);
       mrb_value yield_str = mrb_obj_as_string(mrb, yielded);
+      if (!mrb_str_equal(mrb, self, source)) {
+        mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
+      }
       mrb_str_cat_str(mrb, result, yield_str);
     } else {
       mrb_value expanded = expand_replacement(mrb,
@@ -1051,7 +1059,9 @@ do_string_sub_gsub(mrb_state *mrb, mrb_value self, mrb_bool global)
       mrb_str_cat_str(mrb, result, expanded);
     }
 
-    regexp_release_ref(match_ref);
+    if (0 <= match_ref) {
+      regexp_release_ref(match_ref);
+    }
 
     /* Advance position. For zero-width matches, also append and skip one
      * UTF-8 character so we don't loop forever. */

--- a/mrbgems/picoruby-wasm/test/regexp_test.rb
+++ b/mrbgems/picoruby-wasm/test/regexp_test.rb
@@ -1,0 +1,12 @@
+class RegexpExtTest < Picotest::Test
+  def test_gsub_block_raises_when_receiver_is_modified
+    source = "ab" * 1_000
+
+    assert_raise(RuntimeError) do
+      source.gsub(/./) do
+        source.replace("x" * 100_000)
+        "z"
+      end
+    end
+  end
+end


### PR DESCRIPTION
String#sub and String#gsub kept a raw pointer to the receiver's buffer while invoking the replacement block. If the block modified the receiver, the buffer could be reallocated and leave the substitution loop reading from an invalid pointer.

Duplicate the receiver before processing block-form replacements and scan the stable snapshot instead. After invoking the block and converting its result with to_s, compare the receiver against the snapshot and raise RuntimeError if it was modified.

Also release the JavaScript match reference before invoking arbitrary Ruby code, and avoid releasing it a second time afterward.

Add a regression test that forces the receiver's buffer to be reallocated from inside a gsub replacement block.

Tested with: `rake test:gems:wasm[picoruby-wasm]`