### PR TITLE
Fix sandbox/irb heap corruption and per-command leaks

### DIFF
--- a/mrbgems/picoruby-env/src/mruby/env.c
+++ b/mrbgems/picoruby-env/src/mruby/env.c
@@ -15,11 +15,11 @@ typedef struct ENV {
 static void
 mrb_env_free(mrb_state *mrb, void *ptr) {
   ENV *env = (ENV *)ptr;
-  mrb_value hash = env->hash;
-  if (mrb_hash_p(hash)) {
-    mrb_hash_clear(mrb, hash);
-  }
-  mrb_gc_unregister(mrb, hash);
+  /* Do NOT touch the hash's contents here: during mrb_close teardown
+   * the hash (and its table) may already be freed — mrb_hash_clear
+   * here is a use-after-free. Dropping our GC registration is enough;
+   * the GC owns the hash and frees it with its table. */
+  mrb_gc_unregister(mrb, env->hash);
   mrb_free(mrb, ptr);
 }
 

--- a/mrbgems/picoruby-mruby/src/mrc_utils.c
+++ b/mrbgems/picoruby-mruby/src/mrc_utils.c
@@ -30,9 +30,9 @@ mrc_resolve_intern(mrc_ccontext *cc, mrc_irep *irep)
     irep->syms = new_syms;
   }
 
-  // Local variables
+  // Local variables (irep->lv is NULL after mrc_irep_remove_lv)
   int lv_size = irep->nlocals - 1; // exclude self
