### PR TITLE
Peripheral init with no unit name

### DIFF
--- a/mrbgems/picoruby-i2c/README.md
+++ b/mrbgems/picoruby-i2c/README.md
@@ -8,6 +8,9 @@ I2C (Inter-Integrated Circuit) communication library for PicoRuby.
 # Initialize I2C
 i2c = I2C.new(unit: :RP2040_I2C0, frequency: 400_000, sda_pin: 4, scl_pin: 5)
 
+# On RP2040 the unit can be omitted; it is inferred from the pins
+i2c = I2C.new(sda_pin: 4, scl_pin: 5)  # inferred as :RP2040_I2C0
+
 # Write data
 i2c.write(0x50, 0x00, 0x01, 0x02)  # Write to device 0x50
 
@@ -30,7 +33,7 @@ i2c.scan  # Prints addresses of connected devices
 
 ### Methods
 
-- `I2C.new(unit:, frequency: DEFAULT_FREQUENCY, sda_pin:, scl_pin:, timeout: DEFAULT_TIMEOUT)` - Initialize I2C
+- `I2C.new(unit: nil, frequency: DEFAULT_FREQUENCY, sda_pin:, scl_pin:, timeout: DEFAULT_TIMEOUT)` - Initialize I2C. On RP2040 `unit:` is optional and inferred from `sda_pin`/`scl_pin`. If a given `unit:` disagrees with the pins, or the pins imply different units, or no unit can be determined, an `ArgumentError` is raised. On ESP32 `unit:` is still required.
 - `write(address, *data, timeout: nil, nostop: false)` - Write data to I2C device
 - `read(address, length, *write_data, timeout: nil)` - Read data from I2C device
 - `scan(timeout: nil)` - Scan and print connected I2C devices

--- a/mrbgems/picoruby-i2c/include/i2c.h
+++ b/mrbgems/picoruby-i2c/include/i2c.h
@@ -14,9 +14,19 @@ extern "C" {
 typedef enum {
  I2C_ERROR_NONE          =  0,
  I2C_ERROR_INVALID_UNIT  = -1,
+ I2C_ERROR_UNIT_MISMATCH = -2,
+ I2C_ERROR_UNDETERMINED  = -3,
 } i2c_status_t;
 
 int I2C_unit_name_to_unit_num(const char *);
+/*
+ * Resolve the unit number from the unit name and the SDA/SCL pins.
+ * On RP2 the unit can be inferred from the pins when the name is empty, and a
+ * mismatch between name and pins (or between pins) yields a negative error code.
+ * On other platforms this falls back to I2C_unit_name_to_unit_num().
+ */
+int I2C_resolve_unit_num(const char *unit_name, int sda_pin, int scl_pin);
+int I2C_unit_num_from_pins(const char *unit_name, int sda_pin, int scl_pin);
 i2c_status_t I2C_gpio_init(int, uint32_t, int8_t, int8_t);
 int I2C_read_timeout_us(int, uint8_t, uint8_t*, size_t, bool, uint32_t);
 int I2C_write_timeout_us(int, uint8_t, uint8_t*, size_t, bool, uint32_t);

--- a/mrbgems/picoruby-i2c/mrblib/i2c.rb
+++ b/mrbgems/picoruby-i2c/mrblib/i2c.rb
@@ -4,7 +4,7 @@ class I2C
   DEFAULT_FREQUENCY = 100_000 # Hz
   DEFAULT_TIMEOUT = 500 # ms
 
-  def initialize(unit:, frequency: DEFAULT_FREQUENCY, sda_pin: -1, scl_pin: -1, timeout: DEFAULT_TIMEOUT)
+  def initialize(unit: nil, frequency: DEFAULT_FREQUENCY, sda_pin: -1, scl_pin: -1, timeout: DEFAULT_TIMEOUT)
     @timeout = timeout
     @unit_num = _init(unit.to_s, frequency, sda_pin, scl_pin)
   end

--- a/mrbgems/picoruby-i2c/ports/rp2040/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/rp2040/i2c.c
@@ -43,6 +43,73 @@ I2C_unit_name_to_unit_num(const char *unit_name)
   }
 }
 
