### PR TITLE
Redirecting malloc/free calls from LwIP/MbedTLS to Estalloc 

### DIFF
--- a/build_config/r2p2-picoruby-pico2_w.rb
+++ b/build_config/r2p2-picoruby-pico2_w.rb
@@ -53,6 +53,7 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico2_w") do |conf|
   conf.gembox "peripherals"
   conf.gembox "peripheral_utils"
   conf.gembox "networking"
+  conf.gem core: 'picoruby-psg'
   unless ENV['PICORB_DEBUG']
     # Shinonome is too big for debug build
     conf.gem core: 'picoruby-shinonome'

--- a/build_config/r2p2-picoruby-pico2_w.rb
+++ b/build_config/r2p2-picoruby-pico2_w.rb
@@ -57,7 +57,6 @@ MRuby::CrossBuild.new("r2p2-picoruby-pico2_w") do |conf|
     # Shinonome is too big for debug build
     conf.gem core: 'picoruby-shinonome'
   end
-  conf.gem core: 'picoruby-psg'
   conf.gem core: 'picoruby-midibase-mml'
   conf.gem core: 'picoruby-midibase-looper'
   conf.gem core: 'picoruby-uart-midi'

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -111,6 +111,9 @@ module MRuby
       if alloc_libc
         add_define_once "PICORB_ALLOC_ESTALLOC"
         add_define_once "PICORB_ALLOC_ALIGN=#{alloc_align}"
+        if cc.defines.include?("PICORB_PLATFORM_RP2") && !ENV["R2P2_ALLOC_LIBC"]
+          add_define_once "PICORB_WRAP_LIBC_ALLOC"
+        end
       end
 
       cc.defines << "PICORB_VM_MRUBYC"

--- a/lib/picoruby/build.rb
+++ b/lib/picoruby/build.rb
@@ -111,7 +111,8 @@ module MRuby
       if alloc_libc
         add_define_once "PICORB_ALLOC_ESTALLOC"
         add_define_once "PICORB_ALLOC_ALIGN=#{alloc_align}"
-        if cc.defines.include?("PICORB_PLATFORM_RP2") && !ENV["R2P2_ALLOC_LIBC"]
+        no_shared_alloc = ENV.key?("R2P2_NO_SHARED_ALLOC")
+        if cc.defines.include?("PICORB_PLATFORM_RP2") && !no_shared_alloc
           add_define_once "PICORB_WRAP_LIBC_ALLOC"
         end
       end

--- a/mrbgems/picoruby-machine/include/estalloc_mruby.h
+++ b/mrbgems/picoruby-machine/include/estalloc_mruby.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <mruby.h>
+#include "picorb_heap.h"
 
 MRB_BEGIN_DECL
 

--- a/mrbgems/picoruby-machine/include/estalloc_mrubyc.h
+++ b/mrbgems/picoruby-machine/include/estalloc_mrubyc.h
@@ -2,7 +2,7 @@
 #define PICORUBY_ESTALLOC_MRUBYC_H
 
 #include <stddef.h>
-#include "../lib/estalloc/estalloc.h"
+#include "picorb_heap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/mrbgems/picoruby-machine/include/picorb_heap.h
+++ b/mrbgems/picoruby-machine/include/picorb_heap.h
@@ -1,0 +1,27 @@
+#ifndef PICORUBY_PICORB_HEAP_H
+#define PICORUBY_PICORB_HEAP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include "../lib/estalloc/estalloc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int picorb_heap_init(void *heap, size_t size);
+bool picorb_heap_ready(void);
+bool picorb_heap_owns(const void *ptr);
+void *picorb_heap_malloc(size_t size);
+void *picorb_heap_calloc(size_t nmemb, size_t size);
+void *picorb_heap_realloc(void *ptr, size_t size);
+void picorb_heap_free(void *ptr);
+size_t picorb_heap_usable_size(void *ptr);
+void picorb_heap_set_critical_section(void (*enter)(void), void (*exit_func)(void));
+int picorb_heap_stat(ESTALLOC_STAT *stat);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/mrbgems/picoruby-machine/ports/rp2040/heap_wrap.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/heap_wrap.c
@@ -1,0 +1,79 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "picorb_heap.h"
+
+#if defined(PICORB_ALLOC_ESTALLOC) && !defined(R2P2_ALLOC_LIBC)
+
+void *__real_malloc(size_t size);
+void *__real_calloc(size_t nmemb, size_t size);
+void *__real_realloc(void *ptr, size_t size);
+void __real_free(void *ptr);
+size_t __real_malloc_usable_size(void *ptr);
+
+void *
+__wrap_malloc(size_t size)
+{
+  if (!picorb_heap_ready()) {
+    return __real_malloc(size);
+  }
+  return picorb_heap_malloc(size);
+}
+
+void *
+__wrap_calloc(size_t nmemb, size_t size)
+{
+  if (!picorb_heap_ready()) {
+    return __real_calloc(nmemb, size);
+  }
+  return picorb_heap_calloc(nmemb, size);
+}
+
+void *
+__wrap_realloc(void *ptr, size_t size)
+{
+  if (ptr == NULL) {
+    return __wrap_malloc(size);
+  }
+
+  if (!picorb_heap_ready()) {
+    return __real_realloc(ptr, size);
+  }
+
+  if (picorb_heap_owns(ptr)) {
+    return picorb_heap_realloc(ptr, size);
+  }
+
+  return __real_realloc(ptr, size);
+}
+
+void
+__wrap_free(void *ptr)
+{
+  if (ptr == NULL) {
+    return;
+  }
+
+  if (picorb_heap_ready() && picorb_heap_owns(ptr)) {
+    picorb_heap_free(ptr);
+  }
+  else {
+    __real_free(ptr);
+  }
+}
+
+size_t
+__wrap_malloc_usable_size(void *ptr)
+{
+  if (ptr == NULL) {
+    return 0;
+  }
+
+  if (picorb_heap_ready() && picorb_heap_owns(ptr)) {
+    return picorb_heap_usable_size(ptr);
+  }
+
+  return __real_malloc_usable_size(ptr);
+}
+
+#endif

--- a/mrbgems/picoruby-machine/ports/rp2040/heap_wrap.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/heap_wrap.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include "picorb_heap.h"
 
-#if defined(PICORB_ALLOC_ESTALLOC) && !defined(R2P2_ALLOC_LIBC)
+#if defined(PICORB_ALLOC_ESTALLOC) && !defined(R2P2_NO_SHARED_ALLOC)
 
 void *__real_malloc(size_t size);
 void *__real_calloc(size_t nmemb, size_t size);

--- a/mrbgems/picoruby-machine/ports/rp2040/machine.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/machine.c
@@ -18,6 +18,9 @@
 #include "hardware/structs/scb.h"
 #include "hardware/sync.h"
 #include "pico/aon_timer.h"
+#if defined(PICO_CYW43_ARCH_POLL)
+#include "pico/cyw43_arch.h"
+#endif
 
 #include <stdint.h>
 #include <string.h>