-  if (0 < lv_size) {
+  if (0 < lv_size && irep->lv) {
     picorb_sym *new_lv = (picorb_sym *)mrc_malloc(cc, sizeof(picorb_sym) * lv_size);
     for (int i = 0; i < lv_size; i++) {
       mrc_sym sym = irep->lv[i];

--- a/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
+++ b/mrbgems/picoruby-sandbox/src/mruby/sandbox.c
@@ -21,6 +21,9 @@ static void
 mrb_sandbox_state_free(mrb_state *mrb, void *ptr) {
   SandboxState *ss = (SandboxState *)ptr;
   mrb_gc_unregister(mrb, ss->task);
+  /* Drop the sandbox's counted reference; procs created from this irep
+     hold their own refs and the irep is freed when the last one dies. */
+  if (ss->irep) mrb_irep_decref(mrb, (struct mrb_irep *)ss->irep);
   free_ccontext(ss);
   mrb_free(mrb, ss);
 }
@@ -68,13 +71,18 @@ sandbox_compile_sub(mrb_state *mrb, SandboxState *ss, const uint8_t *script, con
   ss->cc = mrc_ccontext_new(mrb);
   if (filename) mrc_ccontext_filename(ss->cc, filename);
   ss->cc->options = ss->options;
-  // TODO: Ask Matz
+  /* Drop our ref to the previous irep (procs keep it alive if needed).
+     The compiler returns the new irep with refcnt=1 which becomes the
+     sandbox's reference — do NOT incref again or it leaks forever. */
   if (ss->irep) mrb_irep_decref(mrb, (struct mrb_irep *)ss->irep);
   ss->irep = mrc_load_string_cxt(ss->cc, (const uint8_t **)&script, size);
   if (ss->irep && mrb_test(remove_lv)) mrc_irep_remove_lv(ss->cc, ss->irep);
-  if (ss->irep) {
-    mrb_irep_incref(mrb, (struct mrb_irep *)ss->irep);
-  }
+  /* Resolve symbols NOW, while `script` is still alive: the compiler's
+     constant pool points into the script buffer, and by execute time the
+     GC may have freed it (the script is a Ruby string owned by the
+     caller). Deferring mrc_resolve_intern() to Sandbox#execute reads
+     freed memory. */
+  if (ss->irep) mrc_resolve_intern(ss->cc, ss->irep);
   ss->options = ss->cc->options;
   ss->cc->options = NULL;
   if (!ss->irep) {
@@ -89,8 +97,7 @@ static mrb_value
 mrb_sandbox_compile(mrb_state *mrb, mrb_value self)
 {
   SS();
-  const char *script;
-  mrb_int script_len;
+  mrb_value script_val;
 
   uint32_t kw_num = 2;
   uint32_t kw_required = 0;
@@ -98,7 +105,9 @@ mrb_sandbox_compile(mrb_state *mrb, mrb_value self)
   mrb_value kw_values[kw_num];
   mrb_kwargs kwargs = { kw_num, kw_required, kw_names, kw_values, NULL };
 
-  mrb_get_args(mrb, "s:", &script, &script_len, &kwargs);
+  mrb_get_args(mrb, "S:", &script_val, &kwargs);
+  const char *script = RSTRING_PTR(script_val);
+  mrb_int script_len = RSTRING_LEN(script_val);
   if (mrb_undef_p(kw_values[0])) { kw_values[0] = mrb_false_value(); }
 
   const char *filename = NULL;
@@ -155,7 +164,8 @@ static mrb_value
 mrb_sandbox_execute(mrb_state *mrb, mrb_value self)
 {
   SS();
-  mrc_resolve_intern(ss->cc, ss->irep);
+  /* Symbols were already resolved at compile time (sandbox_compile_sub);
+     resolving again would misread mrb_syms as constant-pool ids. */
   struct RProc *proc = mrb_proc_new(mrb, (const mrb_irep *)ss->irep);
   proc->e.target_class = mrb->object_class;
   mrb_task_reset_context(mrb, ss->task);
@@ -262,7 +272,9 @@ mrb_sandbox_exec_vm_code(mrb_state *mrb, mrb_value self)
   mrb_value vm_code;
   mrb_get_args(mrb, "S", &vm_code);
   const uint8_t *code = (const uint8_t *)RSTRING_PTR(vm_code);
-  if (ss->irep) mrc_irep_free(ss->cc, ss->irep);
+  /* mrc_irep_free() would destroy the irep even while live procs still
+     reference it (use-after-free in the GC sweep); drop our ref instead. */
+  if (ss->irep) mrb_irep_decref(mrb, (struct mrb_irep *)ss->irep);
   ss->irep = (mrc_irep *)mrb_read_irep(mrb, code);
   if (sandbox_exec_vm_code_sub(mrb, ss)) {
     return mrb_true_value();
@@ -277,7 +289,7 @@ mrb_sandbox_exec_vm_code_from_memory(mrb_state *mrb, mrb_value self)
   SS();
   mrb_int address;
   mrb_get_args(mrb, "i", &address);
-  if (ss->irep) mrc_irep_free(ss->cc, ss->irep);
+  if (ss->irep) mrb_irep_decref(mrb, (struct mrb_irep *)ss->irep);
   ss->irep = (mrc_irep *)mrb_read_irep(mrb, (const uint8_t *)(uintptr_t)address);
   if (sandbox_exec_vm_code_sub(mrb, ss)) {
     return mrb_true_value();


### PR DESCRIPTION
### Summary

Three memory-safety bugs in the `Sandbox` C layer (mruby VM variant) plus one in `picoruby-env`, found with an AddressSanitizer build of POSIX R2P2 and verified on hardware (Pico 2 W). Together they caused R2P2 sessions to corrupt the heap and die after roughly 55 irb commands, with crash sites deep inside the allocator/GC.

Also bumps the mruby submodule to current master to pick up mruby/mruby#6928 (task-switch exception swallow — `rescue` around blocking C functions such as `CYW43.connect_timeout` never ran).

### The bugs

1. **Use-after-free via `mrc_irep_free()`** — `exec_mrb`/`exec_mrb_from_memory` destroyed `ss->irep` outright while live Procs (the sandbox task's proc, procs from previous `execute` calls) still held counted references; the GC sweep later did a read *and a refcount write* into the freed (and typically reused) chunk, and could "free" pointers that were by then other objects' data. This is the primary corruption. Fixed by dropping the sandbox's reference with `mrb_irep_decref()` instead.
2. **Per-command irep leak** — `sandbox_compile_sub` increfed the fresh irep although the compiler already returns `refcnt=1` as the caller's reference, so every compiled command leaked its whole irep tree (~3 KB per irb command on device). The sandbox's reference is now also released in `mrb_sandbox_state_free`.
3. **Use-after-free of the script string** — prism's constant pool points into the source buffer, and `mrc_resolve_intern` was deferred to `Sandbox#execute`, by which time the GC may have freed the script string (irb builds a fresh wrapper string per command). Symbols are now resolved at compile time, while the script argument is still protected on the VM stack; `mrc_resolve_intern` gained an `irep->lv == NULL` guard since it can now run after `mrc_irep_remove_lv`.
4. **picoruby-env teardown UAF** — `mrb_env_free()` called `mrb_hash_clear()` on the ENV hash during `mrb_close` teardown, when the hash table may already be freed. Unregistering the hash is sufficient.

### Verification

- Host: ASan-instrumented POSIX R2P2 driven through a pty with an irb churn workload. Before: use-after-free at first boot (the shell runs `/bin` executables through `exec_mrb`). After: 60/60 churn iterations clean, zero ASan reports, RSS flat; sandbox gem tests and the full picoruby gem suite green.
- Hardware (Pico 2 W): the no-WiFi corruption repro previously died at ~8-13 iterations (~55 commands); with these fixes it survives to the (separate, known) heap-exhaustion limit at ~110 commands, and the `rescue Network::ConnectTimeout` pattern works (12/12, was 0/12, via the submodule bump).

### Notes

- A remaining, separate issue makes long sessions eventually exhaust the fixed arena (GC heap pages are only reclaimed when completely empty, so fragmentation ratchets the page count); with the companion mruby PR "survive OOM during task context initialization" that exhaustion is a clean `NoMemoryError` instead of corruption.
- `Sandbox#compile` now takes its argument with the `S` format (String required) instead of `s`.