+/*
+ * RP2040 GPIO function-select table (valid for RP2350 QFN-60 as well).
+ * Each array lists the GPIOs usable as the given I2C signal, terminated by -1.
+ */
+static const int8_t i2c0_sda_pins[] = {0, 4, 8, 12, 16, 20, 24, 28, -1};
+static const int8_t i2c1_sda_pins[] = {2, 6, 10, 14, 18, 22, 26, -1};
+static const int8_t i2c0_scl_pins[] = {1, 5, 9, 13, 17, 21, 25, 29, -1};
+static const int8_t i2c1_scl_pins[] = {3, 7, 11, 15, 19, 23, 27, -1};
+
+/* Return the unit that owns pin for the given signal, or -1 if none. */
+static int
+pin_to_unit(const int8_t *unit0_pins, const int8_t *unit1_pins, int pin)
+{
+  int i = 0;
+  while (unit0_pins[i] != -1) {
+    if (unit0_pins[i] == pin) {
+      return PICORB_I2C_RP2040_I2C0;
+    }
+    i++;
+  }
+  i = 0;
+  while (unit1_pins[i] != -1) {
+    if (unit1_pins[i] == pin) {
+      return PICORB_I2C_RP2040_I2C1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+int
+I2C_unit_num_from_pins(const char *unit_name, int sda_pin, int scl_pin)
+{
+  int candidate = -1;
+  if (0 <= sda_pin) {
+    int u = pin_to_unit(i2c0_sda_pins, i2c1_sda_pins, sda_pin);
+    if (u < 0) {
+      return I2C_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (0 <= scl_pin) {
+    int u = pin_to_unit(i2c0_scl_pins, i2c1_scl_pins, scl_pin);
+    if (u < 0) {
+      return I2C_ERROR_UNIT_MISMATCH;
+    }
+    if (0 <= candidate && candidate != u) {
+      return I2C_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (unit_name && unit_name[0] != '\0') {
+    int name_unit = I2C_unit_name_to_unit_num(unit_name);
+    if (name_unit < 0) {
+      return I2C_ERROR_INVALID_UNIT;
+    }
+    if (0 <= candidate && candidate != name_unit) {
+      return I2C_ERROR_UNIT_MISMATCH;
+    }
+    return name_unit;
+  }
+  if (candidate < 0) {
+    return I2C_ERROR_UNDETERMINED;
+  }
+  return candidate;
+}
+
 i2c_status_t
 I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin)
 {
@@ -51,7 +118,7 @@ I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin)
   i2c_init(unit, frequency);
 
   if (sda_pin < 0) { sda_pin = PICO_DEFAULT_I2C_SDA_PIN; }
-  if (scl_pin < 0) { sda_pin = PICO_DEFAULT_I2C_SCL_PIN; }
+  if (scl_pin < 0) { scl_pin = PICO_DEFAULT_I2C_SCL_PIN; }
   gpio_set_function(sda_pin, GPIO_FUNC_I2C);
   gpio_set_function(scl_pin, GPIO_FUNC_I2C);
   gpio_pull_up(sda_pin);

--- a/mrbgems/picoruby-i2c/sig/i2c.rbs
+++ b/mrbgems/picoruby-i2c/sig/i2c.rbs
@@ -9,7 +9,7 @@ class I2C
   @timeout: Integer
 
   def initialize: (
-    unit: Symbol|nil,
+    ?unit: Symbol|nil,
     ?frequency: Integer,
     ?sda_pin: Integer,
     ?scl_pin: Integer,

--- a/mrbgems/picoruby-i2c/src/i2c.c
+++ b/mrbgems/picoruby-i2c/src/i2c.c
@@ -1,6 +1,18 @@
 #include <string.h>
 #include "../include/i2c.h"
 
+int
+I2C_resolve_unit_num(const char *unit_name, int sda_pin, int scl_pin)
+{
+#if defined(PICORB_PLATFORM_RP2)
+  return I2C_unit_num_from_pins(unit_name, sda_pin, scl_pin);
+#else
+  (void)sda_pin;
+  (void)scl_pin;
+  return I2C_unit_name_to_unit_num(unit_name);
+#endif
+}
+
 #if defined(PICORB_VM_MRUBY)
 
 #include "mruby/i2c.c"

--- a/mrbgems/picoruby-i2c/src/mruby/i2c.c
+++ b/mrbgems/picoruby-i2c/src/mruby/i2c.c
@@ -178,7 +178,14 @@ mrb_i2c__init(mrb_state *mrb, mrb_value self)
   mrb_int frequency, sda_pin, scl_pin;
   mrb_get_args(mrb, "ziii", &unit, &frequency, &sda_pin, &scl_pin);
 
-  int unit_num = I2C_unit_name_to_unit_num(unit);
+  int unit_num = I2C_resolve_unit_num(unit, (int)sda_pin, (int)scl_pin);
+  if (unit_num == I2C_ERROR_UNIT_MISMATCH) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "I2C: pins conflict with unit or are invalid for I2C");
+  } else if (unit_num == I2C_ERROR_UNDETERMINED) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "I2C: cannot determine unit; specify unit or valid pins");
+  } else if (unit_num < 0) {
+    mrb_raise(mrb, IOError, "Invalid I2C unit");
+  }
   i2c_status_t status = I2C_gpio_init(unit_num, (uint32_t)frequency, (uint8_t)sda_pin, (uint8_t)scl_pin);
   if (status < 0) {
     const char *message;

--- a/mrbgems/picoruby-i2c/src/mrubyc/i2c.c
+++ b/mrbgems/picoruby-i2c/src/mrubyc/i2c.c
@@ -180,17 +180,29 @@ c_read(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c__init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  int unit_num = I2C_unit_name_to_unit_num((const char *)GET_STRING_ARG(1));
+  int sda_pin = GET_INT_ARG(3);
+  int scl_pin = GET_INT_ARG(4);
+  int unit_num = I2C_resolve_unit_num((const char *)GET_STRING_ARG(1), sda_pin, scl_pin);
+  if (unit_num == I2C_ERROR_UNIT_MISMATCH) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "I2C: pins conflict with unit or are invalid for I2C");
+    return;
+  } else if (unit_num == I2C_ERROR_UNDETERMINED) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "I2C: cannot determine unit; specify unit or valid pins");
+    return;
+  } else if (unit_num < 0) {
+    mrbc_raise(vm, MRBC_CLASS(IOError), "Invalid I2C unit");
+    return;
+  }
   uint32_t frequency = (uint32_t)GET_INT_ARG(2);
-  i2c_status_t status = I2C_gpio_init(unit_num, frequency, (uint8_t)GET_INT_ARG(3), (uint8_t)GET_INT_ARG(4));
+  i2c_status_t status = I2C_gpio_init(unit_num, frequency, (uint8_t)sda_pin, (uint8_t)scl_pin);
   if (status < 0) {
-    char message[30];
+    const char *message;
     switch (status) {
-      case I2C_ERROR_INVALID_UNIT: { strcpy(message, "Invalid I2C unit"); break; }
-      default: { strcpy(message, "Unknows I2C error"); }
-      mrbc_raise(vm, MRBC_CLASS(IOError), message);
-      return;
+      case I2C_ERROR_INVALID_UNIT: { message = "Invalid I2C unit"; break; }
+      default: { message = "Unknown I2C error"; break; }
     }
+    mrbc_raise(vm, MRBC_CLASS(IOError), message);
+    return;
   }
   SET_INT_RETURN(unit_num);
 }