@@ -364,6 +367,18 @@ picorb_hal_idle_cpu()
 picorb_hal_idle_cpu(mrb_state *mrb)
 #endif
 {
+#if defined(PICO_CYW43_ARCH_POLL)
+  /* cyw43_arch POLL mode: pump the shared async_context (cyw43_driver, lwIP and
+     btstack) then block until there is new stack work or the next scheduler
+     tick, whichever comes first. Unlike bare __wfi this self-bounds on the
+     deadline via an armed timer, so it also sidesteps the RP2350
+     __wfi-does-not-wake issue below. No-op until the stack is brought up. */
+  if (cyw43_is_initialized(&cyw43_state)) {
+    cyw43_arch_poll();
+    cyw43_arch_wait_for_work_until(make_timeout_time_ms(MRBC_TICK_UNIT));
+    return;
+  }
+#endif
 #if defined(PICO_RP2040)
   __wfi();
 #elif defined(PICO_RP2350)

--- a/mrbgems/picoruby-machine/src/heap.c
+++ b/mrbgems/picoruby-machine/src/heap.c
@@ -1,0 +1,124 @@
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+#include "../include/picorb_heap.h"
+
+#if defined(PICORB_ALLOC_ESTALLOC)
+
+static ESTALLOC *picorb_heap_estalloc = NULL;
+static uintptr_t picorb_heap_start = 0;
+static uintptr_t picorb_heap_end = 0;
+
+int
+picorb_heap_init(void *heap, size_t size)
+{
+  if (heap == NULL || size == 0 || size > UINT_MAX) {
+    picorb_heap_estalloc = NULL;
+    picorb_heap_start = 0;
+    picorb_heap_end = 0;
+    return -1;
+  }
+  picorb_heap_estalloc = est_init(heap, (unsigned int)size);
+  if (picorb_heap_estalloc == NULL) {
+    picorb_heap_start = 0;
+    picorb_heap_end = 0;
+    return -1;
+  }
+  picorb_heap_start = (uintptr_t)heap;
+  picorb_heap_end = picorb_heap_start + size;
+  return 0;
+}
+
+bool
+picorb_heap_ready(void)
+{
+  return picorb_heap_estalloc != NULL;
+}
+
+bool
+picorb_heap_owns(const void *ptr)
+{
+  uintptr_t addr = (uintptr_t)ptr;
+  return picorb_heap_estalloc != NULL &&
+         picorb_heap_start <= addr &&
+         addr < picorb_heap_end;
+}
+
+void *
+picorb_heap_malloc(size_t size)
+{
+  if (picorb_heap_estalloc == NULL || size > UINT_MAX) {
+    return NULL;
+  }
+  return est_malloc(picorb_heap_estalloc, (unsigned int)size);
+}
+
+void *
+picorb_heap_calloc(size_t nmemb, size_t size)
+{
+  if (picorb_heap_estalloc == NULL) {
+    return NULL;
+  }
+  if (size != 0 && nmemb > SIZE_MAX / size) {
+    return NULL;
+  }
+  if (nmemb > UINT_MAX || size > UINT_MAX) {
+    return NULL;
+  }
+  return est_calloc(picorb_heap_estalloc, (unsigned int)nmemb, (unsigned int)size);
+}
+
+void *
+picorb_heap_realloc(void *ptr, size_t size)
+{
+  if (ptr == NULL) {
+    return picorb_heap_malloc(size);
+  }
+  if (size == 0) {
+    picorb_heap_free(ptr);
+    return NULL;
+  }
+  if (picorb_heap_estalloc == NULL || size > UINT_MAX) {
+    return NULL;
+  }
+  return est_realloc(picorb_heap_estalloc, ptr, (unsigned int)size);
+}
+
+void
+picorb_heap_free(void *ptr)
+{
+  if (picorb_heap_estalloc == NULL || ptr == NULL) {
+    return;
+  }
+  est_free(picorb_heap_estalloc, ptr);
+}
+
+size_t
+picorb_heap_usable_size(void *ptr)
+{
+  if (picorb_heap_estalloc == NULL || ptr == NULL) {
+    return 0;
+  }
+  return (size_t)est_usable_size(picorb_heap_estalloc, ptr);
+}
+
+void
+picorb_heap_set_critical_section(void (*enter)(void), void (*exit_func)(void))
+{
+  if (picorb_heap_estalloc) {
+    est_set_critical_section(picorb_heap_estalloc, enter, exit_func);
+  }
+}
+
+int
+picorb_heap_stat(ESTALLOC_STAT *stat)
+{
+  if (picorb_heap_estalloc == NULL || stat == NULL) {
+    return -1;
+  }
+  est_take_statistics(picorb_heap_estalloc);
+  memcpy(stat, &picorb_heap_estalloc->stat, sizeof(*stat));
+  return 0;
+}
+
+#endif

--- a/mrbgems/picoruby-machine/src/mruby/alloc.c
+++ b/mrbgems/picoruby-machine/src/mruby/alloc.c
@@ -1,53 +1,43 @@
-#include <limits.h>
-
 #include "mruby.h"
 #include "mruby/presym.h"
 #include "mruby/hash.h"
-#include "../../lib/estalloc/estalloc.h"
-
-static ESTALLOC *est = NULL;
+#include "../../include/picorb_heap.h"
 
 void *
 mrb_basic_alloc_func(void *ptr, size_t size)
 {
   if (size == 0) {
-    est_free(est, ptr);
+    picorb_heap_free(ptr);
     return NULL;
   }
-  if (size > UINT_MAX) {
-    return NULL;
-  }
-  return est_realloc(est, ptr, (unsigned int)size);
+  return picorb_heap_realloc(ptr, size);
 }
 
 mrb_value
 mrb_alloc_statistics(mrb_state *mrb)
 {
-  est_take_statistics(est);
-  ESTALLOC_STAT *stat = &est->stat;
+  ESTALLOC_STAT mem;
+  picorb_heap_stat(&mem);
   mrb_value hash = mrb_hash_new_capa(mrb, 5);
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(allocator)), mrb_symbol_value(MRB_SYM(ESTALLOC)));
-  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(total)), mrb_fixnum_value(stat->total));
-  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(used)), mrb_fixnum_value(stat->used));
-  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(free)), mrb_fixnum_value(stat->free));
-  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(frag)), mrb_fixnum_value(stat->frag));
+  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(total)), mrb_fixnum_value(mem.total));
+  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(used)), mrb_fixnum_value(mem.used));
+  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(free)), mrb_fixnum_value(mem.free));
+  mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(frag)), mrb_fixnum_value(mem.frag));
   return hash;
 }
 
 mrb_state *
 mrb_open_with_custom_alloc(void *mem, size_t bytes)
 {
-  if (bytes > UINT_MAX) {
+  if (picorb_heap_init(mem, bytes) != 0) {
     return NULL;
   }
-  est = est_init(mem, (unsigned int)bytes);
   return mrb_open();
 }
 
 void
 mrb_alloc_set_critical_section(void (*enter)(void), void (*exit_func)(void))
 {
-  if (est) {
-    est_set_critical_section(est, enter, exit_func);
-  }
+  picorb_heap_set_critical_section(enter, exit_func);
 }

--- a/mrbgems/picoruby-machine/src/mruby/alloc.c
+++ b/mrbgems/picoruby-machine/src/mruby/alloc.c
@@ -18,11 +18,12 @@ mrb_alloc_statistics(mrb_state *mrb)
 {
   ESTALLOC_STAT mem;
   picorb_heap_stat(&mem);
-  mrb_value hash = mrb_hash_new_capa(mrb, 5);
+  mrb_value hash = mrb_hash_new_capa(mrb, 6);
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(allocator)), mrb_symbol_value(MRB_SYM(ESTALLOC)));
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(total)), mrb_fixnum_value(mem.total));
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(used)), mrb_fixnum_value(mem.used));
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(free)), mrb_fixnum_value(mem.free));
+  mrb_hash_set(mrb, hash, mrb_symbol_value(mrb_intern_lit(mrb, "max_free")), mrb_fixnum_value(mem.max_free));
   mrb_hash_set(mrb, hash, mrb_symbol_value(MRB_SYM(frag)), mrb_fixnum_value(mem.frag));
   return hash;
 }

--- a/mrbgems/picoruby-machine/src/mrubyc/alloc.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/alloc.c
@@ -1,71 +1,40 @@
 #include <stddef.h>
-#include <stdint.h>
-#include <limits.h>
 #include "../../include/estalloc_mrubyc.h"
-
-static ESTALLOC *picorb_mrubyc_estalloc = NULL;
 
 void
 picorb_estalloc_mrubyc_init(void *heap, size_t size)
 {
-  picorb_mrubyc_estalloc = est_init(heap, (unsigned int)size);
+  picorb_heap_init(heap, size);
 }
 
 int
 picorb_estalloc_mrubyc_statistics(ESTALLOC_STAT *stat)
 {
-  if (picorb_mrubyc_estalloc == NULL || stat == NULL) {
-    return -1;
-  }
-  est_take_statistics(picorb_mrubyc_estalloc);
-  *stat = picorb_mrubyc_estalloc->stat;
-  return 0;
+  return picorb_heap_stat(stat);
 }
 
+#if !defined(PICORB_WRAP_LIBC_ALLOC)
 void *
 malloc(size_t size)
 {
-  if (picorb_mrubyc_estalloc == NULL) {
-    return NULL;
-  }
-  if (size > UINT_MAX) {
-    return NULL;
-  }
-  return est_malloc(picorb_mrubyc_estalloc, (unsigned int)size);
+  return picorb_heap_malloc(size);
 }
 
 void *
 calloc(size_t nmemb, size_t size)
 {
-  if (picorb_mrubyc_estalloc == NULL) {
-    return NULL;
-  }
-  if (size != 0 && nmemb > SIZE_MAX / size) {
-    return NULL;
-  }
-  if (nmemb > UINT_MAX || size > UINT_MAX) {
-    return NULL;
-  }
-  return est_calloc(picorb_mrubyc_estalloc, (unsigned int)nmemb, (unsigned int)size);
+  return picorb_heap_calloc(nmemb, size);
 }
 
 void *
 realloc(void *ptr, size_t size)
 {
-  if (picorb_mrubyc_estalloc == NULL) {
-    return NULL;
-  }
-  if (size > UINT_MAX) {
-    return NULL;
-  }
-  return est_realloc(picorb_mrubyc_estalloc, ptr, (unsigned int)size);
+  return picorb_heap_realloc(ptr, size);
 }
 
 void
 free(void *ptr)
 {
-  if (picorb_mrubyc_estalloc == NULL) {
-    return;
-  }
-  est_free(picorb_mrubyc_estalloc, ptr);
+  picorb_heap_free(ptr);
 }
+#endif

--- a/mrbgems/picoruby-mruby/ports/rp2040/task.c
+++ b/mrbgems/picoruby-mruby/ports/rp2040/task.c
@@ -1,9 +1,26 @@
 #include "task_hal.h"
 
+#if defined(PICO_CYW43_ARCH_POLL)
+#include "pico/cyw43_arch.h"
+#endif
+
 void
 mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
 {
   (void)mrb;
   (void)reason;
+#if defined(PICO_CYW43_ARCH_POLL)
+  /* cyw43_arch POLL mode: cyw43_driver, lwIP and btstack share one
+     async_context that is only serviced from thread context. Pump it at every
+     scheduler control point (task switch and GC-drain step alike, hence reason
+     is ignored) so a compute-bound task or a long GC drain cannot starve the
+     network/BLE stack. Guarded by cyw43_is_initialized() so this is a no-op
+     until Wi-Fi/BLE has been brought up (e.g. before CYW43.init). Must stay
+     cheap and must never sleep -- that is mrb_hal_task_idle_cpu()'s job. */
+  if (cyw43_is_initialized(&cyw43_state)) {
+    cyw43_arch_poll();
+  }
+#else
   /* Nothing to service on this platform */
+#endif
 }

