### PR TITLE
Fix broken cross-compilation example link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ rake femtoruby:debug
 
 #### Cross compilation
 
-See an example: [build_config/r2p2-picoruby-pico.rb](build_config/r2p2-picoruby-pico.rb)
+See an example: [build_config/r2p2-picoruby-pico2.rb](build_config/r2p2-picoruby-pico2.rb)
 
 ### Binaries
 


### PR DESCRIPTION
README linked to build_config/r2p2-picoruby-pico.rb, which no longer
exists (renamed to r2p2-femtoruby-pico.rb). Point it at
r2p2-picoruby-pico2.rb instead.