### PR TITLE
Fix UART argument handling in PicoRuby

### DIFF
--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -281,7 +281,7 @@ mrb_break(mrb_state *mrb, mrb_value self)
     if (mrb_float_p(break_ms_val)) {
       break_ms = (uint32_t)(mrb_float(break_ms_val) * 1000);
     } else if (mrb_fixnum_p(break_ms_val)) {
-      break_ms = (uint32_t)mrb_fixnum(break_ms_val);
+      break_ms = (uint32_t)(mrb_fixnum(break_ms_val) * 1000);
     } else {
       mrb_raise(mrb, E_TYPE_ERROR, "can't convert into time interval");
     }

--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -22,7 +22,7 @@ static mrb_value
 mrb_open_rx_buffer(mrb_state *mrb, mrb_value self)
 {
   int rx_buffer_size;
-  mrb_value buffer_size;
+  mrb_value buffer_size = mrb_nil_value();
   mrb_get_args(mrb, "|o", &buffer_size);
   if (mrb_nil_p(buffer_size)) {
     rx_buffer_size = PICORB_UART_RX_BUFFER_SIZE;
@@ -105,7 +105,7 @@ mrb_read(mrb_state *mrb, mrb_value self)
   if (available_len == 0) {
     return mrb_nil_value();
   }
-  mrb_value len_val;
+  mrb_value len_val = mrb_nil_value();
   mrb_int len;
   mrb_get_args(mrb, "|o", &len_val);
   if (mrb_fixnum_p(len_val)) {

--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -273,7 +273,7 @@ static mrb_value
 mrb_break(mrb_state *mrb, mrb_value self)
 {
   uint32_t break_ms;
-  mrb_value break_ms_val;
+  mrb_value break_ms_val = mrb_nil_value();
   mrb_get_args(mrb, "|o", &break_ms_val);
   if (mrb_nil_p(break_ms_val)) {
     break_ms = 100;


### PR DESCRIPTION
This PR fixes UART#break, UART#read and UART#open_rx_buffer on PicoRuby to align its behavior with FemtoRuby.

1. Fixed break not working when called without an argument. When the argument is omitted, it now defaults to 100ms.
2. Fixed PicoRuby treating the argument as milliseconds instead of seconds. It now uses seconds, the same as FemtoRuby. This also matches the [I/O API Guideline](https://github.com/mruby/microcontroller-peripheral-interface-guide/blob/main/mruby_io_UART_en.md).
3. Fixed the same missing-argument bug in UART#read and UART#open_rx_buffer, which have the same root cause as 1.