--- a/mrbgems/picoruby-net-http/mrblib/http_client.rb
+++ b/mrbgems/picoruby-net-http/mrblib/http_client.rb
@@ -69,7 +69,7 @@ module Net
 
     # Finish HTTP session
     def finish
-      if @socket && !@socket.closed?
+      if @socket
         @socket.close
       end
       @socket = nil

--- a/mrbgems/picoruby-picorubyvm/sig/picorubyvm.rbs
+++ b/mrbgems/picoruby-picorubyvm/sig/picorubyvm.rbs
@@ -1,5 +1,5 @@
 class PicoRubyVM
-  type alloc_stat_t = {total: Integer, used: Integer, free: Integer, frag: Integer}
+  type alloc_stat_t = {total: Integer, used: Integer, free: Integer, max_free: Integer, frag: Integer}
   type alloc_prof_t = {peak: Integer, valley: Integer}
 
   def self.memory_statistics: -> alloc_stat_t
@@ -8,4 +8,3 @@ class PicoRubyVM
   private def self.alloc_stop_profiling: () -> 0
   private def self.alloc_profiling_result: () -> alloc_prof_t
 end
-

--- a/mrbgems/picoruby-picorubyvm/src/mrubyc/picorubyvm.c
+++ b/mrbgems/picoruby-picorubyvm/src/mrubyc/picorubyvm.c
@@ -37,7 +37,7 @@ c_memory_statistics(struct VM *vm, mrbc_value v[], int argc)
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "Estalloc is not initialized");
     return;
   }
-  mrbc_value ret = mrbc_hash_new(vm, 5);
+  mrbc_value ret = mrbc_hash_new(vm, 6);
   mrbc_hash_set(
     &ret,
     &mrbc_symbol_value(mrbc_str_to_symid("allocator")),
@@ -57,6 +57,11 @@ c_memory_statistics(struct VM *vm, mrbc_value v[], int argc)
     &ret,
     &mrbc_symbol_value(mrbc_str_to_symid("free")),
     &mrbc_integer_value(mem.free)
+  );
+  mrbc_hash_set(
+    &ret,
+    &mrbc_symbol_value(mrbc_str_to_symid("max_free")),
+    &mrbc_integer_value(mem.max_free)
   );
   mrbc_hash_set(
     &ret,

--- a/mrbgems/picoruby-r2p2/README.md
+++ b/mrbgems/picoruby-r2p2/README.md
@@ -120,6 +120,10 @@ rake r2p2:picoruby:pico2:debug
 rake r2p2:picoruby:pico2_w:prod
 ```
 
+By default, R2P2 shares Estalloc with the libc-backed WiFi stack. Set
+`R2P2_NO_SHARED_ALLOC` to make LwIP/mbedTLS use newlib `malloc`/`free`
+instead.
+
 The output `.uf2` file is generated in:
 ```
 build/r2p2/{vm}/{board}/{mode}/R2P2-{VM}-{BOARD}-{VERSION}-{DATE}-{REV}.uf2

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -212,7 +212,7 @@ endif()
 if(USE_WIFI)
   # these are used only in WiFi build
   target_link_libraries(${PROJECT_NAME} PRIVATE
-    pico_cyw43_arch_lwip_threadsafe_background
+    pico_cyw43_arch_lwip_poll
     pico_btstack_ble
     pico_btstack_cyw43
   )

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -62,6 +62,8 @@ if(USE_WIFI)
     file(GLOB REMOVE_WIFI_SRCS CONFIGURE_DEPENDS
       ${PICORUBY_ROOT}/mrbgems/picoruby-filesystem-fat/ports/rp2040/*.c
       ${PICORUBY_ROOT}/mrbgems/picoruby-net/ports/rp2040/*.c
+      ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/common/*.c
+      ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/*.c
     )
   else()
     # pico_w uses picoruby-socket instead of picoruby-net to avoid function conflicts
@@ -139,27 +141,41 @@ target_link_directories(${PROJECT_NAME} PRIVATE
   ${PICORUBY_ROOT}/build/${MRUBY_CONFIG}/lib
 )
 
-pico_generate_pio_header(${PROJECT_NAME}
-  ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922_pio.pio
-)
+if(NOT PICO_BOARD STREQUAL "pico2_w")
+  pico_generate_pio_header(${PROJECT_NAME}
+    ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922_pio.pio
+  )
+endif()
 
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,--gc-sections)
 if(NOT R2P2_ALLOC_LIBC)
-  target_link_options(${PROJECT_NAME} PRIVATE -Wl,--wrap=malloc_usable_size)
+  target_link_options(${PROJECT_NAME} PRIVATE
+    -Wl,--wrap=malloc
+    -Wl,--wrap=calloc
+    -Wl,--wrap=realloc
+    -Wl,--wrap=free
+    -Wl,--wrap=malloc_usable_size
+  )
 endif()
 
 # RP2040: 4KB stack fits in SCRATCH_Y, use SDK default linker script
 # RP2350: 8KB stack needs RAM, use custom linker script
 if(PICO_BOARD STREQUAL "pico" OR PICO_BOARD STREQUAL "pico_w")
   set(PICORB_STACK_SIZE 0x1000) # 4KB
+  set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB (in SCRATCH_X)
 elseif(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
   set(PICORB_STACK_SIZE 0x2000) # 8KB
+  if(PICO_BOARD STREQUAL "pico2_w")
+    set(PICORB_CORE1_STACK_SIZE 0x0000) # PSG/core1 omitted in WiFi build
+  else()
+    set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB
+  endif()
   pico_set_linker_script(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/memmap_rp2350.ld)
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
   PICO_STACK_SIZE=${PICORB_STACK_SIZE}
-  PICO_CORE1_STACK_SIZE=0x0800 # 2KB (in SCRATCH_X)
+  PICO_CORE1_STACK_SIZE=${PICORB_CORE1_STACK_SIZE}
   PICO_HEAP_SIZE=0x0400        # 1KB
 )
 

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -58,20 +58,11 @@ if(USE_WIFI)
     ${PICO_SDK_PATH}/src/rp2_common/pico_mbedtls/pico_mbedtls.c
   )
   list(APPEND SOURCE_FILES ${ADD_WIFI_SOURCE_FILES})
-  if(PICO_BOARD STREQUAL "pico2_w")
-    file(GLOB REMOVE_WIFI_SRCS CONFIGURE_DEPENDS
-      ${PICORUBY_ROOT}/mrbgems/picoruby-filesystem-fat/ports/rp2040/*.c
-      ${PICORUBY_ROOT}/mrbgems/picoruby-net/ports/rp2040/*.c
-      ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/common/*.c
-      ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/*.c
-    )
-  else()
-    # pico_w uses picoruby-socket instead of picoruby-net to avoid function conflicts
-    file(GLOB REMOVE_WIFI_SRCS CONFIGURE_DEPENDS
-      ${PICORUBY_ROOT}/mrbgems/picoruby-filesystem-fat/ports/rp2040/*.c
-      ${PICORUBY_ROOT}/mrbgems/picoruby-net/ports/rp2040/*.c
-    )
-  endif()
+  # WiFi builds use picoruby-socket instead of picoruby-net to avoid function conflicts.
+  file(GLOB REMOVE_WIFI_SRCS CONFIGURE_DEPENDS
+    ${PICORUBY_ROOT}/mrbgems/picoruby-filesystem-fat/ports/rp2040/*.c
+    ${PICORUBY_ROOT}/mrbgems/picoruby-net/ports/rp2040/*.c
+  )
 else()
   file(GLOB REMOVE_WIFI_SRCS CONFIGURE_DEPENDS
       ${PICORUBY_ROOT}/mrbgems/picoruby-filesystem-fat/ports/rp2040/*.c
@@ -141,11 +132,9 @@ target_link_directories(${PROJECT_NAME} PRIVATE
   ${PICORUBY_ROOT}/build/${MRUBY_CONFIG}/lib
 )
 
-if(NOT PICO_BOARD STREQUAL "pico2_w")
-  pico_generate_pio_header(${PROJECT_NAME}
-    ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922_pio.pio
-  )
-endif()
+pico_generate_pio_header(${PROJECT_NAME}
+  ${PICORUBY_ROOT}/mrbgems/picoruby-psg/ports/rp2040/psg_drv_mcp4922_pio.pio
+)
 
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,--gc-sections)
 if(NOT R2P2_NO_SHARED_ALLOC)
@@ -165,11 +154,7 @@ if(PICO_BOARD STREQUAL "pico" OR PICO_BOARD STREQUAL "pico_w")
   set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB (in SCRATCH_X)
 elseif(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
   set(PICORB_STACK_SIZE 0x2000) # 8KB
-  if(PICO_BOARD STREQUAL "pico2_w")
-    set(PICORB_CORE1_STACK_SIZE 0x0000) # PSG/core1 omitted in WiFi build
-  else()
-    set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB
-  endif()
+  set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB
   pico_set_linker_script(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/memmap_rp2350.ld)
 endif()
 

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -8,9 +8,9 @@ include(pico_extras_import.cmake)
 # Initialize the SDK
 pico_sdk_init()
 
-option(R2P2_ALLOC_LIBC "Use pico-sdk/newlib malloc implementation instead of routing libc allocation to Estalloc" OFF)
-if(R2P2_ALLOC_LIBC)
-  add_compile_definitions(R2P2_ALLOC_LIBC=1)
+option(R2P2_NO_SHARED_ALLOC "Use pico-sdk/newlib malloc implementation instead of routing libc allocation to Estalloc" OFF)
+if(R2P2_NO_SHARED_ALLOC)
+  add_compile_definitions(R2P2_NO_SHARED_ALLOC=1)
 else()
   if(TARGET pico_malloc)
     set_target_properties(pico_malloc PROPERTIES INTERFACE_SOURCES "")
@@ -148,7 +148,7 @@ if(NOT PICO_BOARD STREQUAL "pico2_w")
 endif()
 
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,--gc-sections)
-if(NOT R2P2_ALLOC_LIBC)
+if(NOT R2P2_NO_SHARED_ALLOC)
   target_link_options(${PROJECT_NAME} PRIVATE
     -Wl,--wrap=malloc
     -Wl,--wrap=calloc

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -8,6 +8,15 @@ include(pico_extras_import.cmake)
 # Initialize the SDK
 pico_sdk_init()
 
+option(R2P2_ALLOC_LIBC "Use pico-sdk/newlib malloc implementation instead of routing libc allocation to Estalloc" OFF)
+if(R2P2_ALLOC_LIBC)
+  add_compile_definitions(R2P2_ALLOC_LIBC=1)
+else()
+  if(TARGET pico_malloc)
+    set_target_properties(pico_malloc PROPERTIES INTERFACE_SOURCES "")
+  endif()
+endif()
+
 execute_process (COMMAND date +%Y%m%d OUTPUT_VARIABLE CMAKE_BUILDDATE OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process (COMMAND git rev-parse --short HEAD OUTPUT_VARIABLE CMAKE_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE WORKING_DIRECTORY ${PICORUBY_ROOT})
 # R2P2_VERSION is passed via -D from rake task
@@ -135,6 +144,9 @@ pico_generate_pio_header(${PROJECT_NAME}
 )
 
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,--gc-sections)
+if(NOT R2P2_ALLOC_LIBC)
+  target_link_options(${PROJECT_NAME} PRIVATE -Wl,--wrap=malloc_usable_size)
+endif()
 
 # RP2040: 4KB stack fits in SCRATCH_Y, use SDK default linker script
 # RP2350: 8KB stack needs RAM, use custom linker script

--- a/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld
+++ b/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld
@@ -4,8 +4,8 @@
  * Core 0 stack uses the combined 8KB SCRATCH_X+SCRATCH_Y region,
  * allowing PICO_STACK_SIZE=8KB without consuming regular RAM.
  *
- * Core 1 stack, when enabled, is reserved at the end of regular RAM.
- * pico2_w builds set PICO_CORE1_STACK_SIZE=0 because PSG/core1 is omitted.
+ * Core 1 stack is reserved at the end of regular RAM so core 0 can keep the
+ * full 8KB scratch stack.
  */
 
 MEMORY

--- a/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld
+++ b/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld
@@ -1,11 +1,11 @@
 /* PicoRuby custom linker script for RP2350
  *
  * Based on pico-sdk memmap_default.ld with one key change:
- * Core 0 stack moved from SCRATCH_Y (4KB limit) to end of RAM,
- * allowing PICO_STACK_SIZE > 4KB for deeper Ruby VM call stacks.
+ * Core 0 stack uses the combined 8KB SCRATCH_X+SCRATCH_Y region,
+ * allowing PICO_STACK_SIZE=8KB without consuming regular RAM.
  *
- * Core 1 stack remains in SCRATCH_X.
- * SCRATCH_Y is fully available for .scratch_y data.
+ * Core 1 stack, when enabled, is reserved at the end of regular RAM.
+ * pico2_w builds set PICO_CORE1_STACK_SIZE=0 because PSG/core1 is omitted.
  */
 
 MEMORY
@@ -14,6 +14,7 @@ MEMORY
     RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 512k
     SCRATCH_X(rwx) : ORIGIN = 0x20080000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20081000, LENGTH = 4k
+    SCRATCH(rwx) : ORIGIN = 0x20080000, LENGTH = 8k
 }
 
 ENTRY(_entry_point)
@@ -204,37 +205,36 @@ SECTIONS
      *
      * stack1 section may be empty/missing if platform_launch_core1 is not used */
 
-    /* Core 1 stack remains in SCRATCH_X */
+    /* Core 1 stack is reserved in RAM, not SCRATCH. */
     .stack1_dummy (NOLOAD):
     {
         *(.stack1*)
-    } > SCRATCH_X
+    } > RAM
 
