### PR TITLE
Fix outbuf initialization order in mrubyc read_nonblock

### DIFF
--- a/mrbgems/picoruby-io-console/src/mrubyc/io-console.c
+++ b/mrbgems/picoruby-io-console/src/mrubyc/io-console.c
@@ -60,7 +60,7 @@ c_read_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
     */
   int maxlen = GET_INT_ARG(1);
   char buf[maxlen + 1];
-  mrbc_value outbuf;
+  mrbc_value outbuf = argc >= 2 ? GET_ARG(2) : mrbc_nil_value();
   int len;
   bool was_raw = io_raw_q();
   io_raw_bang(true);
@@ -81,8 +81,7 @@ c_read_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   buf[len] = '\0';
   io__restore_termios();
-  if (GET_ARG(2).tt == MRBC_TT_STRING) {
-    outbuf = GET_ARG(2);
+  if (outbuf.tt == MRBC_TT_STRING) {
     uint8_t *str = outbuf.string->data;
     int orig_len = outbuf.string->size;
     if (orig_len != len) {


### PR DESCRIPTION
## Summary
- `IO#read_nonblock` in the mrubyc port initialized `outbuf` before checking whether an output buffer argument was actually passed, then re-read `GET_ARG(2)` a second time later to decide whether to reuse it as a string buffer. Reorder so `outbuf` is set once from the argument (or nil) up front, and the later branch checks `outbuf.tt` instead of re-fetching the argument.