### PR TITLE
CYW43: Guard against too long SSID/PSK

### DIFF
--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -1,4 +1,5 @@
 #include <mruby.h>
+#include <string.h>
 #include <mruby/presym.h>
 #include <mruby/variable.h>
 #include <mruby/string.h>
@@ -89,6 +90,12 @@ mrb_s_connect_timeout(mrb_state *mrb, mrb_value klass)
     timeout_ms = 60 * 1000;
   } else {
     timeout_ms = mrb_fixnum(timeout) * 1000;
+  }
+  if (strlen(ssid) > 32) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "SSID too long (max 32 bytes)");
+  }
+  if (strlen(pass) > 63) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "PSK too long (max 63 bytes)");
   }
   if (cyw43_arch_sta_mode_enabled && !cyw43_arch_connected) {
     if (CYW43_wifi_connect_with_dhcp(ssid, pass, auth, timeout_ms) != 0) {

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -1,4 +1,5 @@
 #include <mrubyc.h>
+#include <string.h>
 
 #define GETIV(str)       mrbc_instance_getiv(&v[0], mrbc_str_to_symid(#str))
 #define WRITE(pin, val)  CYW43_GPIO_write(pin.i, val)
@@ -97,6 +98,14 @@ c_CYW43_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   const char *ssid = (const char *)GET_STRING_ARG(1);
   const char *pass = (const char *)GET_STRING_ARG(2);
+  if (strlen(ssid) > 32) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "SSID too long (max 32 bytes)");
+    return;
+  }
+  if (strlen(pass) > 63) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "PSK too long (max 63 bytes)");
+    return;
+  }
   int auth = GET_INT_ARG(3);
   int timeout_ms = 3 < argc ? GET_INT_ARG(4)*1000 : 60*1000;
   if (cyw43_arch_sta_mode_enabled && !cyw43_arch_connected) {


### PR DESCRIPTION
SSID is capped by 32 bytes per 802.11 spec, PSK is capped by 63 bytes per WPA2-PSK spec, and these are implemented as fixed byte size fields inside the driver. Copying larger buffers results in a busfault, so added a guard that raises ArgumentError when the input is too long.

Covers both mruby and mrubyc variants.