-    /* Core 0 stack: placed in RAM (not SCRATCH_Y) to allow > 4KB stack.
+    /* Core 0 stack: placed in combined SCRATCH_X+SCRATCH_Y.
      * The .stack_dummy section is only for size calculation (NOLOAD).
      * Actual stack pointer is set to __StackTop by crt0. */
     .stack_dummy (NOLOAD):
     {
         KEEP(*(.stack*))
-    } > RAM
+    } > SCRATCH
 
     .flash_end : {
         KEEP(*(.embedded_end_block*))
         PROVIDE(__flash_binary_end = .);
     } > FLASH =0xaa
 
-    /* Core 0 stack at end of RAM */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    /* Core 0 stack in combined scratch RAM */
+    __StackTop = ORIGIN(SCRATCH) + LENGTH(SCRATCH);
     __StackBottom = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
 
-    /* Core 1 stack in SCRATCH_X (unchanged) */
-    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
+    /* Core 1 stack, if enabled, at end of regular RAM */
+    __StackOneTop = ORIGIN(RAM) + LENGTH(RAM);
     __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
 
-    /* Heap grows up from __end__; stack grows down from __StackTop.
-     * __HeapLimit caps the heap so it cannot collide with the stack. */
-    __HeapLimit = __StackBottom;
+    /* Heap grows up from __end__; core 1 stack grows down from RAM top. */
+    __HeapLimit = __StackOneBottom;
     /* __StackLimit is historically the max heap pointer (poorly named) */
     __StackLimit = __StackBottom;
 
@@ -249,8 +249,12 @@ SECTIONS
     PROVIDE (_end = __end__);
     PROVIDE (__llvm_libc_heap_limit = __HeapLimit);
 
-    /* Check that data + heap + stack fits in RAM */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
+    /* Check that RAM sections and the runtime core 0 stack do not overlap. */
+    ASSERT(__end__ <= __HeapLimit, "region RAM overflowed")
+    ASSERT(__StackOneBottom >= __end__, "core 1 stack overlaps RAM data")
+    ASSERT(__StackBottom >= ORIGIN(SCRATCH), "core 0 stack overflowed SCRATCH")
+    ASSERT(SIZEOF(.scratch_x) == 0, ".scratch_x cannot be used when core 0 stack uses SCRATCH")
+    ASSERT(SIZEOF(.scratch_y) == 0, ".scratch_y cannot be used when core 0 stack uses SCRATCH")
 
     ASSERT( __binary_info_header_end - __logical_binary_start <= 1024, "Binary info must be in first 1024 bytes of the binary")
     ASSERT( __embedded_block_end - __logical_binary_start <= 4096, "Embedded block must be in first 4096 bytes of the binary")

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -47,12 +47,25 @@ heap_exit_critical(void)
 #if !defined(HEAP_SIZE)
   #if defined(PICO_RP2040)
     #define RAM_SIZE_KB             264
-    #define WIFI_RESERVED_SIZE_KB    32
   #elif defined(PICO_RP2350)
     #define RAM_SIZE_KB             520
-    #define WIFI_RESERVED_SIZE_KB    33
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"
+  #endif
+  #if defined(USE_WIFI) && defined(R2P2_ALLOC_LIBC)
+    /*
+     * When libc/newlib allocation is separated from Estalloc, keep room for
+     * CYW43/LwIP/mbedTLS outside heap_pool. In shared mode, libc allocation is
+     * routed to Estalloc too, so reserving this RAM would only shrink the
+     * shared heap and invalidate the experiment.
+     */
+    #if defined(PICO_RP2040)
+      #define WIFI_RESERVED_SIZE_KB  32
+    #else
+      #define WIFI_RESERVED_SIZE_KB  64
+    #endif
+  #else
+    #define WIFI_RESERVED_SIZE_KB    18
   #endif
   // Compiling a big Ruby code may need more stack size
   #define BASIC_STACK_SIZE_KB   80

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -26,6 +26,10 @@
 
 #if defined(PICORB_VM_MRUBY)
 #include "../../picoruby-machine/include/estalloc_mruby.h"
+#endif
+
+#include "../../picoruby-machine/include/picorb_heap.h"
+
 static critical_section_t heap_critsec;
 
 static void
@@ -39,7 +43,6 @@ heap_exit_critical(void)
 {
   critical_section_exit(&heap_critsec);
 }
-#endif
 
 #if !defined(HEAP_SIZE)
   #if defined(PICO_RP2040)
@@ -47,7 +50,7 @@ heap_exit_critical(void)
     #define WIFI_RESERVED_SIZE_KB    32
   #elif defined(PICO_RP2350)
     #define RAM_SIZE_KB             520
