### PR TITLE
Replace ESP32_PLATFORM with PICORB_PLATFORM_ESP32

### DIFF
--- a/mrbgems/picoruby-mruby/include/hal.h
+++ b/mrbgems/picoruby-mruby/include/hal.h
@@ -50,7 +50,7 @@ MRB_BEGIN_DECL
 
 void hal_init(mrb_state *mrb);
 /* Avoid conflict with hal_init() from libpp used in ESP-IDF. */
-#ifdef ESP32_PLATFORM
+#ifdef PICORB_PLATFORM_ESP32
 void machine_hal_init(mrb_state *mrb);
 #define hal_init(mrb) machine_hal_init(mrb)
 #endif

--- a/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
+++ b/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
@@ -51,7 +51,7 @@
  * - some unhandled/untested things might be caught by LWIP_ASSERTs...
  */
 
-#if !defined(PICORB_PLATFORM_POSIX) && !defined(ESP32_PLATFORM)
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
 
 #include "lwip/opt.h"
 #include "lwip/sys.h"
@@ -1366,4 +1366,4 @@ const struct altcp_functions altcp_mbedtls_functions = {
 #endif /* LWIP_ALTCP_TLS && LWIP_ALTCP_TLS_MBEDTLS */
 #endif /* LWIP_ALTCP */
 
-#endif /* !PICORB_PLATFORM_POSIX && !ESP32_PLATFORM */
+#endif /* !PICORB_PLATFORM_POSIX && !PICORB_PLATFORM_ESP32 */


### PR DESCRIPTION
In response to the addition of `PICORB_PLATFORM_ESP32` to the `defines` in #433, I decided to replace `ESP32_PLATFORM`, which I had previously been using to determine whether a build was intended for the ESP32.