--- a/mrbgems/picoruby-spi/README.md
+++ b/mrbgems/picoruby-spi/README.md
@@ -16,6 +16,10 @@ spi = SPI.new(
   mode: 0
 )
 
+# On RP2040 the unit can be omitted; it is inferred from the pins
+# (CS is a plain GPIO and does not affect unit selection)
+spi = SPI.new(sck_pin: 2, copi_pin: 3, cipo_pin: 4, cs_pin: 5)  # inferred as :RP2040_SPI0
+
 # Write data
 spi.write(0x01, 0x02, 0x03)
 
@@ -42,7 +46,7 @@ end
 
 ### Methods
 
-- `SPI.new(unit:, frequency: DEFAULT_FREQUENCY, sck_pin:, cipo_pin:, copi_pin:, cs_pin:, mode: 0, first_bit: MSB_FIRST)` - Initialize SPI
+- `SPI.new(unit: nil, frequency: DEFAULT_FREQUENCY, sck_pin:, cipo_pin:, copi_pin:, cs_pin:, mode: 0, first_bit: MSB_FIRST)` - Initialize SPI. On RP2040 `unit:` is optional and inferred from `sck_pin`/`cipo_pin`/`copi_pin` (only the pins you pass are considered; the CS pin is a plain GPIO and is ignored for unit selection). If a given `unit:` disagrees with the pins, or the pins imply different units, or no unit can be determined, an `ArgumentError` is raised. `:BITBANG` is never inferred and must be requested explicitly. On ESP32 `unit:` is still required.
 - `write(*data)` - Write data to SPI
 - `read(length, repeated_tx_data = 0)` - Read data from SPI
 - `transfer(*data, additional_read_bytes: 0)` - Write and read simultaneously
@@ -53,3 +57,4 @@ end
 
 - SPI mode: 0-3 (determines clock polarity and phase)
 - Data can be Integer, String, or Array of Integers
+- On RP2040, `unit:` can be omitted and is inferred from the pins; the CS pin does not participate in unit selection, and `:BITBANG` must be specified explicitly