-    #define WIFI_RESERVED_SIZE_KB    76
+    #define WIFI_RESERVED_SIZE_KB    33
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"
   #endif
@@ -148,7 +151,7 @@ main(void)
 #if defined(PICORB_VM_MRUBY)
   mrb_state *mrb = mrb_open_with_custom_alloc(heap_pool, HEAP_SIZE);
   critical_section_init(&heap_critsec);
-  mrb_alloc_set_critical_section(heap_enter_critical, heap_exit_critical);
+  picorb_heap_set_critical_section(heap_enter_critical, heap_exit_critical);
   global_mrb = mrb;
   mrc_irep *irep = mrb_read_irep(mrb, main_task);
   mrc_ccontext *cc = mrc_ccontext_new(mrb);
@@ -170,6 +173,8 @@ main(void)
   mrc_ccontext_free(cc);
 #elif defined(PICORB_VM_MRUBYC)
   PICORB_ESTALLOC_MRUBYC_INIT(heap_pool, HEAP_SIZE);
+  critical_section_init(&heap_critsec);
+  picorb_heap_set_critical_section(heap_enter_critical, heap_exit_critical);
   mrbc_init(heap_pool, HEAP_SIZE);
   mrbc_tcb *main_tcb = mrbc_create_task(main_task, 0);
   if (!main_tcb) {

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -48,7 +48,12 @@ heap_exit_critical(void)
   #if defined(PICO_RP2040)
     #define RAM_SIZE_KB             264
   #elif defined(PICO_RP2350)
-    #define RAM_SIZE_KB             520
+    /*
+     * RP2350 has 512KB of regular SRAM plus 8KB of scratch SRAM. R2P2's
+     * RP2350 linker script reserves scratch SRAM for core0 stack, so heap_pool
+     * must be sized against regular SRAM only.
+     */
+    #define RAM_SIZE_KB             512
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"
   #endif
@@ -65,7 +70,7 @@ heap_exit_critical(void)
       #define WIFI_RESERVED_SIZE_KB  64
     #endif
   #else
-    #define WIFI_RESERVED_SIZE_KB    18
+    #define WIFI_RESERVED_SIZE_KB    15
   #endif
   // Compiling a big Ruby code may need more stack size
   #define BASIC_STACK_SIZE_KB   80

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -52,12 +52,12 @@ heap_exit_critical(void)
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"
   #endif
-  #if defined(USE_WIFI) && defined(R2P2_ALLOC_LIBC)
+  #if defined(USE_WIFI) && defined(R2P2_NO_SHARED_ALLOC)
     /*
      * When libc/newlib allocation is separated from Estalloc, keep room for
      * CYW43/LwIP/mbedTLS outside heap_pool. In shared mode, libc allocation is
      * routed to Estalloc too, so reserving this RAM would only shrink the
-     * shared heap and invalidate the experiment.
+     * shared heap.
      */
     #if defined(PICO_RP2040)
       #define WIFI_RESERVED_SIZE_KB  32

--- a/mrbgems/picoruby-shell/mrblib/shell.rb
+++ b/mrbgems/picoruby-shell/mrblib/shell.rb
@@ -105,6 +105,7 @@ class Shell
     end
     flawless = true
     while exe = Shell.next_executable
+      sleep_ms 3 # For GC.scheduler_driven step
       path = "#{root}#{exe[:path]}"
       unless self.ensure_system_file(path, exe[:code], exe[:crc])
         flawless = false
@@ -135,6 +136,7 @@ class Shell
       dirs = %w(bin home etc etc/init.d etc/network etc/dfu var var/log lib)
       di = 0
       while di < dirs.size
+        sleep_ms 3 # For GC.scheduler_driven step
         dir = dirs[di]
         unless Dir.exist?(dir)
           puts "Creating directory: #{dir}"
@@ -210,7 +212,7 @@ class Shell
         skip = true
         break
       end
-      sleep 0.1
+      sleep_ms 100
       j += 1
     end
     STDIN.read_nonblock 1024 # discard remaining input

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -68,6 +68,7 @@ extern void Net_busy_wait_ms(int ms);
 extern int Net_get_ip(const char *name, void *ip);
 #if !defined(PICORB_PLATFORM_ESP32)
 extern const char* Net_get_last_error(void);
+extern void Net_set_last_error(const char *format, ...);
 #endif
 #endif
 

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -66,6 +66,9 @@ extern void lwip_end(void);
 extern void Net_busy_wait_ms(int ms);
 /* Note: ip parameter type depends on LwIP configuration (ip_addr_t in implementation) */
 extern int Net_get_ip(const char *name, void *ip);
+#if !defined(PICORB_PLATFORM_ESP32)
+extern const char* Net_get_last_error(void);
+#endif
 #endif
 
 #endif

--- a/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
@@ -3,24 +3,74 @@
  */
 
 #include "../../include/socket.h"
+#include <stdarg.h>
+#include <stdio.h>
 #include "picoruby/debug.h"
 #include "pico/stdlib.h"
 #include "pico/cyw43_arch.h"
 #include "lwip/dns.h"
 
+static char net_error[SOCKET_ERROR_MSG_LEN];
+
+static void
+Net_clear_error(void)
+{
+  net_error[0] = '\0';
+}
+
+static void
+Net_set_error(const char *format, ...)
+{
+  va_list args;
+
+  va_start(args, format);
+  vsnprintf(net_error, sizeof(net_error), format, args);
+  va_end(args);
+
+  printf("%s\n", net_error);
+}
+
+const char*
+Net_get_last_error(void)
+{
+  return net_error;
+}
+
+static bool
+cyw43_lwip_ready(const char *operation)
+{
+  if (cyw43_arch_async_context() != NULL) {
+    return true;
+  }
+
+  Net_set_error(
+    "%s: CYW43/LwIP is not initialized. "
+    "Call CYW43.init, CYW43.enable_sta_mode, and CYW43.connect_timeout before using sockets",
+    operation
+  );
+  return false;
+}
+
 /* Busy wait with CYW43 polling for rp2040 */
 void
 Net_busy_wait_ms(int ms)
 {
-  cyw43_arch_poll();
+  if (cyw43_arch_async_context() != NULL) {
+    cyw43_arch_poll();
+  }
   busy_wait_ms(ms);
-  cyw43_arch_poll();
+  if (cyw43_arch_async_context() != NULL) {
+    cyw43_arch_poll();
+  }
 }
 
 /* Lock LwIP for thread safety */
 void
 lwip_begin(void)
 {
+  if (!cyw43_lwip_ready("lwip_begin")) {
+    return;
+  }
   cyw43_arch_lwip_begin();
 }
 
@@ -28,6 +78,9 @@ lwip_begin(void)
 void
 lwip_end(void)
 {
+  if (cyw43_arch_async_context() == NULL) {
+    return;
+  }
   cyw43_arch_lwip_end();
 }
 
@@ -51,6 +104,8 @@ Net_get_ip(const char *name, void *ip)
     return -1;
   }
 
+  Net_clear_error();
+
   ip_addr_t *addr = (ip_addr_t *)ip;
   ip_addr_set_zero(addr);
 
@@ -60,6 +115,9 @@ Net_get_ip(const char *name, void *ip)
   }
 
   /* Not a numeric IP, try DNS resolution */
+  if (!cyw43_lwip_ready("Net_get_ip")) {
+    return -1;
+  }
   lwip_begin();
   err_t err = dns_gethostbyname(name, addr, dns_callback, addr);
   lwip_end();
@@ -81,8 +139,10 @@ Net_get_ip(const char *name, void *ip)
       return 0;
     }
     D("Net_get_ip: DNS resolution timed out for %s\n", name);
+    Net_set_error("Net_get_ip: DNS resolution timed out for %s", name);
   } else {
     D("Net_get_ip: DNS failed for %s with error %d\n", name, err);
+    Net_set_error("Net_get_ip: DNS failed for %s with error %d", name, err);
   }
 
   return -1;

--- a/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
@@ -18,8 +18,8 @@ Net_clear_error(void)
   net_error[0] = '\0';
 }
 
-static void
-Net_set_error(const char *format, ...)
+void
+Net_set_last_error(const char *format, ...)
 {
   va_list args;
 
@@ -43,9 +43,23 @@ cyw43_lwip_ready(const char *operation)
     return true;
   }
 
-  Net_set_error(
-    "%s: CYW43/LwIP is not initialized. "
-    "Call CYW43.init, CYW43.enable_sta_mode, and CYW43.connect_timeout before using sockets",
+  Net_set_last_error(
+    "%s: CYW43/LwIP is not initialized; call CYW43.init before sockets",
+    operation
+  );
+  return false;
+}
+
+static bool
+cyw43_wifi_ready(const char *operation)
+{
+  int status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
+  if (status == CYW43_LINK_UP) {
+    return true;
+  }
+
+  Net_set_last_error(
+    "%s: CYW43 Wi-Fi is not connected; call CYW43.connect_timeout before sockets",
     operation
   );
   return false;
@@ -118,6 +132,9 @@ Net_get_ip(const char *name, void *ip)
   if (!cyw43_lwip_ready("Net_get_ip")) {
     return -1;
   }
+  if (!cyw43_wifi_ready("Net_get_ip")) {
+    return -1;
+  }
   lwip_begin();
   err_t err = dns_gethostbyname(name, addr, dns_callback, addr);
   lwip_end();
@@ -139,10 +156,10 @@ Net_get_ip(const char *name, void *ip)
       return 0;
     }
     D("Net_get_ip: DNS resolution timed out for %s\n", name);
-    Net_set_error("Net_get_ip: DNS resolution timed out for %s", name);
+    Net_set_last_error("Net_get_ip: DNS resolution timed out for %s", name);
   } else {
     D("Net_get_ip: DNS failed for %s with error %d\n", name, err);
-    Net_set_error("Net_get_ip: DNS failed for %s with error %d", name, err);
+    Net_set_last_error("Net_get_ip: DNS failed for %s with error %d", name, err);
   }
 
   return -1;

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -152,6 +152,11 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
 
   /* Copy data into pre-allocated buffer (no heap allocation in callback) */
   picorb_socket_t *sock = ssl_sock->base_socket;
+  if (!sock->recv_buf) {
+    Net_set_last_error("SSL recv buffer is not allocated");
+    pbuf_free(pbuf);
+    return ERR_MEM;
+  }
   size_t total_len = pbuf->tot_len;
   size_t new_size = sock->recv_len + total_len;
 
@@ -192,7 +197,9 @@ ssl_err_callback(void *arg, err_t err)
   picorb_ssl_socket_t *ssl_sock = (picorb_ssl_socket_t *)arg;
   if (!ssl_sock) return;
 
-  Net_set_last_error("SSL connection error: %s (%d)", lwip_err_name(err), (int)err);
+  if (!Net_get_last_error()[0]) {
+    Net_set_last_error("SSL connection error: %s (%d)", lwip_err_name(err), (int)err);
+  }
   ssl_sock->state = SSL_STATE_ERROR;
   ssl_sock->connected = false;
   ssl_sock->tls_pcb = NULL;  /* PCB is already freed by LwIP */
@@ -359,14 +366,14 @@ SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ssl_ctx)
   }
   memset(ssl_sock->base_socket, 0, sizeof(picorb_socket_t));
 
-  /* Pre-allocate receive buffer to eliminate heap allocation in callbacks. */
-  ssl_sock->base_socket->recv_buf = (char *)picorb_alloc(vm, SSL_RECV_BUF_SIZE + 1);
-  if (!ssl_sock->base_socket->recv_buf) {
-    picorb_free(vm, ssl_sock->base_socket);
-    picorb_free(vm, ssl_sock);
-    return NULL;
-  }
-  ssl_sock->base_socket->recv_capacity = SSL_RECV_BUF_SIZE;
+  /*
+   * Allocate recv_buf after the TLS handshake completes. The buffer is only
+   * for decrypted application data; mbedTLS uses its own buffers during the
+   * handshake. Deferring this saves heap while altcp_tls_new() allocates its
+   * TLS state.
+   */
+  ssl_sock->base_socket->recv_buf = NULL;
+  ssl_sock->base_socket->recv_capacity = 0;
 
   ssl_sock->ssl_ctx = ssl_ctx;
   ssl_sock->tls_pcb = NULL;
@@ -510,6 +517,10 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   if (!ssl_ctx) {
     D("SSL: altcp_tls_context failed");
     Net_set_last_error("SSL TLS context creation failed");
+    lwip_begin();
+    altcp_abort(ssl_sock->tls_pcb);
+    lwip_end();
+    ssl_sock->tls_pcb = NULL;
     altcp_tls_free_config(tls_config);
     return false;
   }
@@ -535,6 +546,12 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
     D("SSL: altcp_connect failed");
     Net_set_last_error("SSL altcp_connect failed: %s (%d)", lwip_err_name(err), (int)err);
     ssl_sock->state = SSL_STATE_ERROR;
+    altcp_abort(ssl_sock->tls_pcb);
+    ssl_sock->tls_pcb = NULL;
+    if (ssl_sock->ssl_ctx->tls_config == tls_config) {
+      ssl_sock->ssl_ctx->tls_config = NULL;
+    }
+    altcp_tls_free_config(tls_config);
     lwip_end();
     return false;
   }
@@ -552,6 +569,23 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
 
   if (ssl_sock->state == SSL_STATE_CONNECTED) {
     D("SSL: connected");
+    if (!ssl_sock->base_socket->recv_buf) {
+      ssl_sock->base_socket->recv_buf = (char *)picorb_alloc(vm, SSL_RECV_BUF_SIZE + 1);
+      if (!ssl_sock->base_socket->recv_buf) {
+        Net_set_last_error("SSL recv buffer allocation failed");
+        lwip_begin();
+        altcp_abort(ssl_sock->tls_pcb);
+        lwip_end();
+        ssl_sock->tls_pcb = NULL;
+        if (ssl_sock->ssl_ctx->tls_config == tls_config) {
+          ssl_sock->ssl_ctx->tls_config = NULL;
+        }
+        altcp_tls_free_config(tls_config);
+        return false;
+      }
+      ssl_sock->base_socket->recv_capacity = SSL_RECV_BUF_SIZE;
+      ssl_sock->base_socket->recv_len = 0;
+    }
     return true;
   } else {
     D("SSL: timeout or error, state=%d", ssl_sock->state);
@@ -565,6 +599,10 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
       lwip_end();
       ssl_sock->tls_pcb = NULL;
     }
+    if (ssl_sock->ssl_ctx->tls_config == tls_config) {
+      ssl_sock->ssl_ctx->tls_config = NULL;
+    }
+    altcp_tls_free_config(tls_config);
     ssl_sock->state = SSL_STATE_ERROR;
     return false;
   }
@@ -666,6 +704,14 @@ SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
     lwip_end();
 
     ssl_sock->tls_pcb = NULL;