--- a/mrbgems/picoruby-spi/include/spi.h
+++ b/mrbgems/picoruby-spi/include/spi.h
@@ -30,6 +30,8 @@ typedef enum {
   SPI_ERROR_NOT_IMPLEMENTED   = -4,
   SPI_ERROR_FAILED_TO_INIT    = -5,
   SPI_ERROR_FAILED_TO_ADD_DEV = -6,
+  SPI_ERROR_UNIT_MISMATCH     = -7,
+  SPI_ERROR_UNDETERMINED      = -8,
 } spi_status_t;
 
 typedef struct spi_unit_info {
@@ -47,6 +49,15 @@ typedef struct spi_unit_info {
 #define MAX_STACK_BUFFER_SIZE 256
 
 int SPI_unit_name_to_unit_num(const char *);
+/*
+ * Resolve the unit number from the unit name and the SCK/CIPO/COPI pins.
+ * On RP2 the unit can be inferred from the pins when the name is empty, and a
+ * mismatch between name and pins (or between pins) yields a negative error code.
+ * The CS pin is a plain GPIO and is not considered. On other platforms this
+ * falls back to the name-based lookup (with the BITBANG special case preserved).
+ */
+int SPI_resolve_unit_num(const char *unit_name, int sck_pin, int cipo_pin, int copi_pin);
+int SPI_unit_num_from_pins(const char *unit_name, int sck_pin, int cipo_pin, int copi_pin);
 spi_status_t SPI_gpio_init(spi_unit_info_t*);
 int SPI_read_blocking(spi_unit_info_t*, uint8_t*, size_t, uint8_t);
 int SPI_write_blocking(spi_unit_info_t*, uint8_t*, size_t);

--- a/mrbgems/picoruby-spi/mrblib/spi.rb
+++ b/mrbgems/picoruby-spi/mrblib/spi.rb
@@ -8,7 +8,7 @@ class SPI
 
   attr_accessor :unit, :cs
 
-  def self.new(unit:, frequency: DEFAULT_FREQUENCY, sck_pin: -1, cipo_pin: -1, copi_pin: -1, cs_pin: -1, mode: 0, first_bit: MSB_FIRST)
+  def self.new(unit: nil, frequency: DEFAULT_FREQUENCY, sck_pin: -1, cipo_pin: -1, copi_pin: -1, cs_pin: -1, mode: 0, first_bit: MSB_FIRST)
     spi = self.init(
       unit.to_s,
       frequency,

--- a/mrbgems/picoruby-spi/ports/rp2040/spi.c
+++ b/mrbgems/picoruby-spi/ports/rp2040/spi.c
@@ -96,6 +96,89 @@ SPI_unit_name_to_unit_num(const char *unit_name)
   }
 }
 
+/*
+ * RP2040 GPIO function-select table (valid for RP2350 QFN-60 as well).
+ * Each array lists the GPIOs usable as the given SPI signal, terminated by -1.
+ * CS is intentionally omitted: it is driven as a plain GPIO.
+ */
+static const int8_t spi0_sck_pins[]  = {2, 6, 18, 22, -1};
+static const int8_t spi1_sck_pins[]  = {10, 14, 26, -1};
+static const int8_t spi0_cipo_pins[] = {0, 4, 16, 20, -1};
+static const int8_t spi1_cipo_pins[] = {8, 12, 24, 28, -1};
+static const int8_t spi0_copi_pins[] = {3, 7, 19, 23, -1};
+static const int8_t spi1_copi_pins[] = {11, 15, 27, -1};
+
+/* Return the unit that owns pin for the given signal, or -1 if none. */
+static int
+pin_to_unit(const int8_t *spi0_pins, const int8_t *spi1_pins, int pin)
+{
+  int i = 0;
+  while (spi0_pins[i] != -1) {
+    if (spi0_pins[i] == pin) {
+      return PICORB_SPI_RP2040_SPI0;
+    }
+    i++;
+  }
+  i = 0;
+  while (spi1_pins[i] != -1) {
+    if (spi1_pins[i] == pin) {
+      return PICORB_SPI_RP2040_SPI1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+int
+SPI_unit_num_from_pins(const char *unit_name, int sck_pin, int cipo_pin, int copi_pin)
+{
+  if (unit_name && strcmp(unit_name, "BITBANG") == 0) {
+    return PICORB_SPI_BITBANG;
+  }
+  int candidate = -1;
+  if (0 <= sck_pin) {
+    int u = pin_to_unit(spi0_sck_pins, spi1_sck_pins, sck_pin);
+    if (u < 0) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (0 <= cipo_pin) {
+    int u = pin_to_unit(spi0_cipo_pins, spi1_cipo_pins, cipo_pin);
+    if (u < 0) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    if (0 <= candidate && candidate != u) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (0 <= copi_pin) {
+    int u = pin_to_unit(spi0_copi_pins, spi1_copi_pins, copi_pin);
+    if (u < 0) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    if (0 <= candidate && candidate != u) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (unit_name && unit_name[0] != '\0') {
+    int name_unit = SPI_unit_name_to_unit_num(unit_name);
+    if (name_unit < 0) {
+      return SPI_ERROR_INVALID_UNIT;
+    }
+    if (0 <= candidate && candidate != name_unit) {
+      return SPI_ERROR_UNIT_MISMATCH;
+    }
+    return name_unit;
+  }
+  if (candidate < 0) {
+    return SPI_ERROR_UNDETERMINED;
+  }
+  return candidate;
+}
+
 spi_status_t
 SPI_gpio_init(spi_unit_info_t *unit_info)
 {

--- a/mrbgems/picoruby-spi/sig/spi.rbs
+++ b/mrbgems/picoruby-spi/sig/spi.rbs
@@ -19,7 +19,7 @@ class SPI
   def cs_pin: () -> Integer
 
   def self.new: (
-    unit: Symbol | String,
+    ?unit: Symbol | String | nil,
     ?frequency: Integer,
     ?sck_pin: Integer,
     ?cipo_pin: Integer,

--- a/mrbgems/picoruby-spi/src/mruby/spi.c
+++ b/mrbgems/picoruby-spi/src/mruby/spi.c
@@ -234,14 +234,15 @@ mrb_cs_pin(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_s_init(mrb_state *mrb, mrb_value klass)
 {
-  int unit_num = PICORB_SPI_BITBANG;
   const char *unit_name;
   mrb_int frequency, sck_pin, cipo_pin, copi_pin, cs_pin, mode, first_bit, data_bits;
   mrb_get_args(mrb, "ziiiiiiii", &unit_name, &frequency, &sck_pin, &cipo_pin, &copi_pin, &cs_pin, &mode, &first_bit, &data_bits);
-  if (strcmp(unit_name, "BITBANG") != 0) {
-    unit_num = SPI_unit_name_to_unit_num(unit_name);
-  }
-  if (unit_num < 0) {
+  int unit_num = SPI_resolve_unit_num(unit_name, (int)sck_pin, (int)cipo_pin, (int)copi_pin);
+  if (unit_num == SPI_ERROR_UNIT_MISMATCH) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "SPI: pins conflict with unit or are invalid for SPI");
+  } else if (unit_num == SPI_ERROR_UNDETERMINED) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "SPI: cannot determine unit; specify unit or valid pins");
+  } else if (unit_num < 0) {
     struct RClass *IOError = mrb_exc_get_id(mrb, MRB_SYM(IOError));
     mrb_raise(mrb, IOError, "Invalid SPI unit name");
   }

--- a/mrbgems/picoruby-spi/src/mrubyc/spi.c
+++ b/mrbgems/picoruby-spi/src/mrubyc/spi.c
@@ -226,9 +226,19 @@ c_cs_pin(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c_s_init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  int unit_num = PICORB_SPI_BITBANG;
-  if (strcmp((const char *)GET_STRING_ARG(1), "BITBANG") != 0) {
-    unit_num = SPI_unit_name_to_unit_num((const char *)GET_STRING_ARG(1));
+  int sck_pin  = GET_INT_ARG(3);
+  int cipo_pin = GET_INT_ARG(4);
+  int copi_pin = GET_INT_ARG(5);
+  int unit_num = SPI_resolve_unit_num((const char *)GET_STRING_ARG(1), sck_pin, cipo_pin, copi_pin);
+  if (unit_num == SPI_ERROR_UNIT_MISMATCH) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "SPI: pins conflict with unit or are invalid for SPI");
+    return;
+  } else if (unit_num == SPI_ERROR_UNDETERMINED) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "SPI: cannot determine unit; specify unit or valid pins");
+    return;
+  } else if (unit_num < 0) {
+    mrbc_raise(vm, MRBC_CLASS(IOError), "Invalid SPI unit name");
+    return;
   }
   mrbc_value self = mrbc_instance_new(vm, v->cls, sizeof(spi_unit_info_t));
   spi_unit_info_t *unit_info = (spi_unit_info_t *)self.instance->data;

--- a/mrbgems/picoruby-spi/src/spi.c
+++ b/mrbgems/picoruby-spi/src/spi.c
@@ -1,6 +1,22 @@
 #include <string.h>
 #include "../include/spi.h"
 
+int
+SPI_resolve_unit_num(const char *unit_name, int sck_pin, int cipo_pin, int copi_pin)
+{
+#if defined(PICORB_PLATFORM_RP2)
+  return SPI_unit_num_from_pins(unit_name, sck_pin, cipo_pin, copi_pin);
+#else
+  (void)sck_pin;
+  (void)cipo_pin;
+  (void)copi_pin;
+  if (strcmp(unit_name, "BITBANG") == 0) {
+    return PICORB_SPI_BITBANG;
+  }
+  return SPI_unit_name_to_unit_num(unit_name);
+#endif
+}
+
 #if defined(PICORB_VM_MRUBY)
 
 #include "mruby/spi.c"

--- a/mrbgems/picoruby-uart/README.md
+++ b/mrbgems/picoruby-uart/README.md
@@ -17,6 +17,9 @@ uart = UART.new(
 uart.write("Hello, World!\n")
 uart.puts("Hello")  # Adds line ending
 
+# On RP2040 the unit can be omitted; it is inferred from the pins
+uart = UART.new(txd_pin: 4, rxd_pin: 5)  # inferred as :RP2040_UART1
+
 # Read data
 data = uart.read(10)  # Read up to 10 bytes
 data = uart.read      # Read all available data
@@ -49,7 +52,7 @@ uart.clear_tx_buffer
 
 ### Methods
 
-- `UART.new(unit:, txd_pin:, rxd_pin:, baudrate: 115200, data_bits: 8, stop_bits: 1, parity: PARITY_NONE, flow_control: FLOW_CONTROL_NONE, rx_buffer_size: nil)` - Initialize UART
+- `UART.new(unit: nil, txd_pin:, rxd_pin:, baudrate: 115200, data_bits: 8, stop_bits: 1, parity: PARITY_NONE, flow_control: FLOW_CONTROL_NONE, rx_buffer_size: nil)` - Initialize UART. On RP2040 `unit:` is optional and inferred from `txd_pin`/`rxd_pin` (only the pins you pass are considered, so RX-only or TX-only setups work). If a given `unit:` disagrees with the pins, or the pins imply different units, or no unit can be determined, an `ArgumentError` is raised. On ESP32 `unit:` is still required.
 - `write(string)` - Write string to TX
 - `putc(ch)` - Write the low 8 bits of an Integer or the first character of a String
 - `puts(string)` - Write string with line ending

--- a/mrbgems/picoruby-uart/include/uart.h
+++ b/mrbgems/picoruby-uart/include/uart.h
@@ -24,6 +24,8 @@ extern "C" {
 typedef enum {
  UART_ERROR_NONE          =  0,
  UART_ERROR_INVALID_UNIT  = -1,
+ UART_ERROR_UNIT_MISMATCH = -2,
+ UART_ERROR_UNDETERMINED  = -3,
 } uart_status_t;
 
 typedef void (*PushBuffer)(RingBuffer *ring_buffer, uint8_t ch);
@@ -38,6 +40,14 @@ bool UART_lastReadTimestamp(RingBuffer *ring_buffer, uint64_t *timestamp_us);
 uint32_t UART_rxOverflowCount(RingBuffer *ring_buffer);
 
 int UART_unit_name_to_unit_num(const char *unit_name);
+/*
+ * Resolve the unit number from the given unit name and pins.
+ * On RP2 the unit can be inferred from the pins when unit_name is empty, and a
+ * mismatch between unit_name and pins (or between pins) yields a negative error
+ * code. On other platforms this falls back to UART_unit_name_to_unit_num().
+ */
+int UART_resolve_unit_num(const char *unit_name, int txd_pin, int rxd_pin);
+int UART_unit_num_from_pins(const char *unit_name, int txd_pin, int rxd_pin);
 void UART_init(int unit_num, uint32_t txd_pin, uint32_t rxd_pin, RingBuffer *ring_buffer);
 uint32_t UART_set_baudrate(int unit_num, uint32_t baudrate);
 void UART_set_flow_control(int unit_num, bool cts, bool rts);

--- a/mrbgems/picoruby-uart/mrblib/uart.rb
+++ b/mrbgems/picoruby-uart/mrblib/uart.rb
@@ -2,7 +2,7 @@ require "gpio"
 
 class UART
   def initialize(
-        unit:,
+        unit: nil,
         txd_pin: -1,
         rxd_pin: -1,
         baudrate: 9600,

--- a/mrbgems/picoruby-uart/ports/rp2040/uart.c
+++ b/mrbgems/picoruby-uart/ports/rp2040/uart.c
@@ -48,6 +48,73 @@ UART_unit_name_to_unit_num(const char *name)
   }
 }
 
+/*
+ * RP2040 GPIO function-select table (valid for RP2350 QFN-60 as well).
+ * Each array lists the GPIOs usable as the given UART signal, terminated by -1.
+ */
+static const int8_t uart0_tx_pins[] = {0, 12, 16, 28, -1};
+static const int8_t uart1_tx_pins[] = {4, 8, 20, 24, -1};
+static const int8_t uart0_rx_pins[] = {1, 13, 17, 29, -1};
+static const int8_t uart1_rx_pins[] = {5, 9, 21, 25, -1};
+
+/* Return the unit that owns pin for the given signal, or -1 if none. */
+static int
+pin_to_unit(const int8_t *unit0_pins, const int8_t *unit1_pins, int pin)
+{
+  int i = 0;
+  while (unit0_pins[i] != -1) {
+    if (unit0_pins[i] == pin) {
+      return PICORB_UART_RP2040_UART0;
+    }
+    i++;
+  }
+  i = 0;
+  while (unit1_pins[i] != -1) {
+    if (unit1_pins[i] == pin) {
+      return PICORB_UART_RP2040_UART1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+int
+UART_unit_num_from_pins(const char *unit_name, int txd_pin, int rxd_pin)
+{
+  int candidate = -1;
+  if (0 <= txd_pin) {
+    int u = pin_to_unit(uart0_tx_pins, uart1_tx_pins, txd_pin);
+    if (u < 0) {
+      return UART_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (0 <= rxd_pin) {
+    int u = pin_to_unit(uart0_rx_pins, uart1_rx_pins, rxd_pin);
+    if (u < 0) {
+      return UART_ERROR_UNIT_MISMATCH;
+    }
+    if (0 <= candidate && candidate != u) {
+      return UART_ERROR_UNIT_MISMATCH;
+    }
+    candidate = u;
+  }
+  if (unit_name && unit_name[0] != '\0') {
+    int name_unit = UART_unit_name_to_unit_num(unit_name);
+    if (name_unit < 0) {
+      return UART_ERROR_INVALID_UNIT;
+    }
+    if (0 <= candidate && candidate != name_unit) {
+      return UART_ERROR_UNIT_MISMATCH;
+    }
+    return name_unit;
+  }
+  if (candidate < 0) {
+    return UART_ERROR_UNDETERMINED;
+  }
+  return candidate;
+}
+
 void
 UART_init(int unit_num, uint32_t txd_pin, uint32_t rxd_pin, RingBuffer *ring_buffer)
 {

--- a/mrbgems/picoruby-uart/sig/uart.rbs
+++ b/mrbgems/picoruby-uart/sig/uart.rbs
@@ -21,7 +21,7 @@ class UART
   attr_reader baudrate: Integer
 
   def initialize: (
-    unit: unit_t,
+    ?unit: unit_t?,
     ?txd_pin: Integer,
     ?rxd_pin: Integer,
     ?baudrate: Integer,

--- a/mrbgems/picoruby-uart/src/mruby/uart.c
+++ b/mrbgems/picoruby-uart/src/mruby/uart.c
@@ -55,7 +55,15 @@ mrb_open_connection(mrb_state *mrb, mrb_value self)
   mrb_value rx_buffer;
   mrb_get_args(mrb, "ziio", &unit_name, &txd_pin, &rxd_pin, &rx_buffer);
   (void)rx_buffer; // for compatibility with mruby/c
-  int unit_num = UART_unit_name_to_unit_num(unit_name);
+  int unit_num = UART_resolve_unit_num(unit_name, (int)txd_pin, (int)rxd_pin);
+  if (unit_num == UART_ERROR_UNIT_MISMATCH) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "UART: pins conflict with unit or are invalid for UART");
+  } else if (unit_num == UART_ERROR_UNDETERMINED) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "UART: cannot determine unit; specify unit or valid pins");
+  } else if (unit_num < 0) {
+    struct RClass *IOError = mrb_exc_get_id(mrb, MRB_SYM(IOError));
+    mrb_raise(mrb, IOError, "UART: invalid unit name");
+  }
   RingBuffer *rx = (RingBuffer *)mrb_data_get_ptr(mrb, self, &mrb_uart_rx_buffer_type);
   UART_init(unit_num, txd_pin, rxd_pin, rx);
   return mrb_fixnum_value(unit_num);

--- a/mrbgems/picoruby-uart/src/mrubyc/uart.c
+++ b/mrbgems/picoruby-uart/src/mrubyc/uart.c
@@ -37,9 +37,21 @@ c_open_rx_buffer(mrbc_vm *vm, mrbc_value v[], int argc)
 static void
 c_open_connection(mrbc_vm *vm, mrbc_value v[], int argc)
 {
-  int unit_num = UART_unit_name_to_unit_num((const char *)GET_STRING_ARG(1));
+  int txd_pin = GET_INT_ARG(2);
+  int rxd_pin = GET_INT_ARG(3);
+  int unit_num = UART_resolve_unit_num((const char *)GET_STRING_ARG(1), txd_pin, rxd_pin);
+  if (unit_num == UART_ERROR_UNIT_MISMATCH) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "UART: pins conflict with unit or are invalid for UART");
+    return;
+  } else if (unit_num == UART_ERROR_UNDETERMINED) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "UART: cannot determine unit; specify unit or valid pins");
+    return;
+  } else if (unit_num < 0) {
+    mrbc_raise(vm, MRBC_CLASS(IOError), "UART: invalid unit name");
+    return;
+  }
   RingBuffer *rx = (RingBuffer *)v[4].instance->data;
-  UART_init(unit_num, GET_INT_ARG(2), GET_INT_ARG(3), rx);
+  UART_init(unit_num, txd_pin, rxd_pin, rx);
   SET_INT_RETURN(unit_num);
 }
 

--- a/mrbgems/picoruby-uart/src/uart.c
+++ b/mrbgems/picoruby-uart/src/uart.c
@@ -138,6 +138,18 @@ UART_rxOverflowCount(RingBuffer *ring_buffer)
   return rx_metadata(ring_buffer)->overflow_count;
 }
 
+int
+UART_resolve_unit_num(const char *unit_name, int txd_pin, int rxd_pin)
+{
+#if defined(PICORB_PLATFORM_RP2)
+  return UART_unit_num_from_pins(unit_name, txd_pin, rxd_pin);
+#else
+  (void)txd_pin;
+  (void)rxd_pin;
+  return UART_unit_name_to_unit_num(unit_name);
+#endif
+}
+
 #if defined(PICORB_VM_MRUBY)
 
 #include "mruby/uart.c"

--- a/tasks/picoruby/test.rake
+++ b/tasks/picoruby/test.rake
@@ -158,6 +158,14 @@ def configure_test_collection_build(conf, vm_type)
   conf.cc.defines << "PICORB_PLATFORM_POSIX"
   if vm_type == 'femtoruby'
     conf.cc.defines << "PICORB_VM_MRUBYC"
+    # Real FemtoRuby builds define PICORB_INT64, which lib/picoruby/build.rb
+    # (the #femtoruby helper) translates to MRBC_INT64 (64-bit mrbc_int_t).
+    # This build does not go through that helper, so define MRBC_INT64
+    # directly to keep the test VM's integer width in sync with production.
+    # Without it, mrbc_int_t defaults to 32-bit and microsecond timestamps
+    # (e.g. UART#last_read_timestamp_us) overflow to negative after ~35 min uptime.
+    conf.cc.defines << "PICORB_INT64"
+    conf.cc.defines << "MRBC_INT64"
   else
     conf.cc.defines << "PICORB_VM_MRUBY"
   end


### PR DESCRIPTION
This pull request introduces a significant improvement to the I2C, SPI, and UART libraries for PicoRuby: on the RP2040 platform, the hardware unit can now be automatically inferred from the selected pins, making initialization simpler and less error-prone. The changes include robust error handling for mismatches or ambiguous pin selections, and documentation has been updated to reflect the new behavior. On other platforms (e.g., ESP32), the `unit:` parameter remains required.

### API and Usability Improvements

* On RP2040, the `unit:` parameter for `I2C.new`, `SPI.new`, and `UART.new` is now optional and, if omitted, will be inferred from the provided pins. The documentation in the respective `README.md` files for `picoruby-i2c`, `picoruby-spi`, and `picoruby-uart` has been updated to explain this behavior and provide usage examples. [[1]](diffhunk://#diff-6b969a789c6645b18f803c4c78477f81911ba13535e405459938e32187290aebR11-R13) [[2]](diffhunk://#diff-c0d1d1fc9b0ffe8f92c2d4d1d40b56eedebe92fd3ef693c6ddfba9c5cd057560R19-R22) [[3]](diffhunk://#diff-f5cef039e2d13833a6b8fdc2a71bb56c6f3e40f125d235ae3285cdfa4aa89d15R20-R22) [[4]](diffhunk://#diff-6b969a789c6645b18f803c4c78477f81911ba13535e405459938e32187290aebL33-R36) [[5]](diffhunk://#diff-c0d1d1fc9b0ffe8f92c2d4d1d40b56eedebe92fd3ef693c6ddfba9c5cd057560L45-R49) [[6]](diffhunk://#diff-c0d1d1fc9b0ffe8f92c2d4d1d40b56eedebe92fd3ef693c6ddfba9c5cd057560R60) [[7]](diffhunk://#diff-f5cef039e2d13833a6b8fdc2a71bb56c6f3e40f125d235ae3285cdfa4aa89d15L52-R55)

* The Ruby and RBS signatures for `I2C` and `SPI` constructors have been updated to make `unit:` optional and default to `nil`. [[1]](diffhunk://#diff-6020b1130f77d3eca6f41565ba159dcfe20cd849787a9ac663d10313c302e734L7-R7) [[2]](diffhunk://#diff-70d39426cd81fb9b640438a478d8de2f051b680ccdd5bc224c5e2cf7242ec6a2L11-R11) [[3]](diffhunk://#diff-63694a38fae849e9750e3bdf0f717d3898f6396b67198b028866f0845505e896L12-R12) [[4]](diffhunk://#diff-db004941606e7b8c44f9db774d7aa2faafb8971d1f07dd5ecfb24303f8b315a4L22-R22)

### Core Logic and Error Handling

* New logic in C for both I2C and SPI on RP2040 infers the hardware unit from the pins, with clear error codes for mismatched or undetermined units. If the pins do not match a valid unit, or a specified unit conflicts with the pins, an `ArgumentError` is raised. [[1]](diffhunk://#diff-cc499a5a053002d8012cb458a64e022ec392cedbb9dbdf87d725483f6a814fd9R46-R112) [[2]](diffhunk://#diff-cc499a5a053002d8012cb458a64e022ec392cedbb9dbdf87d725483f6a814fd9L54-R121) [[3]](diffhunk://#diff-e7ed6671676579936abf1cdb6b86f4040e5cf6e6b06453c007d3da70231fea86R17-R29) [[4]](diffhunk://#diff-bcdb11598b5e7998efda0bb37fd8fc994246449e496b642e82e3d4daa2076d52R4-R15) [[5]](diffhunk://#diff-4733ed130b3bf3f0c7b0e74dea576601da240a53552d36230f7f6b4e071797d7R33-R34) [[6]](diffhunk://#diff-4733ed130b3bf3f0c7b0e74dea576601da240a53552d36230f7f6b4e071797d7R52-R60) [[7]](diffhunk://#diff-126844cf6c2d5ff92cbece2b184bc8f1346c0d18dbe836519fe036e2fc3f7ef1R99-R181) [[8]](diffhunk://#diff-90f77207f96925711dde163f82b34b38a7fbd59d0fa8fd7a552198e3e59bb847R4-R19)

* The MRuby and MRuby/C bindings for I2C and SPI have been updated to use the new unit resolution logic and raise appropriate Ruby exceptions for invalid configurations. [[1]](diffhunk://#diff-f0fdaec7306ff704b1acb50cb8823af6a47b80e88cdd0461d1206fb04afcf443L181-R188) [[2]](diffhunk://#diff-27563c5f01da99c9502edc6e8cdbc638912d0114ad877426b1e77caeaad5385cL183-L194) [[3]](diffhunk://#diff-b14f529c9576dda81845da78ae7743a8393c8e53ab74b2e0181e21bb8be66993L237-R245) [[4]](diffhunk://#diff-a3614d3798461fd555b0178d57713899d57b04e85bd12e7e3fa055155e4d183eL229-R241)

These changes make the APIs more user-friendly and robust, especially for RP2040 users, by reducing boilerplate and preventing common configuration errors.