+
+    if (ssl_sock->ssl_ctx && ssl_sock->ssl_ctx->tls_config) {
+      altcp_tls_free_config(ssl_sock->ssl_ctx->tls_config);
+      ssl_sock->ssl_ctx->tls_config = NULL;
+    }
+  } else if (ssl_sock->ssl_ctx && ssl_sock->ssl_ctx->tls_config) {
+    altcp_tls_free_config(ssl_sock->ssl_ctx->tls_config);
+    ssl_sock->ssl_ctx->tls_config = NULL;
   }
 
   if (ssl_sock->hostname) {

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -76,6 +76,31 @@ static err_t ssl_sent_callback(void *arg, struct altcp_pcb *pcb, u16_t len);
 static void ssl_err_callback(void *arg, err_t err);
 static err_t ssl_poll_callback(void *arg, struct altcp_pcb *pcb);
 
+static const char*
+lwip_err_name(err_t err)
+{
+  switch (err) {
+    case ERR_OK: return "ERR_OK";
+    case ERR_MEM: return "ERR_MEM";
+    case ERR_BUF: return "ERR_BUF";
+    case ERR_TIMEOUT: return "ERR_TIMEOUT";
+    case ERR_RTE: return "ERR_RTE";
+    case ERR_INPROGRESS: return "ERR_INPROGRESS";
+    case ERR_VAL: return "ERR_VAL";
+    case ERR_WOULDBLOCK: return "ERR_WOULDBLOCK";
+    case ERR_USE: return "ERR_USE";
+    case ERR_ALREADY: return "ERR_ALREADY";
+    case ERR_ISCONN: return "ERR_ISCONN";
+    case ERR_CONN: return "ERR_CONN";
+    case ERR_IF: return "ERR_IF";
+    case ERR_ABRT: return "ERR_ABRT";
+    case ERR_RST: return "ERR_RST";
+    case ERR_CLSD: return "ERR_CLSD";
+    case ERR_ARG: return "ERR_ARG";
+    default: return "ERR_UNKNOWN";
+  }
+}
+
 /* ========================================================================
  * Callback Functions
  * ======================================================================== */
@@ -92,6 +117,7 @@ ssl_connected_callback(void *arg, struct altcp_pcb *pcb, err_t err)
 
   if (err != ERR_OK) {
     D("SSL callback: error");
+    Net_set_last_error("SSL connect callback failed: %s (%d)", lwip_err_name(err), (int)err);
     ssl_sock->state = SSL_STATE_ERROR;
     ssl_sock->connected = false;
     return err;
@@ -166,6 +192,7 @@ ssl_err_callback(void *arg, err_t err)
   picorb_ssl_socket_t *ssl_sock = (picorb_ssl_socket_t *)arg;
   if (!ssl_sock) return;
 
+  Net_set_last_error("SSL connection error: %s (%d)", lwip_err_name(err), (int)err);
   ssl_sock->state = SSL_STATE_ERROR;
   ssl_sock->connected = false;
   ssl_sock->tls_pcb = NULL;  /* PCB is already freed by LwIP */
@@ -448,6 +475,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
 
   if (!tls_config) {
     D("SSL: TLS config failed");
+    Net_set_last_error("SSL TLS config allocation failed");
     return false;
   }
   D("SSL: TLS config ok");
@@ -464,6 +492,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   ssl_sock->tls_pcb = altcp_tls_new(tls_config, IPADDR_TYPE_V4);
   if (!ssl_sock->tls_pcb) {
     D("SSL: TLS PCB failed");
+    Net_set_last_error("SSL TLS PCB allocation failed");
     altcp_tls_free_config(tls_config);
     return false;
   }
@@ -480,6 +509,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   mbedtls_ssl_context *ssl_ctx = altcp_tls_context(ssl_sock->tls_pcb);
   if (!ssl_ctx) {
     D("SSL: altcp_tls_context failed");
+    Net_set_last_error("SSL TLS context creation failed");
     altcp_tls_free_config(tls_config);
     return false;
   }
@@ -503,6 +533,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   err_t err = altcp_connect(ssl_sock->tls_pcb, &ip_addr, ssl_sock->port, ssl_connected_callback);
   if (err != ERR_OK) {
     D("SSL: altcp_connect failed");
+    Net_set_last_error("SSL altcp_connect failed: %s (%d)", lwip_err_name(err), (int)err);
     ssl_sock->state = SSL_STATE_ERROR;
     lwip_end();
     return false;
@@ -524,6 +555,9 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
     return true;
   } else {
     D("SSL: timeout or error, state=%d", ssl_sock->state);
+    if (!Net_get_last_error()[0]) {
+      Net_set_last_error("SSL handshake timed out");
+    }
     /* Cleanup on timeout */
     if (ssl_sock->tls_pcb) {
       lwip_begin();

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -13,6 +13,9 @@
 #include "lwip/altcp.h"
 #include "lwip/dns.h"
 #include "lwip/err.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "pico/cyw43_arch.h"
+#endif
 
 /* Pre-allocated receive buffer size for TCP. */
 #ifndef TCP_RECV_BUF_SIZE

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -197,8 +197,13 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
   int dns_result = Net_get_ip(host, &ip_addr);
   if (dns_result != 0) {
     D("TCP: DNS failed");
-    snprintf(sock->errmsg, sizeof(sock->errmsg),
-             "getaddrinfo(\"%s\"): Name or service not known", host);
+    const char *net_error = Net_get_last_error();
+    if (net_error && net_error[0]) {
+      snprintf(sock->errmsg, sizeof(sock->errmsg), "%s", net_error);
+    } else {
+      snprintf(sock->errmsg, sizeof(sock->errmsg),
+               "getaddrinfo(\"%s\"): Name or service not known", host);
+    }
     return false;
   }
   D("TCP: DNS ok");

--- a/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
@@ -12,6 +12,9 @@
 #define PICORB_NO_LWIP_HELPERS
 #include "lwip/udp.h"
 #include "lwip/dns.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "pico/cyw43_arch.h"
+#endif
 
 /* Pre-allocated receive buffer size for UDP.
  * 1500 covers max Ethernet frame payload. Sufficient for NTP (48 bytes),

--- a/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
+++ b/mrbgems/picoruby-socket/src/altcp_tls_mbedtls.c
@@ -62,6 +62,8 @@
 
 #if LWIP_ALTCP_TLS && LWIP_ALTCP_TLS_MBEDTLS
 
+#include "../include/socket.h"
+
 #include "lwip/altcp.h"
 #include "lwip/altcp_tls.h"
 #include "lwip/priv/altcp_priv.h"
@@ -298,6 +300,7 @@ altcp_mbedtls_lower_recv_process(struct altcp_pcb *conn, altcp_mbedtls_state_t *
     }
     if (ret != 0) {
       LWIP_DEBUGF(ALTCP_MBEDTLS_DEBUG, ("mbedtls_ssl_handshake failed: %d\n", ret));
+      Net_set_last_error("mbedTLS handshake failed: -0x%04x", (unsigned int)-ret);
       /* handshake failed, connection has to be closed */
       if (conn->err) {
         conn->err(conn->arg, ERR_CLSD);
@@ -662,8 +665,11 @@ altcp_tls_wrap(struct altcp_tls_config *config, struct altcp_pcb *inner_pcb)
   if (ret != NULL) {
     if (altcp_mbedtls_setup(config, ret, inner_pcb) != ERR_OK) {
       altcp_free(ret);
+      altcp_free(inner_pcb);
       return NULL;
     }
+  } else {
+    altcp_free(inner_pcb);
   }
   return ret;
 }

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -399,6 +399,13 @@ mrb_ssl_socket_s_open(mrb_state *mrb, mrb_value klass)
   }
 
   if (!SSLSocket_connect(mrb, ssl_sock)) {
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+    const char *net_error = Net_get_last_error();
+    if (net_error && net_error[0]) {
+      SSLSocket_close(mrb, ssl_sock);
+      mrb_raise(mrb, E_RUNTIME_ERROR, net_error);
+    }
+#endif
     SSLSocket_close(mrb, ssl_sock);
     mrb_raise(mrb, E_RUNTIME_ERROR, "SSL connection failed");
   }
@@ -425,6 +432,12 @@ mrb_ssl_socket_connect(mrb_state *mrb, mrb_value self)
   }
 
   if (!SSLSocket_connect(mrb, ssl_sock)) {
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+    const char *net_error = Net_get_last_error();
+    if (net_error && net_error[0]) {
+      mrb_raise(mrb, E_RUNTIME_ERROR, net_error);
+    }
+#endif
     mrb_raise(mrb, E_RUNTIME_ERROR, "SSL handshake failed");
   }
 

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -293,10 +293,7 @@ static void
 mrb_ssl_socket_free(mrb_state *mrb, void *ptr)
 {
   if (ptr) {
-    picorb_ssl_socket_t *ssl_sock = (picorb_ssl_socket_t *)ptr;
-    if (!SSLSocket_closed(mrb, ssl_sock)) {
-      SSLSocket_close(mrb, ssl_sock);
-    }
+    SSLSocket_close(mrb, (picorb_ssl_socket_t *)ptr);
   }
 }
 

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -180,8 +180,17 @@ c_ssl_socket_open(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* Perform SSL handshake */
   if (!SSLSocket_connect(vm, wrapper->ptr)) {
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+    const char *net_error = Net_get_last_error();
+#endif
     SSLSocket_close(vm, wrapper->ptr);
     wrapper->ptr = NULL;
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+    if (net_error && net_error[0]) {
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), net_error);
+      return;
+    }
+#endif
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "SSL connection failed");
     return;
   }
@@ -212,6 +221,13 @@ c_ssl_socket_connect(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* Perform SSL handshake */
   if (!SSLSocket_connect(vm, wrapper->ptr)) {
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+    const char *net_error = Net_get_last_error();
+    if (net_error && net_error[0]) {
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), net_error);
+      return;
+    }
+#endif
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "SSL handshake failed");
     return;
   }

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -12,7 +12,7 @@ static void
 mrbc_ssl_socket_free(mrbc_value *self)
 {
   ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)self->instance->data;
-  if (wrapper->ptr && !SSLSocket_closed(wrapper->vm, wrapper->ptr)) {
+  if (wrapper->ptr) {
     SSLSocket_close(wrapper->vm, wrapper->ptr);
     wrapper->ptr = NULL;
   }

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -53,16 +53,12 @@ def r2p2_def_psg_pwm_dma
   "-D PICORUBY_PSG_PWM_DMA=#{enabled ? 'ON' : 'OFF'}"
 end
 
-def r2p2_def_alloc_libc(board)
-  value = ENV["R2P2_ALLOC_LIBC"]
-  if value
-    enabled = !%w[0 off false no n].include?(value.downcase)
-  else
-    # WiFi/LwIP/mbedTLS need their own libc heap for now. Keep the shared
-    # Estalloc wiring available, but don't enable it by default for W boards.
-    enabled = board.end_with?("_w")
-  end
-  "-D R2P2_ALLOC_LIBC=#{enabled ? 'ON' : 'OFF'}"
+def r2p2_def_no_shared_alloc
+  enabled = ENV.key?("R2P2_NO_SHARED_ALLOC")
+
+  # Shared allocation is the default. Set R2P2_NO_SHARED_ALLOC to route
+  # libc allocation back to newlib malloc/free instead.
+  "-D R2P2_NO_SHARED_ALLOC=#{enabled ? 'ON' : 'OFF'}"
 end
 
 def r2p2_build_dir(vm, board, mode)
@@ -154,7 +150,7 @@ namespace :r2p2 do
                 #{r2p2_def_build_type(mode)} \
                 #{r2p2_def_psg_mcp4922_dma} \
                 #{r2p2_def_psg_pwm_dma} \
-                #{r2p2_def_alloc_libc(board)}
+                #{r2p2_def_no_shared_alloc}
               DEFS
               sh "cmake -S #{R2P2_GEM_DIR}/cmake -B #{dir} #{defs}"
               sh "cmake --build #{dir}"

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -53,6 +53,18 @@ def r2p2_def_psg_pwm_dma
   "-D PICORUBY_PSG_PWM_DMA=#{enabled ? 'ON' : 'OFF'}"
 end
 
+def r2p2_def_alloc_libc(board)
+  value = ENV["R2P2_ALLOC_LIBC"]
+  if value
+    enabled = !%w[0 off false no n].include?(value.downcase)
+  else
+    # WiFi/LwIP/mbedTLS need their own libc heap for now. Keep the shared
+    # Estalloc wiring available, but don't enable it by default for W boards.
+    enabled = board.end_with?("_w")
+  end
+  "-D R2P2_ALLOC_LIBC=#{enabled ? 'ON' : 'OFF'}"
+end
+
 def r2p2_build_dir(vm, board, mode)
   "#{MRUBY_ROOT}/build/r2p2/#{vm}/#{board}/#{mode}"
 end
@@ -142,7 +154,7 @@ namespace :r2p2 do
                 #{r2p2_def_build_type(mode)} \
                 #{r2p2_def_psg_mcp4922_dma} \
                 #{r2p2_def_psg_pwm_dma} \
-                -D R2P2_ALLOC_LIBC=#{ENV["R2P2_ALLOC_LIBC"] ? "ON" : "OFF"}
+                #{r2p2_def_alloc_libc(board)}
               DEFS
               sh "cmake -S #{R2P2_GEM_DIR}/cmake -B #{dir} #{defs}"
               sh "cmake --build #{dir}"

--- a/tasks/picoruby/r2p2.rake
+++ b/tasks/picoruby/r2p2.rake
@@ -141,7 +141,8 @@ namespace :r2p2 do
                 #{r2p2_def_board(board)} \
                 #{r2p2_def_build_type(mode)} \
                 #{r2p2_def_psg_mcp4922_dma} \
-                #{r2p2_def_psg_pwm_dma}
+                #{r2p2_def_psg_pwm_dma} \
+                -D R2P2_ALLOC_LIBC=#{ENV["R2P2_ALLOC_LIBC"] ? "ON" : "OFF"}
               DEFS
               sh "cmake -S #{R2P2_GEM_DIR}/cmake -B #{dir} #{defs}"
               sh "cmake --build #{dir}"


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the heap and memory allocation system for PicoRuby on RP2040/RP2350 platforms, with a focus on improved flexibility, code reuse, and WiFi stack integration. The main changes are the introduction of a unified heap management interface (`picorb_heap`), the ability to optionally share the Estalloc heap with the libc-backed WiFi stack, and improved memory statistics reporting. Additionally, the build system and linker scripts are updated to support these new features and optimize stack allocation.

**Heap and Memory Allocation Refactor**

* Introduced a new unified heap interface (`picorb_heap.h`/`picorb_heap.c`) providing functions for heap initialization, allocation, deallocation, statistics, and critical section management, replacing direct usage of Estalloc in various components. [[1]](diffhunk://#diff-8727383c946bdb6f3ec024930e5f5d8a398eea3429ba8943ab0c9faf0a7b561cR1-R27) [[2]](diffhunk://#diff-391feebeeb1194fef2fbc757bef7257fd7e5aa597085ff45781d5dd222e294ddR1-R124) [[3]](diffhunk://#diff-dda415565cca5ed1cd55bf32bed0dfa51fa15a3cbc5aa5a974d2692ac3f56ab5L1-R43) [[4]](diffhunk://#diff-6e7946302a12fd0f0219d4dfe0b5662b27233c4c9c9ab5ddaf1863598d7a52ebL2-R40)
* Refactored mruby and mrubyc allocation code to use the new `picorb_heap` interface, simplifying and unifying memory management across the VM and runtime. [[1]](diffhunk://#diff-dda415565cca5ed1cd55bf32bed0dfa51fa15a3cbc5aa5a974d2692ac3f56ab5L1-R43) [[2]](diffhunk://#diff-6e7946302a12fd0f0219d4dfe0b5662b27233c4c9c9ab5ddaf1863598d7a52ebL2-R40)

**WiFi Stack and libc Integration**

* Added optional support for wrapping libc allocation functions (`malloc`, `calloc`, `realloc`, `free`) to route them through Estalloc, enabling the WiFi stack (LwIP/mbedTLS) to share the same heap as the Ruby VM. This is controlled by the `R2P2_NO_SHARED_ALLOC` build option. [[1]](diffhunk://#diff-2239369e0f8182887f261c72a0371782fa291954ecbd83923531f08ad3372e74R1-R79) [[2]](diffhunk://#diff-0657ac506f69ff203f497c74922b4cca88c19ed9a880a200e331c259692d21fbR114-R117) [[3]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R11-R19) [[4]](diffhunk://#diff-109fbd549975d571a8dd41852c2b88199514a69e98ca55a2ddc1a4648142406cR123-R126)
* Updated the CMake build system and linker options to support heap sharing and correct symbol wrapping, and documented the new option in the README. [[1]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R11-R19) [[2]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R140-R163) [[3]](diffhunk://#diff-109fbd549975d571a8dd41852c2b88199514a69e98ca55a2ddc1a4648142406cR123-R126)

**Memory Statistics and API Changes**

* Enhanced memory statistics reporting to include a new `max_free` field, updating public Ruby and C APIs and type signatures accordingly. [[1]](diffhunk://#diff-d9d9df0bd50a41522deebf991ab1a7d5828865e76f6619b0815ce54b6b24724bL2-R2) [[2]](diffhunk://#diff-7c6e999f9cefdf8ced3fc6a596935c9c1ab3dd52aaf914eab7c4d8539cfaaab1L40-R40) [[3]](diffhunk://#diff-7c6e999f9cefdf8ced3fc6a596935c9c1ab3dd52aaf914eab7c4d8539cfaaab1R61-R65)
* Updated related Ruby signature files and API consumers to use the new statistics structure. [[1]](diffhunk://#diff-d9d9df0bd50a41522deebf991ab1a7d5828865e76f6619b0815ce54b6b24724bL2-R2) [[2]](diffhunk://#diff-d9d9df0bd50a41522deebf991ab1a7d5828865e76f6619b0815ce54b6b24724bL11)

**WiFi Stack Polling and Power Management Improvements**

* Improved integration with the CYW43 WiFi/BLE stack by polling the async context at appropriate scheduler points (task switch, idle, etc.) to avoid starving the stack and to improve power management. [[1]](diffhunk://#diff-045aa5017eccb5e53c5a2b9efb46c74c1865a803fbf8b429ccd25a93dfb09de2R21-R23) [[2]](diffhunk://#diff-045aa5017eccb5e53c5a2b9efb46c74c1865a803fbf8b429ccd25a93dfb09de2R370-R381) [[3]](diffhunk://#diff-998289862d7400a81bd73b248acd6dd36fe4b6ab372dcbee6cda352750854de6R3-R25)
* Changed the WiFi stack mode to use `pico_cyw43_arch_lwip_poll` for better compatibility with the new allocation and polling scheme.

**Stack and Linker Script Updates**

* Updated linker scripts and build configuration to optimize stack usage for both cores, allowing for larger Ruby VM stacks and improved memory layout on RP2350. [[1]](diffhunk://#diff-a339fd9f633cd98fd042b0ceb53a8cd15bc020843179d148d3bf0ee6db1effadL4-R8) [[2]](diffhunk://#diff-a339fd9f633cd98fd042b0ceb53a8cd15bc020843179d148d3bf0ee6db1effadR17) [[3]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R140-R163)

These changes provide a more robust, flexible, and maintainable heap and memory allocation system, especially for WiFi-enabled builds, and lay the groundwork for future enhancements and debugging capabilities.

---

**References:**

* Heap and Memory Allocation Refactor: [[1]](diffhunk://#diff-8727383c946bdb6f3ec024930e5f5d8a398eea3429ba8943ab0c9faf0a7b561cR1-R27) [[2]](diffhunk://#diff-391feebeeb1194fef2fbc757bef7257fd7e5aa597085ff45781d5dd222e294ddR1-R124) [[3]](diffhunk://#diff-dda415565cca5ed1cd55bf32bed0dfa51fa15a3cbc5aa5a974d2692ac3f56ab5L1-R43) [[4]](diffhunk://#diff-6e7946302a12fd0f0219d4dfe0b5662b27233c4c9c9ab5ddaf1863598d7a52ebL2-R40)
* WiFi Stack and libc Integration: [[1]](diffhunk://#diff-2239369e0f8182887f261c72a0371782fa291954ecbd83923531f08ad3372e74R1-R79) [[2]](diffhunk://#diff-0657ac506f69ff203f497c74922b4cca88c19ed9a880a200e331c259692d21fbR114-R117) [[3]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R11-R19) [[4]](diffhunk://#diff-109fbd549975d571a8dd41852c2b88199514a69e98ca55a2ddc1a4648142406cR123-R126)
* Memory Statistics and API Changes: [[1]](diffhunk://#diff-d9d9df0bd50a41522deebf991ab1a7d5828865e76f6619b0815ce54b6b24724bL2-R2) [[2]](diffhunk://#diff-7c6e999f9cefdf8ced3fc6a596935c9c1ab3dd52aaf914eab7c4d8539cfaaab1L40-R40) [[3]](diffhunk://#diff-7c6e999f9cefdf8ced3fc6a596935c9c1ab3dd52aaf914eab7c4d8539cfaaab1R61-R65)
* WiFi Stack Polling and Power Management Improvements: [[1]](diffhunk://#diff-045aa5017eccb5e53c5a2b9efb46c74c1865a803fbf8b429ccd25a93dfb09de2R21-R23) [[2]](diffhunk://#diff-045aa5017eccb5e53c5a2b9efb46c74c1865a803fbf8b429ccd25a93dfb09de2R370-R381) [[3]](diffhunk://#diff-998289862d7400a81bd73b248acd6dd36fe4b6ab372dcbee6cda352750854de6R3-R25) [[4]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3L203-R216)
* Stack and Linker Script Updates: [[1]](diffhunk://#diff-a339fd9f633cd98fd042b0ceb53a8cd15bc020843179d148d3bf0ee6db1effadL4-R8) [[2]](diffhunk://#diff-a339fd9f633cd98fd042b0ceb53a8cd15bc020843179d148d3bf0ee6db1effadR17) [[3]](diffhunk://#diff-eb6837200cbd9d2cbe9260ae8b3cf1a13bb61c933f05301e2ca212970c2cbfe3R140-R163)