### PR TITLE
Task::Queue#push in Callbacks

### DIFF
--- a/mrbgems/picoruby-ble-hid/mrblib/ble_hid.rb
+++ b/mrbgems/picoruby-ble-hid/mrblib/ble_hid.rb
@@ -254,10 +254,12 @@ class BLE
       @user_block = block
       total_timeout_ms = 0
       @event_queue.clear
+      _event_queue_cleared
       hci_power_control(HCI_POWER_ON)
       while true
         break if timeout_ms && timeout_ms <= total_timeout_ms
         event = @event_queue.pop(timeout_ms: 1)
+        _event_popped if event
         if event.is_a?(String)
           packet_callback(event)
         elsif event

--- a/mrbgems/picoruby-ble-hid/mrblib/ble_hid.rb
+++ b/mrbgems/picoruby-ble-hid/mrblib/ble_hid.rb
@@ -249,18 +249,20 @@ class BLE
 
     # --- BLE lifecycle ---
 
-    # Override BLE#start with 1ms polling for keyboard responsiveness.
-    # The block is called on every iteration (not just on heartbeat).
+    # Keep the 1ms user-block cadence needed for keyboard responsiveness.
     def start(timeout_ms = nil, &block)
       @user_block = block
       total_timeout_ms = 0
+      @event_queue.clear
       hci_power_control(HCI_POWER_ON)
       while true
         break if timeout_ms && timeout_ms <= total_timeout_ms
-        while (packet = pop_packet)
-          packet_callback(packet)
+        event = @event_queue.pop(timeout_ms: 1)
+        if event.is_a?(String)
+          packet_callback(event)
+        elsif event
+          heartbeat_callback
         end
-        heartbeat_callback if pop_heartbeat
         @user_block&.call
         sleep_ms(1)
         total_timeout_ms += 1

--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -113,6 +113,7 @@ class BLE
       started_at = Machine.board_millis
       total_timeout_ms = 0
       @event_queue.clear
+      _event_queue_cleared
       hci_power_control(HCI_POWER_ON)
       while true
         total_timeout_ms = Machine.board_millis - started_at
@@ -123,6 +124,7 @@ class BLE
           wait_ms = remaining_ms if remaining_ms < wait_ms
         end
         event = @event_queue.pop(timeout_ms: wait_ms)
+        _event_popped if event
         if event.is_a?(String)
           packet_callback(event)
         elsif event

--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -38,7 +38,7 @@ class BLE
 
     DEFAULT_ATT_MTU = 23 # BLE 4.0 minimum; payload = MTU - 3 for notifications
 
-    USER_BLOCK_CALL_COUNT_PER_POLL = 5
+    USER_BLOCK_INTERVAL_MS = 20
 
     def initialize(role: :peripheral,
                    name: "RubyUART",
@@ -110,14 +110,22 @@ class BLE
 
     def start(timeout_ms = nil, &block)
       @user_block = block
+      started_at = Machine.board_millis
       total_timeout_ms = 0
+      @event_queue.clear
       hci_power_control(HCI_POWER_ON)
       while true
+        total_timeout_ms = Machine.board_millis - started_at
         break if timeout_ms && timeout_ms <= total_timeout_ms
-        while (packet = pop_packet)
-          packet_callback(packet)
+        wait_ms = USER_BLOCK_INTERVAL_MS
+        if timeout_ms
+          remaining_ms = timeout_ms - total_timeout_ms
+          wait_ms = remaining_ms if remaining_ms < wait_ms
         end
-        while pop_heartbeat
+        event = @event_queue.pop(timeout_ms: wait_ms)
+        if event.is_a?(String)
+          packet_callback(event)
+        elsif event
           heartbeat_callback
         end
         if peripheral?
@@ -126,15 +134,9 @@ class BLE
         else
           _flush_tx_central if @connected
         end
-        sub_sleep_ms = POLLING_UNIT_MS / USER_BLOCK_CALL_COUNT_PER_POLL
-        i = 0
-        while i < USER_BLOCK_CALL_COUNT_PER_POLL do
-          i += 1
-          @user_block&.call
-          sleep_ms sub_sleep_ms
-        end
-        total_timeout_ms += POLLING_UNIT_MS
+        @user_block&.call
       end
+      total_timeout_ms = Machine.board_millis - started_at
       return total_timeout_ms
     ensure
       hci_power_control(HCI_POWER_OFF)

--- a/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
@@ -27,7 +27,7 @@ class BLE
 
     DEFAULT_ATT_MTU: Integer
 
-    USER_BLOCK_CALL_COUNT_PER_POLL: Integer
+    USER_BLOCK_INTERVAL_MS: Integer
 
     # peripheral-only state
     @adv_data: String

--- a/mrbgems/picoruby-ble/mrbgem.rake
+++ b/mrbgems/picoruby-ble/mrbgem.rake
@@ -4,6 +4,6 @@ MRuby::Gem::Specification.new('picoruby-ble') do |spec|
   spec.summary = 'BLE class'
   spec.add_dependency 'picoruby-cyw43'
   spec.add_dependency 'picoruby-mbedtls'
+  spec.add_dependency 'mruby-task'
 end
-
 

--- a/mrbgems/picoruby-ble/mrbgem.rake
+++ b/mrbgems/picoruby-ble/mrbgem.rake
@@ -4,6 +4,5 @@ MRuby::Gem::Specification.new('picoruby-ble') do |spec|
   spec.summary = 'BLE class'
   spec.add_dependency 'picoruby-cyw43'
   spec.add_dependency 'picoruby-mbedtls'
-  spec.add_dependency 'mruby-task'
+  spec.add_dependency 'mruby-task' if build.picoruby?
 end
-

--- a/mrbgems/picoruby-ble/mrblib/ble.rb
+++ b/mrbgems/picoruby-ble/mrblib/ble.rb
@@ -124,6 +124,7 @@ class BLE
     started_at = Machine.board_millis
     total_timeout_ms = 0
     @event_queue.clear
+    _event_queue_cleared
     hci_power_control(HCI_POWER_ON)
     while true
       total_timeout_ms = Machine.board_millis - started_at
@@ -134,6 +135,7 @@ class BLE
       end
       wait_ms = timeout_ms ? timeout_ms - total_timeout_ms : nil
       event = @event_queue.pop(timeout_ms: wait_ms)
+      _event_popped if event
       if event.is_a?(String)
         packet_callback(event)
       elsif event

--- a/mrbgems/picoruby-ble/mrblib/ble.rb
+++ b/mrbgems/picoruby-ble/mrblib/ble.rb
@@ -78,6 +78,7 @@ class BLE
   def initialize(role, profile_data = nil)
     @role = role
     @debug = false
+    @event_queue = Task::Queue.new
     unless CYW43.init
       puts "Failed to initialize CYW43"
       return # raising an exception here may cause a crash
@@ -114,28 +115,32 @@ class BLE
     @led&.write(@led&.low? ? 1 : 0)
   end
 
-  POLLING_UNIT_MS = 100
-
   def start(timeout_ms = nil, stop_state = :no_stop)
     if timeout_ms
       debug_puts "Starting for #{timeout_ms} ms"
     else
       debug_puts "Starting with infinite loop. Ctrl-C for stop"
     end
+    started_at = Machine.board_millis
     total_timeout_ms = 0
+    @event_queue.clear
     hci_power_control(HCI_POWER_ON)
     while true
+      total_timeout_ms = Machine.board_millis - started_at
       break if timeout_ms && timeout_ms <= total_timeout_ms
       if @state == stop_state
         puts "Stopped by state: #{stop_state}"
         break
       end
-      packet = pop_packet
-      packet_callback(packet) if packet
-      heartbeat_callback if pop_heartbeat
-      sleep_ms POLLING_UNIT_MS
-      total_timeout_ms += POLLING_UNIT_MS
+      wait_ms = timeout_ms ? timeout_ms - total_timeout_ms : nil
+      event = @event_queue.pop(timeout_ms: wait_ms)
+      if event.is_a?(String)
+        packet_callback(event)
+      elsif event
+        heartbeat_callback
+      end
     end
+    total_timeout_ms = Machine.board_millis - started_at
     return total_timeout_ms
   ensure
     hci_power_control(HCI_POWER_OFF)
@@ -149,4 +154,3 @@ class BLE
   end
 
 end
-

--- a/mrbgems/picoruby-ble/sig/ble.rbs
+++ b/mrbgems/picoruby-ble/sig/ble.rbs
@@ -75,7 +75,9 @@ class BLE
 
   def initialize: (role_t role, ?(String|nil) profile_data) -> void
   def ensure: () { () -> void }-> void
-  def _init: (String | nil) -> void
+  private def _init: (String | nil) -> void
+  private def _event_popped: () -> nil
+  private def _event_queue_cleared: () -> nil
   def debug_puts: (*untyped) -> nil
   def hci_power_control: (Integer power_mode) -> 0
   def start: (?(Integer | nil) timeout_ms, ?(Symbol | nil)) -> Integer

--- a/mrbgems/picoruby-ble/sig/ble.rbs
+++ b/mrbgems/picoruby-ble/sig/ble.rbs
@@ -64,11 +64,10 @@ class BLE
   ATT_PROPERTY_READ: Integer
   GATT_CHARACTERISTIC_UUID: Integer
 
-  POLLING_UNIT_MS: Integer
-
   @led: CYW43::GPIO | nil
   @led_on: bool
   @ensure_proc: Proc
+  @event_queue: Task::Queue
 
   type role_t = :central | :peripheral | :observer | :broadcaster
   attr_accessor debug: bool
@@ -80,9 +79,7 @@ class BLE
   def debug_puts: (*untyped) -> nil
   def hci_power_control: (Integer power_mode) -> 0
   def start: (?(Integer | nil) timeout_ms, ?(Symbol | nil)) -> Integer
-  def pop_packet: () -> (String | nil)
   def packet_callback: (String) -> void
-  def pop_heartbeat: () -> bool
   def heartbeat_callback: () -> void
   def blink_led: () -> void
   def gap_local_bd_addr: () -> String

--- a/mrbgems/picoruby-ble/src/ble.c
+++ b/mrbgems/picoruby-ble/src/ble.c
@@ -9,13 +9,7 @@
  * Workaround: To avoid deadlock
  * TODO: Maybe we need a critical section instead of these simple mutex
  */
-static bool packet_mutex = false;
 static bool write_values_mutex = false;
-static bool heatbeat_flag = false;
-static bool packet_flag = false;
-
-static uint8_t *packet = NULL;
-static uint16_t packet_size = 0;
 
 #if defined(PICORB_VM_MRUBY)
 

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -110,6 +110,7 @@ mrb__init(mrb_state *mrb, mrb_value self)
 {
   _mrb = mrb;
   event_queue = mrb_iv_get(mrb, self, MRB_IVSYM(event_queue));
+  mrb_gc_register(mrb, event_queue);
   pending_event_count = 0;
   write_values = mrb_hash_new(mrb);
   mrb_gc_register(mrb, write_values);

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -9,21 +9,45 @@ static mrb_state *_mrb = NULL;
 static mrb_value write_values;
 static mrb_value read_values;
 static mrb_value event_queue;
+static uint8_t pending_event_count;
+
+#define BLE_MAX_PENDING_EVENTS 16
 
 void
 BLE_push_event(uint8_t *data, uint16_t size)
 {
-  if (_mrb == NULL || mrb_nil_p(event_queue)) return;
+  if (_mrb == NULL || mrb_nil_p(event_queue) ||
+      BLE_MAX_PENDING_EVENTS <= pending_event_count) return;
   mrb_value event = mrb_str_new(_mrb, (const char *)data, size);
-  (void)mrb_task_queue_push(_mrb, event_queue, event);
+  if (mrb_task_queue_push(_mrb, event_queue, event) == MRB_TASK_QUEUE_PUSH_OK) {
+    pending_event_count++;
+  }
 }
 
 void
 BLE_heartbeat(void)
 {
-  if (_mrb == NULL || mrb_nil_p(event_queue)) return;
+  if (_mrb == NULL || mrb_nil_p(event_queue) ||
+      BLE_MAX_PENDING_EVENTS <= pending_event_count) return;
   mrb_state *mrb = _mrb;
-  (void)mrb_task_queue_push(_mrb, event_queue, mrb_symbol_value(MRB_SYM(heartbeat)));
+  if (mrb_task_queue_push(mrb, event_queue, mrb_symbol_value(MRB_SYM(heartbeat))) ==
+      MRB_TASK_QUEUE_PUSH_OK) {
+    pending_event_count++;
+  }
+}
+
+static mrb_value
+mrb_event_popped(mrb_state *mrb, mrb_value self)
+{
+  if (0 < pending_event_count) pending_event_count--;
+  return mrb_nil_value();
+}
+
+static mrb_value
+mrb_event_queue_cleared(mrb_state *mrb, mrb_value self)
+{
+  pending_event_count = 0;
+  return mrb_nil_value();
 }
 
 int
@@ -86,6 +110,7 @@ mrb__init(mrb_state *mrb, mrb_value self)
 {
   _mrb = mrb;
   event_queue = mrb_iv_get(mrb, self, MRB_IVSYM(event_queue));
+  pending_event_count = 0;
   write_values = mrb_hash_new(mrb);
   mrb_gc_register(mrb, write_values);
   read_values = mrb_hash_new(mrb);
@@ -153,11 +178,13 @@ mrb_picoruby_ble_gem_init(mrb_state* mrb)
 {
   struct RClass *class_BLE = mrb_define_class_id(mrb, MRB_SYM(BLE), mrb->object_class);
 
-  mrb_define_method_id(mrb, class_BLE, MRB_SYM(_init), mrb__init, MRB_ARGS_REQ(1));
+  mrb_define_private_method_id(mrb, class_BLE, MRB_SYM(_init), mrb__init, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(hci_power_control), mrb_hci_power_control, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(gap_local_bd_addr), mrb_gap_local_bd_addr, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(pop_write_value), mrb_pop_write_value, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(push_read_value), mrb_push_read_value, MRB_ARGS_REQ(2));
+  mrb_define_private_method_id(mrb, class_BLE, MRB_SYM(_event_popped), mrb_event_popped, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, class_BLE, MRB_SYM(_event_queue_cleared), mrb_event_queue_cleared, MRB_ARGS_NONE());
   mrb_init_class_BLE_Peripheral(mrb, class_BLE);
   mrb_init_class_BLE_Broadcaster(mrb, class_BLE);
   mrb_init_class_BLE_Central(mrb, class_BLE);

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -3,31 +3,27 @@
 #include "mruby/string.h"
 #include "mruby/hash.h"
 #include "mruby/array.h"
+#include "task.h"
 
 static mrb_state *_mrb = NULL;
 static mrb_value write_values;
 static mrb_value read_values;
+static mrb_value event_queue;
 
 void
 BLE_push_event(uint8_t *data, uint16_t size)
 {
-  if (packet_mutex) return;
-  packet_mutex = true;
-  packet_flag = true;
-  packet_size = size;
-  if (packet != NULL) {
-    mrb_free(_mrb, packet);
-  }
-  packet = mrb_malloc(_mrb, packet_size);
-  memcpy(packet, data, packet_size);
-  packet_mutex = false;
+  if (_mrb == NULL || mrb_nil_p(event_queue)) return;
+  mrb_value event = mrb_str_new(_mrb, (const char *)data, size);
+  (void)mrb_task_queue_push(_mrb, event_queue, event);
 }
 
 void
 BLE_heartbeat(void)
 {
-  if (packet_mutex) return;
-  heatbeat_flag = true;
+  if (_mrb == NULL || mrb_nil_p(event_queue)) return;
+  mrb_state *mrb = _mrb;
+  (void)mrb_task_queue_push(_mrb, event_queue, mrb_symbol_value(MRB_SYM(heartbeat)));
 }
 
 int
@@ -62,30 +58,6 @@ BLE_read_data(BLE_read_value_t *read_value)
 
 
 static mrb_value
-mrb_pop_heartbeat(mrb_state *mrb, mrb_value self)
-{
-  if (heatbeat_flag) {
-    heatbeat_flag = false;
-    return mrb_true_value();
-  }
-  return mrb_false_value();
-}
-
-static mrb_value
-mrb_pop_packet(mrb_state *mrb, mrb_value self)
-{
-  mrb_value packet_value = mrb_nil_value();
-  if (packet_mutex || !packet_flag) return packet_value;
-  packet_mutex = true;
-  packet_flag = false;
-  packet_value = mrb_str_new(mrb, (const char *)packet, packet_size);
-  mrb_free(mrb, packet);
-  packet = NULL;
-  packet_mutex = false;
-  return packet_value;
-}
-
-static mrb_value
 mrb_pop_write_value(mrb_state *mrb, mrb_value self)
 {
   if (write_values_mutex) return mrb_nil_value();
@@ -113,6 +85,7 @@ static mrb_value
 mrb__init(mrb_state *mrb, mrb_value self)
 {
   _mrb = mrb;
+  event_queue = mrb_iv_get(mrb, self, MRB_IVSYM(event_queue));
   write_values = mrb_hash_new(mrb);
   mrb_gc_register(mrb, write_values);
   read_values = mrb_hash_new(mrb);
@@ -185,9 +158,6 @@ mrb_picoruby_ble_gem_init(mrb_state* mrb)
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(gap_local_bd_addr), mrb_gap_local_bd_addr, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(pop_write_value), mrb_pop_write_value, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_BLE, MRB_SYM(push_read_value), mrb_push_read_value, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, class_BLE, MRB_SYM(pop_heartbeat), mrb_pop_heartbeat, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_BLE, MRB_SYM(pop_packet), mrb_pop_packet, MRB_ARGS_NONE());
-
   mrb_init_class_BLE_Peripheral(mrb, class_BLE);
   mrb_init_class_BLE_Broadcaster(mrb, class_BLE);
   mrb_init_class_BLE_Central(mrb, class_BLE);

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -1,5 +1,6 @@
 static mrbc_value write_values = {.tt = MRBC_TT_NIL};
 static mrbc_value read_values = {.tt = MRBC_TT_NIL};
+static mrbc_value event_queue = {.tt = MRBC_TT_NIL};
 
 #define NODE_BOX_SIZE 10
 #define VM_REGS_SIZE 110 // can be reduced?
@@ -7,23 +8,19 @@ static mrbc_value read_values = {.tt = MRBC_TT_NIL};
 void
 BLE_push_event(uint8_t *data, uint16_t size)
 {
-  if (packet_mutex) return;
-  packet_mutex = true;
-  packet_flag = true;
-  packet_size = size;
-  if (packet != NULL) {
-    mrbc_raw_free(packet);
+  if (event_queue.tt == MRBC_TT_NIL) return;
+  mrbc_value event = mrbc_string_new(NULL, (const void *)data, size);
+  if (mrbc_task_queue_push(&event_queue, &event) != MRBC_TASK_QUEUE_PUSH_OK) {
+    mrbc_decref(&event);
   }
-  packet = mrbc_raw_alloc(packet_size);
-  memcpy(packet, data, packet_size);
-  packet_mutex = false;
 }
 
 void
 BLE_heartbeat(void)
 {
-  if (packet_mutex) return;
-  heatbeat_flag = true;
+  if (event_queue.tt == MRBC_TT_NIL) return;
+  mrbc_value event = mrbc_symbol_value(mrbc_str_to_symid("heartbeat"));
+  mrbc_task_queue_push(&event_queue, &event);
 }
 
 int
@@ -60,33 +57,6 @@ BLE_read_data(BLE_read_value_t *read_value)
 
 
 static void
-c_pop_heartbeat(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  if (heatbeat_flag) {
-    heatbeat_flag = false;
-    SET_TRUE_RETURN();
-  } else {
-    SET_FALSE_RETURN();
-  }
-}
-
-static void
-c_pop_packet(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-  if (packet_mutex || !packet_flag) {
-    SET_NIL_RETURN();
-    return;
-  }
-  packet_mutex = true;
-  packet_flag = false;
-  mrb_value packet_value = mrbc_string_new(vm, (const char *)packet, packet_size);
-  mrbc_raw_free(packet);
-  packet = NULL;
-  packet_mutex = false;
-  SET_RETURN(packet_value);
-}
-
-static void
 c_pop_write_value(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   if (write_values_mutex) {
@@ -121,6 +91,8 @@ c_push_read_value(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c__init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
+  if (event_queue.tt != MRBC_TT_NIL) mrbc_decref(&event_queue);
+  event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
   write_values = mrbc_hash_new(vm, 0);
   read_values = mrbc_hash_new(vm, 0);
 
@@ -185,11 +157,7 @@ mrbc_ble_init(mrbc_vm *vm)
   mrbc_define_method(vm, class_BLE, "gap_local_bd_addr", c_gap_local_bd_addr);
   mrbc_define_method(vm, class_BLE, "pop_write_value", c_pop_write_value);
   mrbc_define_method(vm, class_BLE, "push_read_value", c_push_read_value);
-  mrbc_define_method(vm, class_BLE, "pop_heartbeat", c_pop_heartbeat);
-  mrbc_define_method(vm, class_BLE, "pop_packet", c_pop_packet);
-
   mrbc_init_class_BLE_Peripheral(vm, class_BLE);
   mrbc_init_class_BLE_Broadcaster(vm, class_BLE);
   mrbc_init_class_BLE_Central(vm, class_BLE);
 }
-

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -1,6 +1,9 @@
 static mrbc_value write_values = {.tt = MRBC_TT_NIL};
 static mrbc_value read_values = {.tt = MRBC_TT_NIL};
 static mrbc_value event_queue = {.tt = MRBC_TT_NIL};
+static uint8_t pending_event_count;
+
+#define BLE_MAX_PENDING_EVENTS 16
 
 #define NODE_BOX_SIZE 10
 #define VM_REGS_SIZE 110 // can be reduced?
@@ -8,19 +11,38 @@ static mrbc_value event_queue = {.tt = MRBC_TT_NIL};
 void
 BLE_push_event(uint8_t *data, uint16_t size)
 {
-  if (event_queue.tt == MRBC_TT_NIL) return;
+  if (event_queue.tt == MRBC_TT_NIL ||
+      BLE_MAX_PENDING_EVENTS <= pending_event_count) return;
   mrbc_value event = mrbc_string_new(NULL, (const void *)data, size);
-  if (mrbc_task_queue_push(&event_queue, &event) != MRBC_TASK_QUEUE_PUSH_OK) {
-    mrbc_decref(&event);
+  if (mrbc_task_queue_push(&event_queue, &event) == MRBC_TASK_QUEUE_PUSH_OK) {
+    pending_event_count++;
   }
+  mrbc_decref(&event);
 }
 
 void
 BLE_heartbeat(void)
 {
-  if (event_queue.tt == MRBC_TT_NIL) return;
+  if (event_queue.tt == MRBC_TT_NIL ||
+      BLE_MAX_PENDING_EVENTS <= pending_event_count) return;
   mrbc_value event = mrbc_symbol_value(mrbc_str_to_symid("heartbeat"));
-  mrbc_task_queue_push(&event_queue, &event);
+  if (mrbc_task_queue_push(&event_queue, &event) == MRBC_TASK_QUEUE_PUSH_OK) {
+    pending_event_count++;
+  }
+}
+
+static void
+c_event_popped(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (0 < pending_event_count) pending_event_count--;
+  SET_NIL_RETURN();
+}
+
+static void
+c_event_queue_cleared(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  pending_event_count = 0;
+  SET_NIL_RETURN();
 }
 
 int
@@ -93,6 +115,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   if (event_queue.tt != MRBC_TT_NIL) mrbc_decref(&event_queue);
   event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
+  pending_event_count = 0;
   write_values = mrbc_hash_new(vm, 0);
   read_values = mrbc_hash_new(vm, 0);
 
@@ -118,7 +141,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   if (ble_role == BLE_ROLE_PERIPHERAL && GET_TT_ARG(1) == MRBC_TT_STRING) {
     profile_copy = mrbc_string_dup(vm, &v[1]);
-    profile_data = mrbc_string_cstr(&profile_copy);
+    profile_data = (uint8_t *)mrbc_string_cstr(&profile_copy);
   }
   Machine_tud_task();
   if (BLE_init(profile_data, ble_role) < 0) {
@@ -157,6 +180,8 @@ mrbc_ble_init(mrbc_vm *vm)
   mrbc_define_method(vm, class_BLE, "gap_local_bd_addr", c_gap_local_bd_addr);
   mrbc_define_method(vm, class_BLE, "pop_write_value", c_pop_write_value);
   mrbc_define_method(vm, class_BLE, "push_read_value", c_push_read_value);
+  mrbc_define_method(vm, class_BLE, "_event_popped", c_event_popped);
+  mrbc_define_method(vm, class_BLE, "_event_queue_cleared", c_event_queue_cleared);
   mrbc_init_class_BLE_Peripheral(vm, class_BLE);
   mrbc_init_class_BLE_Broadcaster(vm, class_BLE);
   mrbc_init_class_BLE_Central(vm, class_BLE);

--- a/mrbgems/picoruby-env/include/env.h
+++ b/mrbgems/picoruby-env/include/env.h
@@ -4,6 +4,6 @@
 void ENV_get_key_value(char **key, size_t *key_len, char **value, size_t *value_len);
 int ENV_unsetenv(const char *name);
 int ENV_setenv(const char *name, const char *value, int override);
+long ENV_get_timezone_offset(void);
 
 #endif
-

--- a/mrbgems/picoruby-env/ports/nrf52/env.c
+++ b/mrbgems/picoruby-env/ports/nrf52/env.c
@@ -27,3 +27,9 @@ ENV_setenv(const char *name, const char *value, int override)
   (void)override;
   return 0;
 }
+
+long
+ENV_get_timezone_offset(void)
+{
+  return 0;
+}

--- a/mrbgems/picoruby-env/ports/posix/env.c
+++ b/mrbgems/picoruby-env/ports/posix/env.c
@@ -60,3 +60,9 @@ ENV_setenv(const char *name, const char *value, int override)
 #endif
   return setenv(name, value, override);
 }
+
+long
+ENV_get_timezone_offset(void)
+{
+  return 0;
+}

--- a/mrbgems/picoruby-env/ports/rp2040/env.c
+++ b/mrbgems/picoruby-env/ports/rp2040/env.c
@@ -1,3 +1,8 @@
+/*
+ * RP2040 has no process environment.  Keep these operations as NOPs because
+ * newlib's setenv/unsetenv implementation touches the heap, which is unsafe
+ * for the firmware's memory model.
+ */
 #include <stddef.h>
 
 void

--- a/mrbgems/picoruby-env/ports/rp2040/env.c
+++ b/mrbgems/picoruby-env/ports/rp2040/env.c
@@ -1,5 +1,4 @@
 #include <stddef.h>
-#include <stdlib.h>
 
 void
 ENV_get_key_value(char **key, size_t *key_len, char **value, size_t *value_len)
@@ -13,11 +12,15 @@ ENV_get_key_value(char **key, size_t *key_len, char **value, size_t *value_len)
 int
 ENV_unsetenv(const char *name)
 {
-  return unsetenv(name);
+  (void)name;
+  return 0;
 }
 
 int
 ENV_setenv(const char *name, const char *value, int override)
 {
-  return setenv(name, value, override);
+  (void)name;
+  (void)value;
+  (void)override;
+  return 0;
 }

--- a/mrbgems/picoruby-env/ports/rp2040/env.c
+++ b/mrbgems/picoruby-env/ports/rp2040/env.c
@@ -1,9 +1,44 @@
 /*
- * RP2040 has no process environment.  Keep these operations as NOPs because
+ * RP2040 has no process environment.  Keep ordinary variables as NOPs because
  * newlib's setenv/unsetenv implementation touches the heap, which is unsafe
- * for the firmware's memory model.
+ * for the firmware's memory model.  TZ is parsed into a small static offset
+ * because picoruby-time needs it for local time conversion.
  */
 #include <stddef.h>
+#include <ctype.h>
+#include <string.h>
+
+static long timezone_offset;
+
+static int
+parse_timezone_offset(const char *value, long *offset)
+{
+  const char *p = value;
+  int sign = 1;
+  long hours = 0;
+  long minutes = 0;
+
+  while (isalpha((unsigned char)*p)) p++;
+  if (*p == '+' || *p == '-') {
+    sign = *p == '-' ? -1 : 1;
+    p++;
+  }
+  if (!isdigit((unsigned char)*p)) return -1;
+  while (isdigit((unsigned char)*p)) {
+    hours = hours * 10 + (*p++ - '0');
+  }
+  if (*p == ':') {
+    p++;
+    if (!isdigit((unsigned char)p[0]) || !isdigit((unsigned char)p[1])) return -1;
+    minutes = (p[0] - '0') * 10 + p[1] - '0';
+    p += 2;
+  }
+  if (*p != '\0' || minutes >= 60) return -1;
+
+  /* Store the conventional seconds-west offset used by Time. */
+  *offset = sign * (hours * 3600 + minutes * 60);
+  return 0;
+}
 
 void
 ENV_get_key_value(char **key, size_t *key_len, char **value, size_t *value_len)
@@ -17,6 +52,7 @@ ENV_get_key_value(char **key, size_t *key_len, char **value, size_t *value_len)
 int
 ENV_unsetenv(const char *name)
 {
+  if (strcmp(name, "TZ") == 0) timezone_offset = 0;
   (void)name;
   return 0;
 }
@@ -24,8 +60,18 @@ ENV_unsetenv(const char *name)
 int
 ENV_setenv(const char *name, const char *value, int override)
 {
+  long offset;
+  if (strcmp(name, "TZ") == 0 && parse_timezone_offset(value, &offset) == 0) {
+    timezone_offset = offset;
+  }
   (void)name;
   (void)value;
   (void)override;
   return 0;
+}
+
+long
+ENV_get_timezone_offset(void)
+{
+  return timezone_offset;
 }

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -147,15 +147,30 @@ if(NOT R2P2_NO_SHARED_ALLOC)
   )
 endif()
 
-# RP2040: 4KB stack fits in SCRATCH_Y, use SDK default linker script
-# RP2350: 8KB stack needs RAM, use custom linker script
+# RP2040 keeps both stacks in scratch RAM. RP2350 needs more than the combined
+# scratch banks provide for Prism in debug builds, so core 0 uses regular RAM.
 if(PICO_BOARD STREQUAL "pico" OR PICO_BOARD STREQUAL "pico_w")
   set(PICORB_STACK_SIZE 0x1000) # 4KB
   set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB (in SCRATCH_X)
 elseif(PICO_BOARD STREQUAL "pico2" OR PICO_BOARD STREQUAL "pico2_w")
-  set(PICORB_STACK_SIZE 0x2000) # 8KB
-  set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB
-  pico_set_linker_script(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/memmap_rp2350.ld)
+  if(PICORB_DEBUG)
+    set(PICORB_STACK_SIZE 0x6000) # 24KB
+    set(PICORB_RAM_LENGTH_KB 488)
+    set(PICORB_STACK_ORIGIN 0x2007a000)
+    set(PICORB_STACK_LENGTH_KB 24)
+  else()
+    set(PICORB_STACK_SIZE 0x4000) # 16KB
+    set(PICORB_RAM_LENGTH_KB 496)
+    set(PICORB_STACK_ORIGIN 0x2007c000)
+    set(PICORB_STACK_LENGTH_KB 16)
+  endif()
+  set(PICORB_CORE1_STACK_SIZE 0x0800) # 2KB (in SCRATCH_X)
+  configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/memmap_rp2350.ld.in
+    ${CMAKE_CURRENT_BINARY_DIR}/memmap_rp2350.ld
+    @ONLY
+  )
+  pico_set_linker_script(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR}/memmap_rp2350.ld)
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE

--- a/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld.in
+++ b/mrbgems/picoruby-r2p2/cmake/memmap_rp2350.ld.in
@@ -1,20 +1,17 @@
-/* PicoRuby custom linker script for RP2350
+/* PicoRuby custom linker script for RP2350.
  *
- * Based on pico-sdk memmap_default.ld with one key change:
- * Core 0 stack uses the combined 8KB SCRATCH_X+SCRATCH_Y region,
- * allowing PICO_STACK_SIZE=8KB without consuming regular RAM.
- *
- * Core 1 stack is reserved at the end of regular RAM so core 0 can keep the
- * full 8KB scratch stack.
+ * Core 0 needs more stack than the 8KB scratch banks provide when Prism is
+ * used in debug builds. Its stack is therefore reserved at the top of regular
+ * RAM. Core 1 keeps using SCRATCH_X.
  */
 
 MEMORY
 {
     INCLUDE "pico_flash_region.ld"
-    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 512k
+    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = @PICORB_RAM_LENGTH_KB@k
+    STACK(rwx) : ORIGIN = @PICORB_STACK_ORIGIN@, LENGTH = @PICORB_STACK_LENGTH_KB@k
     SCRATCH_X(rwx) : ORIGIN = 0x20080000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20081000, LENGTH = 4k
-    SCRATCH(rwx) : ORIGIN = 0x20080000, LENGTH = 8k
 }
 
 ENTRY(_entry_point)
@@ -205,36 +202,31 @@ SECTIONS
      *
      * stack1 section may be empty/missing if platform_launch_core1 is not used */
 
-    /* Core 1 stack is reserved in RAM, not SCRATCH. */
+    /* Core 1 stack remains in SCRATCH_X. */
     .stack1_dummy (NOLOAD):
     {
         *(.stack1*)
-    } > RAM
+    } > SCRATCH_X
 
-    /* Core 0 stack: placed in combined SCRATCH_X+SCRATCH_Y.
-     * The .stack_dummy section is only for size calculation (NOLOAD).
-     * Actual stack pointer is set to __StackTop by crt0. */
+    /* Core 0 stack is reserved at the top of regular RAM. */
     .stack_dummy (NOLOAD):
     {
         KEEP(*(.stack*))
-    } > SCRATCH
+    } > STACK
 
     .flash_end : {
         KEEP(*(.embedded_end_block*))
         PROVIDE(__flash_binary_end = .);
     } > FLASH =0xaa
 
-    /* Core 0 stack in combined scratch RAM */
-    __StackTop = ORIGIN(SCRATCH) + LENGTH(SCRATCH);
+    __StackTop = ORIGIN(STACK) + LENGTH(STACK);
     __StackBottom = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
 
-    /* Core 1 stack, if enabled, at end of regular RAM */
-    __StackOneTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
     __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
 
-    /* Heap grows up from __end__; core 1 stack grows down from RAM top. */
-    __HeapLimit = __StackOneBottom;
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
     /* __StackLimit is historically the max heap pointer (poorly named) */
     __StackLimit = __StackBottom;
 
@@ -249,12 +241,11 @@ SECTIONS
     PROVIDE (_end = __end__);
     PROVIDE (__llvm_libc_heap_limit = __HeapLimit);
 
-    /* Check that RAM sections and the runtime core 0 stack do not overlap. */
+    /* Check that each reserved stack fits its dedicated memory region. */
     ASSERT(__end__ <= __HeapLimit, "region RAM overflowed")
-    ASSERT(__StackOneBottom >= __end__, "core 1 stack overlaps RAM data")
-    ASSERT(__StackBottom >= ORIGIN(SCRATCH), "core 0 stack overflowed SCRATCH")
-    ASSERT(SIZEOF(.scratch_x) == 0, ".scratch_x cannot be used when core 0 stack uses SCRATCH")
-    ASSERT(SIZEOF(.scratch_y) == 0, ".scratch_y cannot be used when core 0 stack uses SCRATCH")
+    ASSERT(__StackBottom >= ORIGIN(STACK), "core 0 stack overflowed STACK")
+    ASSERT(__StackOneBottom >= ORIGIN(SCRATCH_X), "core 1 stack overflowed SCRATCH_X")
+    ASSERT(SIZEOF(.scratch_x) == 0, ".scratch_x overlaps the core 1 stack")
 
     ASSERT( __binary_info_header_end - __logical_binary_start <= 1024, "Binary info must be in first 1024 bytes of the binary")
     ASSERT( __embedded_block_end - __logical_binary_start <= 4096, "Embedded block must be in first 4096 bytes of the binary")

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -74,7 +74,7 @@ heap_exit_critical(void)
       #define WIFI_RESERVED_SIZE_KB  64
     #endif
   #else
-    #define WIFI_RESERVED_SIZE_KB    15
+    #define WIFI_RESERVED_SIZE_KB    20
   #endif
   // Compiling a big Ruby code may need more stack size
   #define BASIC_STACK_SIZE_KB   80

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -50,40 +50,33 @@ heap_exit_critical(void)
 
 #if !defined(HEAP_SIZE)
   #if defined(PICO_RP2040)
-    #define RAM_SIZE_KB             264
+    /*
+     * Both CPU stacks live in scratch RAM. The sizes below leave regular RAM
+     * for static pico-sdk state and, when requested, its separate allocator.
+     */
+    #if defined(USE_WIFI) && defined(R2P2_NO_SHARED_ALLOC)
+      #define HEAP_SIZE_KB 152
+    #elif defined(USE_WIFI)
+      #define HEAP_SIZE_KB 164
+    #else
+      #define HEAP_SIZE_KB 184
+    #endif
   #elif defined(PICO_RP2350)
     /*
-     * RP2350 has 512KB of regular SRAM plus 8KB of scratch SRAM. R2P2's
-     * RP2350 linker script reserves scratch SRAM for core0 stack, so heap_pool
-     * must be sized against regular SRAM only.
+     * The production build uses a 16KB core 0 stack and a larger Estalloc
+     * heap. Debug builds use a 24KB stack for unoptimized Prism frames. A
+     * separate allocator needs its own 64KB reserve.
      */
-    #define RAM_SIZE_KB             512
+    #if defined(USE_WIFI) && defined(R2P2_NO_SHARED_ALLOC)
+      #define HEAP_SIZE_KB 320
+    #elif defined(PICORB_DEBUG)
+      #define HEAP_SIZE_KB 384
+    #else
+      #define HEAP_SIZE_KB 396
+    #endif
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"
   #endif
-  #if defined(USE_WIFI) && defined(R2P2_NO_SHARED_ALLOC)
-    /*
-     * When libc/newlib allocation is separated from Estalloc, keep room for
-     * CYW43/LwIP/mbedTLS outside heap_pool. In shared mode, libc allocation is
-     * routed to Estalloc too, so reserving this RAM would only shrink the
-     * shared heap.
-     */
-    #if defined(PICO_RP2040)
-      #define WIFI_RESERVED_SIZE_KB  32
-    #else
-      #define WIFI_RESERVED_SIZE_KB  64
-    #endif
-  #else
-    #define WIFI_RESERVED_SIZE_KB    20
-  #endif
-  // Compiling a big Ruby code may need more stack size
-  #define BASIC_STACK_SIZE_KB   80
-  #if defined(USE_WIFI)
-    #define STACK_SIZE_KB (BASIC_STACK_SIZE_KB + WIFI_RESERVED_SIZE_KB)
-  #else
-    #define STACK_SIZE_KB BASIC_STACK_SIZE_KB
-  #endif
-  #define HEAP_SIZE_KB (RAM_SIZE_KB - STACK_SIZE_KB)
   #define HEAP_SIZE (HEAP_SIZE_KB * 1024)
 #endif
 

--- a/mrbgems/picoruby-r2p2/ports/rp2040/main.c
+++ b/mrbgems/picoruby-r2p2/ports/rp2040/main.c
@@ -70,9 +70,17 @@ heap_exit_critical(void)
     #if defined(USE_WIFI) && defined(R2P2_NO_SHARED_ALLOC)
       #define HEAP_SIZE_KB 320
     #elif defined(PICORB_DEBUG)
-      #define HEAP_SIZE_KB 384
+      #if defined(PICORB_VM_MRUBYC)
+        #define HEAP_SIZE_KB 376
+      #else
+        #define HEAP_SIZE_KB 384
+      #endif
     #else
-      #define HEAP_SIZE_KB 396
+      #if defined(PICORB_VM_MRUBYC)
+        #define HEAP_SIZE_KB 390
+      #else
+        #define HEAP_SIZE_KB 396
+      #endif
     #endif
   #else
     #error "PICO_RP2040 or PICO_RP2350 must be defined"

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -208,6 +208,7 @@ typedef struct picorb_ssl_socket picorb_ssl_socket_t;
 
 picorb_ssl_socket_t* SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ssl_ctx);
 bool SSLSocket_set_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const char *hostname);
+bool SSLSocket_set_connect_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const char *hostname);
 bool SSLSocket_set_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, int port);
 bool SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 int SSLSocket_connection_state(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -72,6 +72,11 @@ extern int Net_get_ip(const char *name, void *ip);
 #if !defined(PICORB_PLATFORM_ESP32)
 extern const char* Net_get_last_error(void);
 extern void Net_set_last_error(const char *format, ...);
+typedef void (*picorb_dns_notify_func)(void *arg);
+void* Net_dns_start(const char *name, picorb_dns_notify_func notify, void *arg);
+int Net_dns_status(void *request);
+void Net_dns_release(void *request);
+void Net_dns_abandon(void *request);
 #endif
 #endif
 

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -12,6 +12,14 @@
 
 #define SOCKET_ERROR_MSG_LEN 128
 
+/* Connection states returned by the socket polling API. */
+#define SOCKET_STATE_NONE        0
+#define SOCKET_STATE_CONNECTING  1
+#define SOCKET_STATE_CONNECTED   2
+#define SOCKET_STATE_CLOSING     3
+#define SOCKET_STATE_CLOSED      4
+#define SOCKET_STATE_ERROR       99
+
 /* Socket structure for POSIX */
 #ifdef PICORB_PLATFORM_POSIX
 typedef struct {
@@ -33,14 +41,6 @@ typedef struct {
 /* Forward declarations for LwIP types */
 struct altcp_pcb;
 struct ip_addr;
-
-/* Socket states */
-#define SOCKET_STATE_NONE        0
-#define SOCKET_STATE_CONNECTING  1
-#define SOCKET_STATE_CONNECTED   2
-#define SOCKET_STATE_CLOSING     3
-#define SOCKET_STATE_CLOSED      4
-#define SOCKET_STATE_ERROR       99
 
 typedef struct {
   struct altcp_pcb *pcb;     /* LwIP control block */
@@ -228,6 +228,7 @@ bool resolve_address(const char *host, char *ip, size_t ip_len);
   void ssl_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket);
   void tcp_server_init(mrbc_vm *vm, mrbc_class *class_BasicSocket);
   void mrbc_socket_free(mrbc_value *self);
+  mrbc_value picorb_task_queue_new(mrbc_vm *vm);
 #elif defined(PICORB_VM_MRUBY)
   #include "mruby.h"
   void mrb_socket_free(mrb_state *mrb, void *ptr);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -92,6 +92,13 @@ void Net_dns_abandon(void *request);
 #define picorb_state mrbc_vm
 #endif
 
+#ifdef PICO_CYW43_ARCH_POLL
+void picorb_task_queue_notify(picorb_state *vm, void *queue, bool *pending);
+bool picorb_task_queue_attach(picorb_state *vm, void *self, void **queue);
+bool picorb_socket_attach_event_queue(picorb_state *vm, void *self, picorb_socket_t *sock);
+void picorb_socket_notify_readable(picorb_socket_t *sock);
+#endif
+
 /* Special return value from read functions: no data available in non-blocking mode */
 #define PICORB_RECV_WOULD_BLOCK (-2)
 /* Special return value from blocking read functions: timed out waiting for data */
@@ -107,7 +114,6 @@ int TCPSocket_connection_state(picorb_state *vm, picorb_socket_t *sock);
 ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
 ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, bool nonblock);
 bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
-void TCPSocket_notify_readable(picorb_socket_t *sock);
 
 /* Get socket info */
 const char* TCPSocket_remote_host(picorb_state *vm, picorb_socket_t *sock);
@@ -126,7 +132,6 @@ ssize_t UDPSocket_recvfrom(picorb_state *vm, picorb_socket_t *sock, void *buf, s
                             char *host, size_t host_len, int *port);
 bool UDPSocket_close(picorb_state *vm, picorb_socket_t *sock);
 bool UDPSocket_closed(picorb_state *vm, picorb_socket_t *sock);
-void UDPSocket_notify_readable(picorb_socket_t *sock);
 
 /* TCP Server API */
 #ifdef PICORB_PLATFORM_POSIX
@@ -213,7 +218,6 @@ bool SSLSocket_closed(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 bool SSLSocket_ready(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 const char* SSLSocket_remote_host(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 int SSLSocket_remote_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
-void SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock);
 
 /* Address resolution */
 bool resolve_address(const char *host, char *ip, size_t ip_len);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -97,6 +97,7 @@ extern void Net_set_last_error(const char *format, ...);
 /* TCP Socket API */
 bool TCPSocket_create(picorb_state *vm, picorb_socket_t *sock);
 bool TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int port);
+int TCPSocket_connection_state(picorb_state *vm, picorb_socket_t *sock);
 ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
 ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, bool nonblock);
 bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -149,12 +149,14 @@ picorb_tcp_server_t* TCPServer_create(picorb_state *vm, int port, int backlog);
 picorb_socket_t* TCPServer_accept_nonblock(picorb_state *vm, picorb_tcp_server_t *server);
 bool TCPServer_close(picorb_state *vm, picorb_tcp_server_t *server);
 int TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server);
+#ifdef PICO_CYW43_ARCH_POLL
 void TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue);
 void* TCPServer_event_queue(picorb_tcp_server_t *server);
 picorb_state* TCPServer_vm(picorb_tcp_server_t *server);
 bool TCPServer_event_pending(picorb_tcp_server_t *server);
 void TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending);
 void TCPServer_notify_accepted(picorb_tcp_server_t *server);
+#endif
 bool TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server);
 
 /* SSL Context API */

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -75,6 +75,7 @@ extern void Net_set_last_error(const char *format, ...);
 typedef void (*picorb_dns_notify_func)(void *arg);
 void* Net_dns_start(const char *name, picorb_dns_notify_func notify, void *arg);
 int Net_dns_status(void *request);
+int Net_dns_get_address(void *request, char *buf, size_t buflen);
 void Net_dns_release(void *request);
 void Net_dns_abandon(void *request);
 #endif

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -57,6 +57,8 @@ typedef struct {
   char last_sender_host[256];
   int last_sender_port;
   char errmsg[SOCKET_ERROR_MSG_LEN]; /* Last error message from C layer */
+  void *vm;                   /* Owning VM for callback notification */
+  void *event_queue;          /* VM-specific Task::Queue value (RP2040 only) */
 } picorb_socket_t;
 
 /* LwIP helper functions - implemented in ports/rp2040/ */
@@ -115,6 +117,7 @@ ssize_t UDPSocket_recvfrom(picorb_state *vm, picorb_socket_t *sock, void *buf, s
                             char *host, size_t host_len, int *port);
 bool UDPSocket_close(picorb_state *vm, picorb_socket_t *sock);
 bool UDPSocket_closed(picorb_state *vm, picorb_socket_t *sock);
+void UDPSocket_notify_readable(picorb_socket_t *sock);
 
 /* TCP Server API */
 #ifdef PICORB_PLATFORM_POSIX

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -138,6 +138,12 @@ picorb_tcp_server_t* TCPServer_create(picorb_state *vm, int port, int backlog);
 picorb_socket_t* TCPServer_accept_nonblock(picorb_state *vm, picorb_tcp_server_t *server);
 bool TCPServer_close(picorb_state *vm, picorb_tcp_server_t *server);
 int TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server);
+void TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue);
+void* TCPServer_event_queue(picorb_tcp_server_t *server);
+picorb_state* TCPServer_vm(picorb_tcp_server_t *server);
+bool TCPServer_event_pending(picorb_tcp_server_t *server);
+void TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending);
+void TCPServer_notify_accepted(picorb_tcp_server_t *server);
 bool TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server);
 
 /* SSL Context API */

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -59,6 +59,7 @@ typedef struct {
   char errmsg[SOCKET_ERROR_MSG_LEN]; /* Last error message from C layer */
   void *vm;                   /* Owning VM for callback notification */
   void *event_queue;          /* VM-specific Task::Queue value (RP2040 only) */
+  bool event_pending;         /* A readable notification is already queued */
 } picorb_socket_t;
 
 /* LwIP helper functions - implemented in ports/rp2040/ */
@@ -99,6 +100,7 @@ bool TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host
 ssize_t TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len);
 ssize_t TCPSocket_recv(picorb_state *vm, picorb_socket_t *sock, void *buf, size_t len, bool nonblock);
 bool TCPSocket_close(picorb_state *vm, picorb_socket_t *sock);
+void TCPSocket_notify_readable(picorb_socket_t *sock);
 
 /* Get socket info */
 const char* TCPSocket_remote_host(picorb_state *vm, picorb_socket_t *sock);

--- a/mrbgems/picoruby-socket/include/socket.h
+++ b/mrbgems/picoruby-socket/include/socket.h
@@ -191,6 +191,9 @@ picorb_ssl_socket_t* SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ss
 bool SSLSocket_set_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const char *hostname);
 bool SSLSocket_set_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, int port);
 bool SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
+int SSLSocket_connection_state(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
+bool SSLSocket_finish_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
+picorb_socket_t* SSLSocket_event_socket(picorb_ssl_socket_t *ssl_sock);
 ssize_t SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data, size_t len);
 ssize_t SSLSocket_recv(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, void *buf, size_t len, bool nonblock);
 bool SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
@@ -198,6 +201,7 @@ bool SSLSocket_closed(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 bool SSLSocket_ready(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 const char* SSLSocket_remote_host(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
 int SSLSocket_remote_port(picorb_state *vm, picorb_ssl_socket_t *ssl_sock);
+void SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock);
 
 /* Address resolution */
 bool resolve_address(const char *host, char *ip, size_t ip_len);

--- a/mrbgems/picoruby-socket/mrbgem.rake
+++ b/mrbgems/picoruby-socket/mrbgem.rake
@@ -12,7 +12,9 @@ MRuby::Gem::Specification.new('picoruby-socket') do |spec|
   end
   spec.add_conflict 'picoruby-net'
   spec.add_dependency 'picoruby-machine'
-  spec.add_dependency 'mruby-task' unless build.posix? || build.platform?(:esp32)
+  if build.picoruby? && !build.posix? && !build.platform?(:esp32)
+    spec.add_dependency 'mruby-task'
+  end
 
   # Add include directory
   spec.cc.include_paths << "#{dir}/include"

--- a/mrbgems/picoruby-socket/mrbgem.rake
+++ b/mrbgems/picoruby-socket/mrbgem.rake
@@ -12,6 +12,7 @@ MRuby::Gem::Specification.new('picoruby-socket') do |spec|
   end
   spec.add_conflict 'picoruby-net'
   spec.add_dependency 'picoruby-machine'
+  spec.add_dependency 'mruby-task' unless build.posix? || build.platform?(:esp32)
 
   # Add include directory
   spec.cc.include_paths << "#{dir}/include"

--- a/mrbgems/picoruby-socket/mrbgem.rake
+++ b/mrbgems/picoruby-socket/mrbgem.rake
@@ -12,6 +12,7 @@ MRuby::Gem::Specification.new('picoruby-socket') do |spec|
   end
   spec.add_conflict 'picoruby-net'
   spec.add_dependency 'picoruby-machine'
+  spec.add_dependency 'picoruby-metaprog' if build.femtoruby?
   if build.picoruby? && !build.posix? && !build.platform?(:esp32)
     spec.add_dependency 'mruby-task'
   end

--- a/mrbgems/picoruby-socket/mrblib/basic_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/basic_socket.rb
@@ -3,6 +3,31 @@ class SocketError < StandardError; end
 class EOFError < IOError; end
 
 class BasicSocket
+  CONNECTION_TIMEOUT_MS = 10_000
+
+  private def __connection_timeout_ms
+    CONNECTION_TIMEOUT_MS
+  end
+
+  private def __wait_for_event(event_queue, timeout_message)
+    unless event_queue.pop(timeout_ms: __connection_timeout_ms)
+      close
+      raise SocketError, timeout_message
+    end
+  end
+
+  private def __readpartial_event_queue(maxlen, timeout_message, failure_message)
+    event_queue = @event_queue
+    return __readpartial_poll(maxlen) unless event_queue
+
+    data = read_nonblock(maxlen)
+    while data.nil?
+      __wait_for_event(event_queue, timeout_message)
+      data = read_nonblock(maxlen)
+    end
+    data || raise(IOError, failure_message)
+  end
+
   # IO-compatible methods
 
   def read(maxlen = nil)

--- a/mrbgems/picoruby-socket/mrblib/basic_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/basic_socket.rb
@@ -4,11 +4,13 @@ class EOFError < IOError; end
 
 class BasicSocket
   CONNECTION_TIMEOUT_MS = 10_000
+  READ_TIMEOUT_MS = 60_000
 
   private def __connection_timeout_ms
     CONNECTION_TIMEOUT_MS
   end
 
+  # A connection that timed out cannot be used, so release its resources here.
   private def __wait_for_event(event_queue, timeout_message)
     unless event_queue.pop(timeout_ms: __connection_timeout_ms)
       close
@@ -16,16 +18,21 @@ class BasicSocket
     end
   end
 
-  private def __readpartial_event_queue(maxlen, timeout_message, failure_message)
+  # A read timeout is recoverable (the peer may just be slow), so keep the
+  # socket open and let the caller retry or close.
+  private def __readpartial_event_queue(maxlen, timeout_message)
     event_queue = @event_queue
     return __readpartial_poll(maxlen) unless event_queue
 
     data = read_nonblock(maxlen)
     while data.nil?
-      __wait_for_event(event_queue, timeout_message)
+      unless event_queue.pop(timeout_ms: READ_TIMEOUT_MS)
+        raise SocketError, timeout_message
+      end
       data = read_nonblock(maxlen)
     end
-    data || raise(IOError, failure_message)
+    # @type var data: String
+    data
   end
 
   # IO-compatible methods

--- a/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
+++ b/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
@@ -7,7 +7,7 @@ if Object.const_defined?(:SocketDNSResolver)
     def resolve(host)
       status = __status
       if status == 1
-        unless @event_queue.pop(timeout_ms: 10_000)
+        unless @event_queue.pop(timeout_ms: BasicSocket::CONNECTION_TIMEOUT_MS)
           __abandon
           raise SocketError, "DNS resolution timed out for #{host}"
         end

--- a/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
+++ b/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
@@ -1,0 +1,22 @@
+if Object.const_defined?(:SocketDNSResolver)
+  class SocketDNSResolver
+    def self.resolve(host)
+      new(host).resolve(host)
+    end
+
+    def resolve(host)
+      status = __status
+      if status == 1
+        unless @event_queue.pop(timeout_ms: 10_000)
+          __abandon
+          raise SocketError, "DNS resolution timed out for #{host}"
+        end
+        status = __status
+      end
+      __release
+      return host if status == 2
+
+      raise SocketError, "DNS resolution failed for #{host}"
+    end
+  end
+end

--- a/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
+++ b/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
@@ -13,8 +13,9 @@ if Object.const_defined?(:SocketDNSResolver)
         end
         status = __status
       end
+      address = __address
       __release
-      return host if status == 2
+      return address if status == 2 && address
 
       raise SocketError, "DNS resolution failed for #{host}"
     end

--- a/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
+++ b/mrbgems/picoruby-socket/mrblib/dns_resolver.rb
@@ -1,6 +1,6 @@
 if Object.const_defined?(:SocketDNSResolver)
   class SocketDNSResolver
-    def self.resolve(host)
+    def self.resolve_host(host)
       new(host).resolve(host)
     end
 

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -61,7 +61,7 @@ class SSLSocket < BasicSocket
     end
 
     def readpartial(maxlen)
-      __readpartial_event_queue(maxlen, "SSL read timeout", "SSL read failed")
+      __readpartial_event_queue(maxlen, "SSL read timeout")
     end
   end
 

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -29,6 +29,43 @@ class SSLSocket < BasicSocket
 
   # Instance methods
 
+  def connect
+    __connect_poll
+    event_queue = @event_queue
+    return self unless event_queue
+
+    while __connection_state == 1
+      unless event_queue.pop(timeout_ms: 10_000)
+        close
+        raise SocketError, "SSL handshake timed out"
+      end
+    end
+
+    if __connection_state == 2
+      event_queue.pop(true)
+      return self if __finish_connect
+
+      close
+      raise SocketError, "SSL receive buffer allocation failed"
+    end
+
+    message = __error_message
+    close
+    raise SocketError, message || "SSL handshake failed"
+  end
+
+  def readpartial(maxlen)
+    event_queue = @event_queue
+    return __readpartial_poll(maxlen) unless event_queue
+
+    data = read_nonblock(maxlen)
+    until data
+      event_queue.pop
+      data = read_nonblock(maxlen)
+    end
+    data || raise(IOError, "SSL read failed")
+  end
+
   def addr
     # Returns [address_family, port, hostname, numeric_address]
     # Delegates to underlying TCP socket

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -44,10 +44,7 @@ class SSLSocket < BasicSocket
       return self unless event_queue
 
       while __connection_state == 1
-        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
-          close
-          raise SocketError, "SSL handshake timed out"
-        end
+        __wait_for_event(event_queue, "SSL handshake timed out")
       end
 
       if __connection_state == 2
@@ -63,18 +60,7 @@ class SSLSocket < BasicSocket
     end
 
     def readpartial(maxlen)
-      event_queue = @event_queue
-      return __readpartial_poll(maxlen) unless event_queue
-
-      data = read_nonblock(maxlen)
-      until data
-        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
-          close
-          raise SocketError, "SSL read timeout"
-        end
-        data = read_nonblock(maxlen)
-      end
-      data || raise(IOError, "SSL read failed")
+      __readpartial_event_queue(maxlen, "SSL read timeout", "SSL read failed")
     end
   end
 

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -29,43 +29,50 @@ class SSLSocket < BasicSocket
 
   # Instance methods
 
-  def connect
-    host = remote_host
-    SocketDNSResolver.resolve(host) if Object.const_defined?(:SocketDNSResolver)
-    __connect_poll
-    event_queue = @event_queue
-    return self unless event_queue
+  if Object.const_defined?(:SocketDNSResolver)
+    def self.open(host, port, ssl_context)
+      socket = __open_poll(host, port, ssl_context)
+      socket.connect
+      socket
+    end
 
-    while __connection_state == 1
-      unless event_queue.pop(timeout_ms: 10_000)
-        close
-        raise SocketError, "SSL handshake timed out"
+    def connect
+      host = remote_host
+      SocketDNSResolver.resolve_host(host)
+      __connect_poll
+      event_queue = @event_queue
+      return self unless event_queue
+
+      while __connection_state == 1
+        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
+          close
+          raise SocketError, "SSL handshake timed out"
+        end
       end
-    end
 
-    if __connection_state == 2
-      event_queue.pop(true)
-      return self if __finish_connect
+      if __connection_state == 2
+        return self if __finish_connect
 
+        close
+        raise SocketError, "SSL receive buffer allocation failed"
+      end
+
+      message = __error_message
       close
-      raise SocketError, "SSL receive buffer allocation failed"
+      raise SocketError, message || "SSL handshake failed"
     end
 
-    message = __error_message
-    close
-    raise SocketError, message || "SSL handshake failed"
-  end
+    def readpartial(maxlen)
+      event_queue = @event_queue
+      return __readpartial_poll(maxlen) unless event_queue
 
-  def readpartial(maxlen)
-    event_queue = @event_queue
-    return __readpartial_poll(maxlen) unless event_queue
-
-    data = read_nonblock(maxlen)
-    until data
-      event_queue.pop
       data = read_nonblock(maxlen)
+      until data
+        event_queue.pop
+        data = read_nonblock(maxlen)
+      end
+      data || raise(IOError, "SSL read failed")
     end
-    data || raise(IOError, "SSL read failed")
   end
 
   def addr

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -68,7 +68,10 @@ class SSLSocket < BasicSocket
 
       data = read_nonblock(maxlen)
       until data
-        event_queue.pop
+        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
+          close
+          raise SocketError, "SSL read timeout"
+        end
         data = read_nonblock(maxlen)
       end
       data || raise(IOError, "SSL read failed")

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -30,6 +30,8 @@ class SSLSocket < BasicSocket
   # Instance methods
 
   def connect
+    host = remote_host
+    SocketDNSResolver.resolve(host) if Object.const_defined?(:SocketDNSResolver)
     __connect_poll
     event_queue = @event_queue
     return self unless event_queue

--- a/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/ssl_socket.rb
@@ -38,7 +38,8 @@ class SSLSocket < BasicSocket
 
     def connect
       host = remote_host
-      SocketDNSResolver.resolve_host(host)
+      resolved_host = SocketDNSResolver.resolve_host(host)
+      __set_connect_hostname(resolved_host)
       __connect_poll
       event_queue = @event_queue
       return self unless event_queue

--- a/mrbgems/picoruby-socket/mrblib/tcp_server.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_server.rb
@@ -39,13 +39,14 @@ class TCPServer
   # @return [TCPSocket] Connected client socket
   # @raise [Interrupt] if interrupted by signal or external task
   def accept
+    event_queue = @event_queue
     Signal.trap(:INT) do
       self.close
     end
     while true
       client = accept_nonblock
       break if client
-      sleep_ms 10
+      event_queue ? event_queue.pop : sleep_ms(10)
     end
     # @type var client: TCPSocket
     return client

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -2,23 +2,25 @@ class TCPSocket < BasicSocket
   # TCPSocket is mostly implemented in C
   # This file provides additional Ruby-level methods
 
-  def initialize(host, port)
-    SocketDNSResolver.resolve(host) if Object.const_defined?(:SocketDNSResolver)
-    __initialize_poll(host, port)
-    event_queue = @event_queue
-    return unless event_queue
+  if Object.const_defined?(:SocketDNSResolver)
+    def initialize(host, port)
+      SocketDNSResolver.resolve_host(host)
+      __initialize_poll(host, port)
+      event_queue = @event_queue
+      return unless event_queue
 
-    while __connection_state == 1
-      unless event_queue.pop(timeout_ms: 10_000)
-        close
-        raise SocketError, "connection timed out"
+      while __connection_state == 1
+        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
+          close
+          raise SocketError, "connection timed out"
+        end
       end
-    end
-    return if __connection_state == 2
+      return if __connection_state == 2
 
-    message = __error_message
-    close
-    raise SocketError, message || "failed to connect"
+      message = __error_message
+      close
+      raise SocketError, message || "failed to connect"
+    end
   end
 
   # Class methods
@@ -45,15 +47,17 @@ class TCPSocket < BasicSocket
     !closed?
   end
 
-  def readpartial(maxlen)
-    event_queue = @event_queue
-    return __readpartial_poll(maxlen) unless event_queue
+  if Object.const_defined?(:SocketDNSResolver)
+    def readpartial(maxlen)
+      event_queue = @event_queue
+      return __readpartial_poll(maxlen) unless event_queue
 
-    data = read_nonblock(maxlen)
-    until data
-      event_queue.pop
       data = read_nonblock(maxlen)
+      until data
+        event_queue.pop
+        data = read_nonblock(maxlen)
+      end
+      data || raise(IOError, "read failed")
     end
-    data || raise(IOError, "read failed")
   end
 end

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -2,6 +2,8 @@ class TCPSocket < BasicSocket
   # TCPSocket is mostly implemented in C
   # This file provides additional Ruby-level methods
 
+  alias __readpartial_poll readpartial
+
   # Class methods
 
   def self.open(host, port)
@@ -24,5 +26,16 @@ class TCPSocket < BasicSocket
 
   def connected?
     !closed?
+  end
+
+  def readpartial(maxlen)
+    event_queue = @event_queue
+    return __readpartial_poll(maxlen) unless event_queue
+
+    while true
+      data = read_nonblock(maxlen)
+      return data if data
+      event_queue.pop
+    end
   end
 end

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -54,7 +54,10 @@ class TCPSocket < BasicSocket
 
       data = read_nonblock(maxlen)
       until data
-        event_queue.pop
+        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
+          close
+          raise SocketError, "read timeout"
+        end
         data = read_nonblock(maxlen)
       end
       data || raise(IOError, "read failed")

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -46,7 +46,7 @@ class TCPSocket < BasicSocket
 
   if Object.const_defined?(:SocketDNSResolver)
     def readpartial(maxlen)
-      __readpartial_event_queue(maxlen, "read timeout", "read failed")
+      __readpartial_event_queue(maxlen, "read timeout")
     end
   end
 end

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -2,7 +2,23 @@ class TCPSocket < BasicSocket
   # TCPSocket is mostly implemented in C
   # This file provides additional Ruby-level methods
 
-  alias __readpartial_poll readpartial
+  def initialize(host, port)
+    __initialize_poll(host, port)
+    event_queue = @event_queue
+    return unless event_queue
+
+    while __connection_state == 1
+      unless event_queue.pop(timeout_ms: 10_000)
+        close
+        raise SocketError, "connection timed out"
+      end
+    end
+    return if __connection_state == 2
+
+    message = __error_message
+    close
+    raise SocketError, message || "failed to connect"
+  end
 
   # Class methods
 
@@ -32,10 +48,11 @@ class TCPSocket < BasicSocket
     event_queue = @event_queue
     return __readpartial_poll(maxlen) unless event_queue
 
-    while true
-      data = read_nonblock(maxlen)
-      return data if data
+    data = read_nonblock(maxlen)
+    until data
       event_queue.pop
+      data = read_nonblock(maxlen)
     end
+    data || raise(IOError, "read failed")
   end
 end

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -10,10 +10,7 @@ class TCPSocket < BasicSocket
       return unless event_queue
 
       while __connection_state == 1
-        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
-          close
-          raise SocketError, "connection timed out"
-        end
+        __wait_for_event(event_queue, "connection timed out")
       end
       return if __connection_state == 2
 
@@ -49,18 +46,7 @@ class TCPSocket < BasicSocket
 
   if Object.const_defined?(:SocketDNSResolver)
     def readpartial(maxlen)
-      event_queue = @event_queue
-      return __readpartial_poll(maxlen) unless event_queue
-
-      data = read_nonblock(maxlen)
-      until data
-        unless event_queue.pop(timeout_ms: __connection_timeout_ms)
-          close
-          raise SocketError, "read timeout"
-        end
-        data = read_nonblock(maxlen)
-      end
-      data || raise(IOError, "read failed")
+      __readpartial_event_queue(maxlen, "read timeout", "read failed")
     end
   end
 end

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -3,6 +3,7 @@ class TCPSocket < BasicSocket
   # This file provides additional Ruby-level methods
 
   def initialize(host, port)
+    SocketDNSResolver.resolve(host) if Object.const_defined?(:SocketDNSResolver)
     __initialize_poll(host, port)
     event_queue = @event_queue
     return unless event_queue

--- a/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/tcp_socket.rb
@@ -4,7 +4,7 @@ class TCPSocket < BasicSocket
 
   if Object.const_defined?(:SocketDNSResolver)
     def initialize(host, port)
-      SocketDNSResolver.resolve_host(host)
+      host = SocketDNSResolver.resolve_host(host)
       __initialize_poll(host, port)
       event_queue = @event_queue
       return unless event_queue

--- a/mrbgems/picoruby-socket/mrblib/udp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/udp_socket.rb
@@ -4,17 +4,17 @@ class UDPSocket
 
   if Object.const_defined?(:SocketDNSResolver)
     def bind(host, port)
-      SocketDNSResolver.resolve(host) if host && host != "" && host != "0.0.0.0"
+      SocketDNSResolver.resolve_host(host) if host && host != "" && host != "0.0.0.0"
       __bind_resolved(host, port)
     end
 
     def connect(host, port)
-      SocketDNSResolver.resolve(host)
+      SocketDNSResolver.resolve_host(host)
       __connect_resolved(host, port)
     end
 
     def send(data, flags = 0, host = nil, port = nil)
-      SocketDNSResolver.resolve(host) if host
+      SocketDNSResolver.resolve_host(host) if host
       host ? __send_resolved(data, flags, host, port) : __send_resolved(data, flags)
     end
   end

--- a/mrbgems/picoruby-socket/mrblib/udp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/udp_socket.rb
@@ -2,6 +2,23 @@ class UDPSocket
   # UDPSocket is already defined in C
   # This file adds convenience methods
 
+  if Object.const_defined?(:SocketDNSResolver)
+    def bind(host, port)
+      SocketDNSResolver.resolve(host) if host && host != "" && host != "0.0.0.0"
+      __bind_resolved(host, port)
+    end
+
+    def connect(host, port)
+      SocketDNSResolver.resolve(host)
+      __connect_resolved(host, port)
+    end
+
+    def send(data, flags = 0, host = nil, port = nil)
+      SocketDNSResolver.resolve(host) if host
+      host ? __send_resolved(data, flags, host, port) : __send_resolved(data, flags)
+    end
+  end
+
   # Receive data with blocking behavior
   def recvfrom(maxlen, flags = 0)
     Signal.trap(:INT) do

--- a/mrbgems/picoruby-socket/mrblib/udp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/udp_socket.rb
@@ -3,7 +3,6 @@ class UDPSocket
   # This file adds convenience methods
 
   # Receive data with blocking behavior
-  # Continuously polls recvfrom_nonblock until data is available
   def recvfrom(maxlen, flags = 0)
     Signal.trap(:INT) do
       self.close
@@ -11,7 +10,11 @@ class UDPSocket
     while true
       result = recvfrom_nonblock(maxlen, flags)
       break if result
-      sleep_ms 10
+      if event_queue = @event_queue
+        event_queue.pop
+      else
+        sleep_ms 10
+      end
     end
     # @type var result: [String, Array[String | Integer]]
     return result

--- a/mrbgems/picoruby-socket/mrblib/udp_socket.rb
+++ b/mrbgems/picoruby-socket/mrblib/udp_socket.rb
@@ -4,17 +4,19 @@ class UDPSocket
 
   if Object.const_defined?(:SocketDNSResolver)
     def bind(host, port)
-      SocketDNSResolver.resolve_host(host) if host && host != "" && host != "0.0.0.0"
+      if host && host != "" && host != "0.0.0.0"
+        host = SocketDNSResolver.resolve_host(host)
+      end
       __bind_resolved(host, port)
     end
 
     def connect(host, port)
-      SocketDNSResolver.resolve_host(host)
+      host = SocketDNSResolver.resolve_host(host)
       __connect_resolved(host, port)
     end
 
     def send(data, flags = 0, host = nil, port = nil)
-      SocketDNSResolver.resolve_host(host) if host
+      host = SocketDNSResolver.resolve_host(host) if host
       host ? __send_resolved(data, flags, host, port) : __send_resolved(data, flags)
     end
   end

--- a/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/ssl_socket.c
@@ -292,6 +292,26 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   return true;
 }
 
+int
+SSLSocket_connection_state(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  (void)vm;
+  return ssl_sock ? ssl_sock->state : SSL_STATE_ERROR;
+}
+
+bool
+SSLSocket_finish_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  (void)vm;
+  return ssl_sock && ssl_sock->state == SSL_STATE_CONNECTED;
+}
+
+picorb_socket_t*
+SSLSocket_event_socket(picorb_ssl_socket_t *ssl_sock)
+{
+  return ssl_sock ? ssl_sock->base_socket : NULL;
+}
+
 ssize_t
 SSLSocket_send(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const void *data, size_t len)
 {

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
@@ -131,6 +131,42 @@ TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server)
   return server->port;
 }
 
+void
+TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue)
+{
+  (void)server;
+  (void)vm;
+  (void)queue;
+}
+
+void*
+TCPServer_event_queue(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return NULL;
+}
+
+picorb_state*
+TCPServer_vm(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return NULL;
+}
+
+bool
+TCPServer_event_pending(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return false;
+}
+
+void
+TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending)
+{
+  (void)server;
+  (void)pending;
+}
+
 bool
 TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server)
 {

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_server.c
@@ -131,42 +131,6 @@ TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server)
   return server->port;
 }
 
-void
-TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue)
-{
-  (void)server;
-  (void)vm;
-  (void)queue;
-}
-
-void*
-TCPServer_event_queue(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return NULL;
-}
-
-picorb_state*
-TCPServer_vm(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return NULL;
-}
-
-bool
-TCPServer_event_pending(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return false;
-}
-
-void
-TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending)
-{
-  (void)server;
-  (void)pending;
-}
-
 bool
 TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server)
 {

--- a/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/esp32/tcp_socket.c
@@ -85,6 +85,13 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
   return true;
 }
 
+int
+TCPSocket_connection_state(picorb_state *vm, picorb_socket_t *sock)
+{
+  (void)vm;
+  return sock && sock->connected ? SOCKET_STATE_CONNECTED : SOCKET_STATE_ERROR;
+}
+
 ssize_t
 TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len)
 {

--- a/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/posix/ssl_socket.c
@@ -472,6 +472,26 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   return true;
 }
 
+int
+SSLSocket_connection_state(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  (void)vm;
+  return ssl_sock && ssl_sock->connected ? SOCKET_STATE_CONNECTED : SOCKET_STATE_ERROR;
+}
+
+bool
+SSLSocket_finish_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  (void)vm;
+  return ssl_sock && ssl_sock->connected;
+}
+
+picorb_socket_t*
+SSLSocket_event_socket(picorb_ssl_socket_t *ssl_sock)
+{
+  return ssl_sock ? ssl_sock->base_socket : NULL;
+}
+
 /*
  * Send data over SSL socket
  */

--- a/mrbgems/picoruby-socket/ports/posix/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/posix/tcp_server.c
@@ -185,42 +185,6 @@ TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server)
   return srv ? srv->port : -1;
 }
 
-void
-TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue)
-{
-  (void)server;
-  (void)vm;
-  (void)queue;
-}
-
-void*
-TCPServer_event_queue(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return NULL;
-}
-
-picorb_state*
-TCPServer_vm(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return NULL;
-}
-
-bool
-TCPServer_event_pending(picorb_tcp_server_t *server)
-{
-  (void)server;
-  return false;
-}
-
-void
-TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending)
-{
-  (void)server;
-  (void)pending;
-}
-
 /* Check if server is listening */
 bool
 TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server)

--- a/mrbgems/picoruby-socket/ports/posix/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/posix/tcp_server.c
@@ -185,6 +185,42 @@ TCPServer_port(picorb_state *vm, picorb_tcp_server_t *server)
   return srv ? srv->port : -1;
 }
 
+void
+TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue)
+{
+  (void)server;
+  (void)vm;
+  (void)queue;
+}
+
+void*
+TCPServer_event_queue(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return NULL;
+}
+
+picorb_state*
+TCPServer_vm(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return NULL;
+}
+
+bool
+TCPServer_event_pending(picorb_tcp_server_t *server)
+{
+  (void)server;
+  return false;
+}
+
+void
+TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending)
+{
+  (void)server;
+  (void)pending;
+}
+
 /* Check if server is listening */
 bool
 TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server)

--- a/mrbgems/picoruby-socket/ports/posix/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/posix/tcp_socket.c
@@ -98,6 +98,13 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
   return true;
 }
 
+int
+TCPSocket_connection_state(picorb_state *vm, picorb_socket_t *sock)
+{
+  (void)vm;
+  return sock && sock->connected ? SOCKET_STATE_CONNECTED : SOCKET_STATE_ERROR;
+}
+
 /* Send data */
 ssize_t
 TCPSocket_send(picorb_state *vm, picorb_socket_t *sock, const void *data, size_t len)

--- a/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
@@ -197,6 +197,21 @@ Net_dns_status(void *ptr)
   return request ? request->state : 3;
 }
 
+int
+Net_dns_get_address(void *ptr, char *buf, size_t buflen)
+{
+  picorb_dns_request *request = (picorb_dns_request *)ptr;
+
+  if (!request || !buf || buflen == 0 || request->state != 2) {
+    return -1;
+  }
+  if (!ipaddr_ntoa_r(&request->address, buf, (int)buflen)) {
+    buf[0] = '\0';
+    return -1;
+  }
+  return 0;
+}
+
 void
 Net_dns_release(void *ptr)
 {

--- a/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/net_helpers.c
@@ -5,12 +5,27 @@
 #include "../../include/socket.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 #include "picoruby/debug.h"
 #include "pico/stdlib.h"
 #include "pico/cyw43_arch.h"
 #include "lwip/dns.h"
 
 static char net_error[SOCKET_ERROR_MSG_LEN];
+
+#ifndef PICORB_DNS_REQUEST_COUNT
+#define PICORB_DNS_REQUEST_COUNT 4
+#endif
+
+typedef struct {
+  ip_addr_t address;
+  picorb_dns_notify_func notify;
+  void *arg;
+  uint8_t state;
+  bool abandoned;
+} picorb_dns_request;
+
+static picorb_dns_request dns_requests[PICORB_DNS_REQUEST_COUNT];
 
 static void
 Net_clear_error(void)
@@ -107,6 +122,101 @@ dns_callback(const char *name, const ip_addr_t *ip, void *arg)
     ip_addr_copy(*result, *ip);
   } else {
     ip_addr_set_zero(result);
+  }
+}
+
+static void
+dns_request_callback(const char *name, const ip_addr_t *ip, void *arg)
+{
+  (void)name;
+  picorb_dns_request *request = (picorb_dns_request *)arg;
+  if (!request || request->state != 1) return;
+  if (ip) {
+    ip_addr_copy(request->address, *ip);
+    request->state = 2;
+  } else {
+    ip_addr_set_zero(&request->address);
+    request->state = 3;
+  }
+  if (request->abandoned) {
+    memset(request, 0, sizeof(*request));
+  } else if (request->notify) {
+    request->notify(request->arg);
+  }
+}
+
+void*
+Net_dns_start(const char *name, picorb_dns_notify_func notify, void *arg)
+{
+  if (!name || !notify || !cyw43_lwip_ready("Net_dns_start") ||
+      !cyw43_wifi_ready("Net_dns_start")) {
+    return NULL;
+  }
+
+  picorb_dns_request *request = NULL;
+  int i = 0;
+  while (i < PICORB_DNS_REQUEST_COUNT) {
+    if (dns_requests[i].state == 0) {
+      request = &dns_requests[i];
+      break;
+    }
+    i++;
+  }
+  if (!request) {
+    Net_set_last_error("DNS request pool is full");
+    return NULL;
+  }
+
+  memset(request, 0, sizeof(*request));
+  request->notify = notify;
+  request->arg = arg;
+  request->state = 1;
+
+  if (ip4addr_aton(name, &request->address)) {
+    request->state = 2;
+    return request;
+  }
+
+  lwip_begin();
+  err_t err = dns_gethostbyname(name, &request->address,
+                                dns_request_callback, request);
+  lwip_end();
+  if (err == ERR_OK) {
+    request->state = 2;
+  } else if (err != ERR_INPROGRESS) {
+    request->state = 3;
+    Net_set_last_error("DNS failed for %s with error %d", name, err);
+  }
+  return request;
+}
+
+int
+Net_dns_status(void *ptr)
+{
+  picorb_dns_request *request = (picorb_dns_request *)ptr;
+  return request ? request->state : 3;
+}
+
+void
+Net_dns_release(void *ptr)
+{
+  picorb_dns_request *request = (picorb_dns_request *)ptr;
+  if (request && request->state != 1) {
+    memset(request, 0, sizeof(*request));
+  }
+}
+
+void
+Net_dns_abandon(void *ptr)
+{
+  picorb_dns_request *request = (picorb_dns_request *)ptr;
+  if (!request) return;
+  if (request->state == 1) {
+    request->abandoned = true;
+    request->notify = NULL;
+    request->arg = NULL;
+  } else {
+    memset(request, 0, sizeof(*request));
   }
 }
 

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -120,12 +120,14 @@ ssl_connected_callback(void *arg, struct altcp_pcb *pcb, err_t err)
     Net_set_last_error("SSL connect callback failed: %s (%d)", lwip_err_name(err), (int)err);
     ssl_sock->state = SSL_STATE_ERROR;
     ssl_sock->connected = false;
+    SSLSocket_notify_readable(ssl_sock);
     return err;
   }
 
   D("SSL callback: success");
   ssl_sock->state = SSL_STATE_CONNECTED;
   ssl_sock->connected = true;
+  SSLSocket_notify_readable(ssl_sock);
   return ERR_OK;
 }
 
@@ -140,6 +142,7 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     ssl_sock->state = SSL_STATE_ERROR;
     ssl_sock->connected = false;
+    SSLSocket_notify_readable(ssl_sock);
     return err;
   }
 
@@ -147,22 +150,22 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   if (!pbuf) {
     ssl_sock->state = SSL_STATE_NONE;
     ssl_sock->connected = false;
+    SSLSocket_notify_readable(ssl_sock);
     return ERR_OK;
   }
 
   /* Copy data into pre-allocated buffer (no heap allocation in callback) */
   picorb_socket_t *sock = ssl_sock->base_socket;
   if (!sock->recv_buf) {
-    Net_set_last_error("SSL recv buffer is not allocated");
-    pbuf_free(pbuf);
+    /* The VM task allocates this buffer after the handshake notification.
+     * Keep the pbuf owned by LwIP so the callback can be retried. */
     return ERR_MEM;
   }
   size_t total_len = pbuf->tot_len;
   size_t new_size = sock->recv_len + total_len;
 
   if (new_size > sock->recv_capacity) {
-    /* Buffer full - cannot accept more data */
-    pbuf_free(pbuf);
+    /* Keep the pbuf owned by LwIP and retry after the VM drains the buffer. */
     return ERR_MEM;
   }
 
@@ -180,6 +183,7 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   /* Tell LwIP we processed the data */
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
+  SSLSocket_notify_readable(ssl_sock);
 
   return ERR_OK;
 }
@@ -203,6 +207,7 @@ ssl_err_callback(void *arg, err_t err)
   ssl_sock->state = SSL_STATE_ERROR;
   ssl_sock->connected = false;
   ssl_sock->tls_pcb = NULL;  /* PCB is already freed by LwIP */
+  SSLSocket_notify_readable(ssl_sock);
 }
 
 static err_t
@@ -429,6 +434,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
     D("SSL: bad params");
     return false;
   }
+  Net_set_last_error("");
 
   /* Get port from base_socket if set, otherwise use 443 */
   if (ssl_sock->port == 0) {
@@ -538,6 +544,8 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   D("SSL: waiting before connect");
   Net_busy_wait_ms(100);
 
+  ssl_sock->state = SSL_STATE_CONNECTING;
+
   /* Initiate connection */
   D("SSL: initiating connection to port %d", ssl_sock->port);
   lwip_begin();
@@ -558,7 +566,9 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   lwip_end();
   D("SSL: altcp_connect ok");
 
-  ssl_sock->state = SSL_STATE_CONNECTING;
+  if (ssl_sock->base_socket->event_queue) {
+    return true;
+  }
 
   /* Wait for connection to establish */
   D("SSL: waiting for connection");
@@ -569,24 +579,7 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
 
   if (ssl_sock->state == SSL_STATE_CONNECTED) {
     D("SSL: connected");
-    if (!ssl_sock->base_socket->recv_buf) {
-      ssl_sock->base_socket->recv_buf = (char *)picorb_alloc(vm, SSL_RECV_BUF_SIZE + 1);
-      if (!ssl_sock->base_socket->recv_buf) {
-        Net_set_last_error("SSL recv buffer allocation failed");
-        lwip_begin();
-        altcp_abort(ssl_sock->tls_pcb);
-        lwip_end();
-        ssl_sock->tls_pcb = NULL;
-        if (ssl_sock->ssl_ctx->tls_config == tls_config) {
-          ssl_sock->ssl_ctx->tls_config = NULL;
-        }
-        altcp_tls_free_config(tls_config);
-        return false;
-      }
-      ssl_sock->base_socket->recv_capacity = SSL_RECV_BUF_SIZE;
-      ssl_sock->base_socket->recv_len = 0;
-    }
-    return true;
+    return SSLSocket_finish_connect(vm, ssl_sock);
   } else {
     D("SSL: timeout or error, state=%d", ssl_sock->state);
     if (!Net_get_last_error()[0]) {
@@ -606,6 +599,40 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
     ssl_sock->state = SSL_STATE_ERROR;
     return false;
   }
+}
+
+int
+SSLSocket_connection_state(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  (void)vm;
+  return ssl_sock ? ssl_sock->state : SSL_STATE_ERROR;
+}
+
+bool
+SSLSocket_finish_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
+{
+  if (!ssl_sock || ssl_sock->state != SSL_STATE_CONNECTED || !ssl_sock->base_socket) {
+    return false;
+  }
+  if (ssl_sock->base_socket->recv_buf) {
+    return true;
+  }
+
+  ssl_sock->base_socket->recv_buf = (char *)picorb_alloc(vm, SSL_RECV_BUF_SIZE + 1);
+  if (!ssl_sock->base_socket->recv_buf) {
+    Net_set_last_error("SSL recv buffer allocation failed");
+    return false;
+  }
+  ssl_sock->base_socket->recv_capacity = SSL_RECV_BUF_SIZE;
+  ssl_sock->base_socket->recv_len = 0;
+  ssl_sock->base_socket->event_pending = false;
+  return true;
+}
+
+picorb_socket_t*
+SSLSocket_event_socket(picorb_ssl_socket_t *ssl_sock)
+{
+  return ssl_sock ? ssl_sock->base_socket : NULL;
 }
 
 ssize_t
@@ -720,6 +747,11 @@ SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   }
 
   if (ssl_sock->base_socket) {
+    SSLSocket_notify_readable(ssl_sock);
+    if (ssl_sock->base_socket->event_queue) {
+      picorb_free(vm, ssl_sock->base_socket->event_queue);
+      ssl_sock->base_socket->event_queue = NULL;
+    }
     if (ssl_sock->base_socket->recv_buf) {
       picorb_free(vm, ssl_sock->base_socket->recv_buf);
     }

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -120,14 +120,14 @@ ssl_connected_callback(void *arg, struct altcp_pcb *pcb, err_t err)
     Net_set_last_error("SSL connect callback failed: %s (%d)", lwip_err_name(err), (int)err);
     ssl_sock->state = SSL_STATE_ERROR;
     ssl_sock->connected = false;
-    SSLSocket_notify_readable(ssl_sock);
+    picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
     return err;
   }
 
   D("SSL callback: success");
   ssl_sock->state = SSL_STATE_CONNECTED;
   ssl_sock->connected = true;
-  SSLSocket_notify_readable(ssl_sock);
+  picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
   return ERR_OK;
 }
 
@@ -142,7 +142,7 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     ssl_sock->state = SSL_STATE_ERROR;
     ssl_sock->connected = false;
-    SSLSocket_notify_readable(ssl_sock);
+    picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
     return err;
   }
 
@@ -150,7 +150,7 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   if (!pbuf) {
     ssl_sock->state = SSL_STATE_NONE;
     ssl_sock->connected = false;
-    SSLSocket_notify_readable(ssl_sock);
+    picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
     return ERR_OK;
   }
 
@@ -183,7 +183,7 @@ ssl_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   /* Tell LwIP we processed the data */
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
-  SSLSocket_notify_readable(ssl_sock);
+  picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
 
   return ERR_OK;
 }
@@ -207,7 +207,7 @@ ssl_err_callback(void *arg, err_t err)
   ssl_sock->state = SSL_STATE_ERROR;
   ssl_sock->connected = false;
   ssl_sock->tls_pcb = NULL;  /* PCB is already freed by LwIP */
-  SSLSocket_notify_readable(ssl_sock);
+  picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
 }
 
 static err_t
@@ -540,10 +540,6 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   altcp_poll(ssl_sock->tls_pcb, ssl_poll_callback, 10);
   altcp_arg(ssl_sock->tls_pcb, ssl_sock);
 
-  /* Small delay before connecting (like picoruby-net's function boundary) */
-  D("SSL: waiting before connect");
-  Net_busy_wait_ms(100);
-
   ssl_sock->state = SSL_STATE_CONNECTING;
 
   /* Initiate connection */
@@ -747,7 +743,7 @@ SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   }
 
   if (ssl_sock->base_socket) {
-    SSLSocket_notify_readable(ssl_sock);
+  picorb_socket_notify_readable(SSLSocket_event_socket(ssl_sock));
     if (ssl_sock->base_socket->event_queue) {
       picorb_free(vm, ssl_sock->base_socket->event_queue);
       ssl_sock->base_socket->event_queue = NULL;

--- a/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/ssl_socket.c
@@ -50,6 +50,7 @@ struct picorb_ssl_socket {
   int state;
   bool connected;
   char *hostname;
+  char *connect_hostname;
   int port;
 };
 
@@ -385,6 +386,7 @@ SSLSocket_create(picorb_state *vm, picorb_ssl_context_t *ssl_ctx)
   ssl_sock->state = SSL_STATE_NONE;
   ssl_sock->connected = false;
   ssl_sock->hostname = NULL;
+  ssl_sock->connect_hostname = NULL;
   ssl_sock->port = 0;
 
   return ssl_sock;
@@ -406,6 +408,27 @@ SSLSocket_set_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock, const ch
     return false;
   }
   strcpy(ssl_sock->hostname, hostname);
+
+  return true;
+}
+
+bool
+SSLSocket_set_connect_hostname(picorb_state *vm, picorb_ssl_socket_t *ssl_sock,
+                               const char *hostname)
+{
+  if (!ssl_sock || !hostname) {
+    return false;
+  }
+
+  if (ssl_sock->connect_hostname) {
+    picorb_free(vm, ssl_sock->connect_hostname);
+  }
+
+  ssl_sock->connect_hostname = (char *)picorb_alloc(vm, strlen(hostname) + 1);
+  if (!ssl_sock->connect_hostname) {
+    return false;
+  }
+  strcpy(ssl_sock->connect_hostname, hostname);
 
   return true;
 }
@@ -445,7 +468,10 @@ SSLSocket_connect(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   /* Resolve hostname to IP */
   ip_addr_t ip_addr;
   ip4_addr_set_zero(&ip_addr);
-  int dns_result = Net_get_ip(ssl_sock->hostname, &ip_addr);
+  const char *connect_hostname = ssl_sock->connect_hostname
+                                   ? ssl_sock->connect_hostname
+                                   : ssl_sock->hostname;
+  int dns_result = Net_get_ip(connect_hostname, &ip_addr);
   if (dns_result != 0) {
     D("SSL: DNS failed");
     return false;
@@ -740,6 +766,10 @@ SSLSocket_close(picorb_state *vm, picorb_ssl_socket_t *ssl_sock)
   if (ssl_sock->hostname) {
     picorb_free(vm, ssl_sock->hostname);
     ssl_sock->hostname = NULL;
+  }
+  if (ssl_sock->connect_hostname) {
+    picorb_free(vm, ssl_sock->connect_hostname);
+    ssl_sock->connect_hostname = NULL;
   }
 
   if (ssl_sock->base_socket) {

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
@@ -57,7 +57,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
-    TCPSocket_notify_readable(sock);
+    picorb_socket_notify_readable(sock);
     D("tcp_server.c tcp_recv_callback: error, state set to ERROR");
     return err;
   }
@@ -67,7 +67,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     sock->state = SOCKET_STATE_CLOSED;
     sock->connected = false;
     sock->closed = true;
-    TCPSocket_notify_readable(sock);
+    picorb_socket_notify_readable(sock);
     D("tcp_server.c tcp_recv_callback: connection closed");
     return ERR_OK;
   }
@@ -99,7 +99,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
 
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
   D("tcp_server.c tcp_recv_callback: success, total recv_len=%zu\n", sock->recv_len);
   return ERR_OK;
 }
@@ -122,7 +122,7 @@ tcp_err_callback(void *arg, err_t err)
   sock->state = SOCKET_STATE_ERROR;
   sock->connected = false;
   sock->pcb = NULL; /* PCB is already freed by LwIP */
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
 }
 
 /* Accept callback - runs in LwIP callback context (may be IRQ/PendSV).

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
@@ -28,6 +28,8 @@ struct picorb_tcp_server {
   picorb_socket_t *accepted_socket;
   picorb_socket_t *pending_socket; /* pre-allocated, ready for next accept */
   picorb_state *vm;
+  void *event_queue;
+  bool event_pending;
   int port;
   int state;
 };
@@ -161,6 +163,7 @@ tcp_accept_callback(void *arg, struct altcp_pcb *newpcb, err_t err)
   altcp_recv(newpcb, tcp_recv_callback);
   altcp_sent(newpcb, tcp_sent_callback);
   altcp_err(newpcb, tcp_err_callback);
+  TCPServer_notify_accepted(server);
 
   return ERR_OK;
 }
@@ -293,6 +296,7 @@ TCPServer_accept_nonblock(picorb_state *vm, picorb_tcp_server_t *server)
   /* Clear from server */
   server->accepted_socket = NULL;
   server->state = 0;
+  server->event_pending = false;
 
   /* Replenish pending_socket for the next accepted connection. */
   if (!server->pending_socket) {
@@ -353,6 +357,11 @@ TCPServer_close(picorb_state *vm, picorb_tcp_server_t *server)
     Net_busy_wait_ms(50);
   }
 
+  TCPServer_notify_accepted(server);
+  if (server->event_queue) {
+    picorb_free(vm, server->event_queue);
+    server->event_queue = NULL;
+  }
   picorb_free(vm, server);
   return true;
 }
@@ -375,4 +384,36 @@ TCPServer_listening(picorb_state *vm, picorb_tcp_server_t *server)
     return false;
   }
   return server->listen_pcb != NULL;
+}
+
+void
+TCPServer_set_event_queue(picorb_tcp_server_t *server, picorb_state *vm, void *queue)
+{
+  if (!server) return;
+  server->vm = vm;
+  server->event_queue = queue;
+}
+
+void*
+TCPServer_event_queue(picorb_tcp_server_t *server)
+{
+  return server ? server->event_queue : NULL;
+}
+
+picorb_state*
+TCPServer_vm(picorb_tcp_server_t *server)
+{
+  return server ? server->vm : NULL;
+}
+
+bool
+TCPServer_event_pending(picorb_tcp_server_t *server)
+{
+  return server && server->event_pending;
+}
+
+void
+TCPServer_set_event_pending(picorb_tcp_server_t *server, bool pending)
+{
+  if (server) server->event_pending = pending;
 }

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_server.c
@@ -57,6 +57,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
+    TCPSocket_notify_readable(sock);
     D("tcp_server.c tcp_recv_callback: error, state set to ERROR");
     return err;
   }
@@ -66,6 +67,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     sock->state = SOCKET_STATE_CLOSED;
     sock->connected = false;
     sock->closed = true;
+    TCPSocket_notify_readable(sock);
     D("tcp_server.c tcp_recv_callback: connection closed");
     return ERR_OK;
   }
@@ -97,6 +99,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
 
+  TCPSocket_notify_readable(sock);
   D("tcp_server.c tcp_recv_callback: success, total recv_len=%zu\n", sock->recv_len);
   return ERR_OK;
 }
@@ -119,6 +122,7 @@ tcp_err_callback(void *arg, err_t err)
   sock->state = SOCKET_STATE_ERROR;
   sock->connected = false;
   sock->pcb = NULL; /* PCB is already freed by LwIP */
+  TCPSocket_notify_readable(sock);
 }
 
 /* Accept callback - runs in LwIP callback context (may be IRQ/PendSV).

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -102,6 +102,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
+    TCPSocket_notify_readable(sock);
     D("tcp_recv_callback: error, state set to ERROR");
     return err;
   }
@@ -111,6 +112,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     sock->state = SOCKET_STATE_CLOSED;
     sock->connected = false;
     sock->closed = true;
+    TCPSocket_notify_readable(sock);
     D("tcp_recv_callback: connection closed");
     return ERR_OK;
   }
@@ -141,6 +143,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   /* Tell LwIP we processed the data */
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
+  TCPSocket_notify_readable(sock);
 
   return ERR_OK;
 }
@@ -165,6 +168,7 @@ tcp_err_callback(void *arg, err_t err)
   sock->state = SOCKET_STATE_ERROR;
   sock->connected = false;
   sock->pcb = NULL; /* PCB is already freed by LwIP */
+  TCPSocket_notify_readable(sock);
 }
 
 /* Poll callback - called periodically by LwIP */
@@ -391,6 +395,12 @@ TCPSocket_close(picorb_state *vm, picorb_socket_t *sock)
   if (sock->recv_buf) {
     picorb_free(vm, sock->recv_buf);
     sock->recv_buf = NULL;
+  }
+
+  TCPSocket_notify_readable(sock);
+  if (sock->event_queue) {
+    picorb_free(vm, sock->event_queue);
+    sock->event_queue = NULL;
   }
 
   sock->state = SOCKET_STATE_CLOSED;

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -75,11 +75,14 @@ tcp_connected_callback(void *arg, struct altcp_pcb *pcb, err_t err)
   if (err != ERR_OK) {
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
+    snprintf(sock->errmsg, sizeof(sock->errmsg), "connect failed: %d", (int)err);
+    TCPSocket_notify_readable(sock);
     return err;
   }
 
   sock->state = SOCKET_STATE_CONNECTED;
   sock->connected = true;
+  TCPSocket_notify_readable(sock);
   return ERR_OK;
 }
 
@@ -224,6 +227,13 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
 
   Net_busy_wait_ms(100);
 
+  /* Set the state before starting the asynchronous connection so callbacks
+   * cannot be overwritten if the backend completes immediately. */
+  strncpy(sock->remote_host, host, sizeof(sock->remote_host) - 1);
+  sock->remote_host[sizeof(sock->remote_host) - 1] = '\0';
+  sock->remote_port = port;
+  sock->state = SOCKET_STATE_CONNECTING;
+
   /* Initiate connection */
   D("TCP: connecting");
   lwip_begin();
@@ -232,14 +242,14 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
 
   if (err != ERR_OK) {
     D("TCP: connect err=%d\n", err);
+    sock->state = SOCKET_STATE_ERROR;
+    snprintf(sock->errmsg, sizeof(sock->errmsg), "connect failed: %d", (int)err);
     return false;
   }
 
-  /* Save connection info */
-  strncpy(sock->remote_host, host, sizeof(sock->remote_host) - 1);
-  sock->remote_host[sizeof(sock->remote_host) - 1] = '\0';
-  sock->remote_port = port;
-  sock->state = SOCKET_STATE_CONNECTING;
+  if (sock->event_queue) {
+    return true;
+  }
 
   /* Wait for connection to establish */
   D("TCP: waiting");
@@ -263,6 +273,13 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
     sock->state = SOCKET_STATE_ERROR;
     return false;
   }
+}
+
+int
+TCPSocket_connection_state(picorb_state *vm, picorb_socket_t *sock)
+{
+  (void)vm;
+  return sock ? sock->state : SOCKET_STATE_ERROR;
 }
 
 /* Send data */

--- a/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/tcp_socket.c
@@ -76,13 +76,13 @@ tcp_connected_callback(void *arg, struct altcp_pcb *pcb, err_t err)
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
     snprintf(sock->errmsg, sizeof(sock->errmsg), "connect failed: %d", (int)err);
-    TCPSocket_notify_readable(sock);
+    picorb_socket_notify_readable(sock);
     return err;
   }
 
   sock->state = SOCKET_STATE_CONNECTED;
   sock->connected = true;
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
   return ERR_OK;
 }
 
@@ -105,7 +105,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     if (pbuf) pbuf_free(pbuf);
     sock->state = SOCKET_STATE_ERROR;
     sock->connected = false;
-    TCPSocket_notify_readable(sock);
+    picorb_socket_notify_readable(sock);
     D("tcp_recv_callback: error, state set to ERROR");
     return err;
   }
@@ -115,7 +115,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
     sock->state = SOCKET_STATE_CLOSED;
     sock->connected = false;
     sock->closed = true;
-    TCPSocket_notify_readable(sock);
+    picorb_socket_notify_readable(sock);
     D("tcp_recv_callback: connection closed");
     return ERR_OK;
   }
@@ -146,7 +146,7 @@ tcp_recv_callback(void *arg, struct altcp_pcb *pcb, struct pbuf *pbuf, err_t err
   /* Tell LwIP we processed the data */
   altcp_recved(pcb, total_len);
   pbuf_free(pbuf);
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
 
   return ERR_OK;
 }
@@ -171,7 +171,7 @@ tcp_err_callback(void *arg, err_t err)
   sock->state = SOCKET_STATE_ERROR;
   sock->connected = false;
   sock->pcb = NULL; /* PCB is already freed by LwIP */
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
 }
 
 /* Poll callback - called periodically by LwIP */
@@ -224,8 +224,6 @@ TCPSocket_connect(picorb_state *vm, picorb_socket_t *sock, const char *host, int
   altcp_err(sock->pcb, tcp_err_callback);
   altcp_poll(sock->pcb, tcp_poll_callback, 4);  /* Poll every 2 seconds (4 * 500ms) */
   altcp_arg(sock->pcb, sock);
-
-  Net_busy_wait_ms(100);
 
   /* Set the state before starting the asynchronous connection so callbacks
    * cannot be overwritten if the backend completes immediately. */
@@ -414,7 +412,7 @@ TCPSocket_close(picorb_state *vm, picorb_socket_t *sock)
     sock->recv_buf = NULL;
   }
 
-  TCPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
   if (sock->event_queue) {
     picorb_free(vm, sock->event_queue);
     sock->event_queue = NULL;

--- a/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
@@ -71,6 +71,7 @@ udp_recv_callback(void *arg, struct udp_pcb *pcb, struct pbuf *pbuf,
   sock->recv_buf[sock->recv_len] = '\0';
 
   pbuf_free(pbuf);
+  UDPSocket_notify_readable(sock);
 }
 
 /* Create UDP socket */
@@ -287,6 +288,11 @@ UDPSocket_close(picorb_state *vm, picorb_socket_t *sock)
   if (sock->recv_buf) {
     picorb_free(vm, sock->recv_buf);
     sock->recv_buf = NULL;
+  }
+
+  if (sock->event_queue) {
+    picorb_free(vm, sock->event_queue);
+    sock->event_queue = NULL;
   }
 
   sock->state = SOCKET_STATE_CLOSED;

--- a/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
@@ -290,6 +290,7 @@ UDPSocket_close(picorb_state *vm, picorb_socket_t *sock)
     sock->recv_buf = NULL;
   }
 
+  UDPSocket_notify_readable(sock);
   if (sock->event_queue) {
     picorb_free(vm, sock->event_queue);
     sock->event_queue = NULL;

--- a/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
+++ b/mrbgems/picoruby-socket/ports/rp2040/udp_socket.c
@@ -71,7 +71,7 @@ udp_recv_callback(void *arg, struct udp_pcb *pcb, struct pbuf *pbuf,
   sock->recv_buf[sock->recv_len] = '\0';
 
   pbuf_free(pbuf);
-  UDPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
 }
 
 /* Create UDP socket */
@@ -290,7 +290,7 @@ UDPSocket_close(picorb_state *vm, picorb_socket_t *sock)
     sock->recv_buf = NULL;
   }
 
-  UDPSocket_notify_readable(sock);
+  picorb_socket_notify_readable(sock);
   if (sock->event_queue) {
     picorb_free(vm, sock->event_queue);
     sock->event_queue = NULL;

--- a/mrbgems/picoruby-socket/sig/basic_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/basic_socket.rbs
@@ -3,6 +3,7 @@ end
 
 class BasicSocket
   CONNECTION_TIMEOUT_MS: Integer
+  READ_TIMEOUT_MS: Integer
 
   def puts: (*untyped args) -> nil
   def gets: (?String sep) -> String?
@@ -24,5 +25,5 @@ class BasicSocket
   private def __connection_timeout_ms: () -> Integer
   private def __wait_for_event: (untyped event_queue, String timeout_message) -> void
   private def __readpartial_poll: (Integer maxlen) -> String
-  private def __readpartial_event_queue: (Integer maxlen, String timeout_message, String failure_message) -> String
+  private def __readpartial_event_queue: (Integer maxlen, String timeout_message) -> String
 end

--- a/mrbgems/picoruby-socket/sig/basic_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/basic_socket.rbs
@@ -2,6 +2,8 @@ class SocketError < StandardError
 end
 
 class BasicSocket
+  CONNECTION_TIMEOUT_MS: Integer
+
   def puts: (*untyped args) -> nil
   def gets: (?String sep) -> String?
   def print: (*untyped args) -> nil
@@ -19,4 +21,8 @@ class BasicSocket
   def close: () -> void
   def remote_host: () -> String
   def remote_port: () -> Integer
+  private def __connection_timeout_ms: () -> Integer
+  private def __wait_for_event: (untyped event_queue, String timeout_message) -> void
+  private def __readpartial_poll: (Integer maxlen) -> String
+  private def __readpartial_event_queue: (Integer maxlen, String timeout_message, String failure_message) -> String
 end

--- a/mrbgems/picoruby-socket/sig/dns_resolver.rbs
+++ b/mrbgems/picoruby-socket/sig/dns_resolver.rbs
@@ -1,0 +1,10 @@
+class SocketDNSResolver
+  @event_queue: Task::Queue
+
+  def self.resolve: (String host) -> String
+  def initialize: (String host) -> void
+  def resolve: (String host) -> String
+  private def __status: () -> Integer
+  private def __release: () -> nil
+  private def __abandon: () -> nil
+end

--- a/mrbgems/picoruby-socket/sig/dns_resolver.rbs
+++ b/mrbgems/picoruby-socket/sig/dns_resolver.rbs
@@ -1,7 +1,7 @@
 class SocketDNSResolver
   @event_queue: Task::Queue
 
-  def self.resolve: (String host) -> String
+  def self.resolve_host: (String host) -> String
   def initialize: (String host) -> void
   def resolve: (String host) -> String
   private def __status: () -> Integer

--- a/mrbgems/picoruby-socket/sig/dns_resolver.rbs
+++ b/mrbgems/picoruby-socket/sig/dns_resolver.rbs
@@ -5,6 +5,7 @@ class SocketDNSResolver
   def initialize: (String host) -> void
   def resolve: (String host) -> String
   private def __status: () -> Integer
+  private def __address: () -> String?
   private def __release: () -> nil
   private def __abandon: () -> nil
 end

--- a/mrbgems/picoruby-socket/sig/ssl_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/ssl_socket.rbs
@@ -10,7 +10,6 @@ class SSLSocket < BasicSocket
   def connect: () -> self
   private def __connect_poll: () -> self
   private def __connection_state: () -> Integer
-  private def __connection_timeout_ms: () -> Integer
   private def __finish_connect: () -> bool
   private def __error_message: () -> String?
   private def __readpartial_poll: (Integer maxlen) -> String

--- a/mrbgems/picoruby-socket/sig/ssl_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/ssl_socket.rbs
@@ -6,9 +6,11 @@ class SSLSocket < BasicSocket
 
   def self.new: (TCPSocket tcp_socket, SSLContext ssl_context) -> SSLSocket
   def self.open: (String hostname, Integer port, SSLContext ssl_context) -> SSLSocket
+  private def self.__open_poll: (String hostname, Integer port, SSLContext ssl_context) -> SSLSocket
   def connect: () -> self
   private def __connect_poll: () -> self
   private def __connection_state: () -> Integer
+  private def __connection_timeout_ms: () -> Integer
   private def __finish_connect: () -> bool
   private def __error_message: () -> String?
   private def __readpartial_poll: (Integer maxlen) -> String

--- a/mrbgems/picoruby-socket/sig/ssl_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/ssl_socket.rbs
@@ -8,6 +8,7 @@ class SSLSocket < BasicSocket
   def self.open: (String hostname, Integer port, SSLContext ssl_context) -> SSLSocket
   private def self.__open_poll: (String hostname, Integer port, SSLContext ssl_context) -> SSLSocket
   def connect: () -> self
+  private def __set_connect_hostname: (String hostname) -> bool
   private def __connect_poll: () -> self
   private def __connection_state: () -> Integer
   private def __finish_connect: () -> bool

--- a/mrbgems/picoruby-socket/sig/ssl_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/ssl_socket.rbs
@@ -1,10 +1,17 @@
 class SSLSocket < BasicSocket
+  @event_queue: Task::Queue?
+
   attr_reader tcp_socket: TCPSocket
   attr_reader ssl_context: SSLContext
 
   def self.new: (TCPSocket tcp_socket, SSLContext ssl_context) -> SSLSocket
   def self.open: (String hostname, Integer port, SSLContext ssl_context) -> SSLSocket
   def connect: () -> self
+  private def __connect_poll: () -> self
+  private def __connection_state: () -> Integer
+  private def __finish_connect: () -> bool
+  private def __error_message: () -> String?
+  private def __readpartial_poll: (Integer maxlen) -> String
   def addr: () -> Array[String | Integer]
   def connected?: () -> bool
   def peer_cert: () -> nil

--- a/mrbgems/picoruby-socket/sig/tcp_server.rbs
+++ b/mrbgems/picoruby-socket/sig/tcp_server.rbs
@@ -1,4 +1,6 @@
 class TCPServer
+  @event_queue: Task::Queue?
+
   def self.new: (String? host, Integer service, ?Integer backlog) -> TCPServer
   def accept: () -> TCPSocket
   def accept_nonblock: () -> (TCPSocket | nil)

--- a/mrbgems/picoruby-socket/sig/tcp_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/tcp_socket.rbs
@@ -8,6 +8,7 @@ class TCPSocket < BasicSocket
   def initialize: (String host, Integer port) -> void
   private def __initialize_poll: (String host, Integer port) -> void
   private def __connection_state: () -> Integer
+  private def __connection_timeout_ms: () -> Integer
   private def __error_message: () -> String?
   private def __readpartial_poll: (Integer maxlen) -> String
 

--- a/mrbgems/picoruby-socket/sig/tcp_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/tcp_socket.rbs
@@ -8,7 +8,6 @@ class TCPSocket < BasicSocket
   def initialize: (String host, Integer port) -> void
   private def __initialize_poll: (String host, Integer port) -> void
   private def __connection_state: () -> Integer
-  private def __connection_timeout_ms: () -> Integer
   private def __error_message: () -> String?
   private def __readpartial_poll: (Integer maxlen) -> String
 

--- a/mrbgems/picoruby-socket/sig/tcp_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/tcp_socket.rbs
@@ -1,7 +1,16 @@
 class TCPSocket < BasicSocket
+  @event_queue: Task::Queue?
+
   def self.new: (String host, Integer port) -> TCPSocket
   def self.open: (String host, Integer port) -> TCPSocket
   def self.gethostbyname: (String host) -> [String, Array[String], Integer, String]
+
+  def initialize: (String host, Integer port) -> void
+  private def __initialize_poll: (String host, Integer port) -> void
+  private def __connection_state: () -> Integer
+  private def __error_message: () -> String?
+  private def __readpartial_poll: (Integer maxlen) -> String
+
   def addr: () -> Array[String | Integer]
   def connected?: () -> bool
 end

--- a/mrbgems/picoruby-socket/sig/udp_socket.rbs
+++ b/mrbgems/picoruby-socket/sig/udp_socket.rbs
@@ -3,6 +3,9 @@ class UDPSocket < BasicSocket
   def bind: (String host, Integer port) -> void
   def connect: (String host, Integer port) -> void
   def send: (String data, Integer flags, ?String? host, ?Integer? port) -> Integer
+  private def __bind_resolved: (String host, Integer port) -> void
+  private def __connect_resolved: (String host, Integer port) -> void
+  private def __send_resolved: (String data, Integer flags, ?String? host, ?Integer? port) -> Integer
   def recvfrom: (Integer maxlen, ?Integer flags) -> [String, Array[String | Integer]]
   def recvfrom_nonblock: (Integer maxlen, ?Integer flags) -> ([String, Array[String | Integer]] | nil)
 

--- a/mrbgems/picoruby-socket/src/mruby/socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/socket.c
@@ -80,6 +80,19 @@ mrb_dns_resolver_status(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_dns_resolver_address(mrb_state *mrb, mrb_value self)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)
+    mrb_data_get_ptr(mrb, self, &mrb_dns_resolver_type);
+  char address[40];
+
+  if (Net_dns_get_address(resolver->request, address, sizeof(address)) != 0) {
+    return mrb_nil_value();
+  }
+  return mrb_str_new_cstr(mrb, address);
+}
+
+static mrb_value
 mrb_dns_resolver_release(mrb_state *mrb, mrb_value self)
 {
   mrb_dns_resolver *resolver = (mrb_dns_resolver *)
@@ -113,6 +126,8 @@ mrb_init_dns_resolver(mrb_state *mrb)
                        mrb_dns_resolver_initialize, MRB_ARGS_REQ(1));
   mrb_define_private_method_id(mrb, resolver, MRB_SYM(__status),
                                mrb_dns_resolver_status, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, resolver, MRB_SYM(__address),
+                               mrb_dns_resolver_address, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, resolver, MRB_SYM(__release),
                                mrb_dns_resolver_release, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, resolver, MRB_SYM(__abandon),

--- a/mrbgems/picoruby-socket/src/mruby/socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/socket.c
@@ -1,6 +1,11 @@
 #include "../../include/socket.h"
 #include "mruby/presym.h"
+#include "mruby/class.h"
 #include "mruby/data.h"
+#include "mruby/variable.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "task.h"
+#endif
 
 /* Socket type constants (matching socket.h) */
 #if defined(PICORB_PLATFORM_POSIX)
@@ -13,6 +18,107 @@
 const struct mrb_data_type mrb_socket_type = {
   "Socket", mrb_socket_free,
 };
+
+#ifdef PICO_CYW43_ARCH_POLL
+typedef struct {
+  mrb_state *mrb;
+  mrb_value queue;
+  void *request;
+} mrb_dns_resolver;
+
+static void
+mrb_dns_resolver_notify(void *arg)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)arg;
+  if (!resolver) return;
+  mrb_task_queue_push(resolver->mrb, resolver->queue, mrb_true_value());
+}
+
+static void
+mrb_dns_resolver_free(mrb_state *mrb, void *ptr)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)ptr;
+  if (!resolver) return;
+  if (resolver->request) Net_dns_abandon(resolver->request);
+  mrb_free(mrb, resolver);
+}
+
+static const struct mrb_data_type mrb_dns_resolver_type = {
+  "Socket::DNSResolver", mrb_dns_resolver_free,
+};
+
+static mrb_value
+mrb_dns_resolver_initialize(mrb_state *mrb, mrb_value self)
+{
+  const char *name;
+  mrb_get_args(mrb, "z", &name);
+
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)mrb_malloc(mrb, sizeof(*resolver));
+  resolver->mrb = mrb;
+  resolver->queue = queue;
+  resolver->request = Net_dns_start(name, mrb_dns_resolver_notify, resolver);
+  if (!resolver->request) {
+    mrb_free(mrb, resolver);
+    mrb_raise(mrb, E_RUNTIME_ERROR, Net_get_last_error());
+  }
+
+  mrb_data_init(self, resolver, &mrb_dns_resolver_type);
+  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
+  return self;
+}
+
+static mrb_value
+mrb_dns_resolver_status(mrb_state *mrb, mrb_value self)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)
+    mrb_data_get_ptr(mrb, self, &mrb_dns_resolver_type);
+  return mrb_fixnum_value(Net_dns_status(resolver->request));
+}
+
+static mrb_value
+mrb_dns_resolver_release(mrb_state *mrb, mrb_value self)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)
+    mrb_data_get_ptr(mrb, self, &mrb_dns_resolver_type);
+  if (resolver->request) {
+    Net_dns_release(resolver->request);
+    resolver->request = NULL;
+  }
+  return mrb_nil_value();
+}
+
+static mrb_value
+mrb_dns_resolver_abandon(mrb_state *mrb, mrb_value self)
+{
+  mrb_dns_resolver *resolver = (mrb_dns_resolver *)
+    mrb_data_get_ptr(mrb, self, &mrb_dns_resolver_type);
+  if (resolver->request) {
+    Net_dns_abandon(resolver->request);
+    resolver->request = NULL;
+  }
+  return mrb_nil_value();
+}
+
+static void
+mrb_init_dns_resolver(mrb_state *mrb)
+{
+  struct RClass *resolver = mrb_define_class_id(
+    mrb, MRB_SYM(SocketDNSResolver), mrb->object_class);
+  MRB_SET_INSTANCE_TT(resolver, MRB_TT_DATA);
+  mrb_define_method_id(mrb, resolver, MRB_SYM(initialize),
+                       mrb_dns_resolver_initialize, MRB_ARGS_REQ(1));
+  mrb_define_private_method_id(mrb, resolver, MRB_SYM(__status),
+                               mrb_dns_resolver_status, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, resolver, MRB_SYM(__release),
+                               mrb_dns_resolver_release, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, resolver, MRB_SYM(__abandon),
+                               mrb_dns_resolver_abandon, MRB_ARGS_NONE());
+}
+#endif
 
 /* Data type for sockets (shared by TCP and UDP) */
 void
@@ -40,6 +146,10 @@ mrb_picoruby_socket_gem_init(mrb_state *mrb)
 
   /* BasicSocket class */
   basic_socket_class = mrb_define_class_id(mrb, MRB_SYM(BasicSocket), mrb->object_class);
+
+#ifdef PICO_CYW43_ARCH_POLL
+  mrb_init_dns_resolver(mrb);
+#endif
 
   /* Initialize each socket type */
   tcp_socket_init(mrb, basic_socket_class);

--- a/mrbgems/picoruby-socket/src/mruby/socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/socket.c
@@ -20,6 +20,50 @@ const struct mrb_data_type mrb_socket_type = {
 };
 
 #ifdef PICO_CYW43_ARCH_POLL
+void
+picorb_task_queue_notify(mrb_state *mrb, void *queue_ptr, bool *pending)
+{
+  if (!queue_ptr || !pending || *pending) return;
+  mrb_value queue = *(mrb_value *)queue_ptr;
+  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
+    *pending = true;
+  }
+}
+
+bool
+picorb_task_queue_attach(mrb_state *mrb, void *self_ptr, void **queue_ptr)
+{
+  mrb_value *self = (mrb_value *)self_ptr;
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+
+  mrb_iv_set(mrb, *self, MRB_IVSYM(event_queue), queue);
+  *queue_ptr = mrb_malloc(mrb, sizeof(mrb_value));
+  if (!*queue_ptr) return false;
+  *(mrb_value *)*queue_ptr = queue;
+  return true;
+}
+
+bool
+picorb_socket_attach_event_queue(mrb_state *mrb, void *self_ptr,
+                                 picorb_socket_t *sock)
+{
+  if (!picorb_task_queue_attach(mrb, self_ptr, &sock->event_queue)) return false;
+  sock->vm = mrb;
+  return true;
+}
+
+void
+picorb_socket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock) return;
+  picorb_task_queue_notify((mrb_state *)sock->vm, sock->event_queue,
+                           &sock->event_pending);
+}
+#endif
+
+#ifdef PICO_CYW43_ARCH_POLL
 typedef struct {
   mrb_state *mrb;
   mrb_value queue;

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -707,16 +707,6 @@ mrb_ssl_socket_ready_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(SSLSocket_ready(mrb, ssl_sock));
 }
 
-static mrb_value
-mrb_ssl_socket_connection_timeout_ms(mrb_state *mrb, mrb_value self)
-{
-#ifdef PICORB_DEBUG
-  return mrb_fixnum_value(30000);
-#else
-  return mrb_fixnum_value(10000);
-#endif
-}
-
 void
 ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 {
@@ -757,7 +747,6 @@ ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 #ifdef PICO_CYW43_ARCH_POLL
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connect_poll), mrb_ssl_socket_connect, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_state), mrb_ssl_socket_connection_state, MRB_ARGS_NONE());
-  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_timeout_ms), mrb_ssl_socket_connection_timeout_ms, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__finish_connect), mrb_ssl_socket_finish_connect, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__error_message), mrb_ssl_socket_error_message, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__readpartial_poll), mrb_ssl_socket_readpartial, MRB_ARGS_REQ(1));

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -460,6 +460,23 @@ mrb_ssl_socket_connect(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+#ifdef PICO_CYW43_ARCH_POLL
+static mrb_value
+mrb_ssl_socket_set_connect_hostname(mrb_state *mrb, mrb_value self)
+{
+  char *hostname;
+  mrb_get_args(mrb, "z", &hostname);
+
+  picorb_ssl_socket_t *ssl_sock = (picorb_ssl_socket_t *)mrb_data_get_ptr(
+    mrb, self, &mrb_ssl_socket_type);
+  if (!ssl_sock || !SSLSocket_set_connect_hostname(mrb, ssl_sock, hostname)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "failed to set connect hostname");
+  }
+
+  return mrb_true_value();
+}
+#endif
+
 static mrb_value
 mrb_ssl_socket_connection_state(mrb_state *mrb, mrb_value self)
 {
@@ -745,6 +762,10 @@ ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   mrb_define_class_method_id(mrb, ssl_socket_class, MRB_SYM(open), mrb_ssl_socket_s_open, MRB_ARGS_REQ(3));
 #endif
 #ifdef PICO_CYW43_ARCH_POLL
+  mrb_define_private_method_id(mrb, ssl_socket_class,
+                               MRB_SYM(__set_connect_hostname),
+                               mrb_ssl_socket_set_connect_hostname,
+                               MRB_ARGS_REQ(1));
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connect_poll), mrb_ssl_socket_connect, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_state), mrb_ssl_socket_connection_state, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__finish_connect), mrb_ssl_socket_finish_connect, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -12,40 +12,6 @@
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
 #define E_EOF_ERROR    (mrb_class_get_id(mrb, MRB_SYM(EOFError)))
 
-#ifdef PICO_CYW43_ARCH_POLL
-void
-SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
-{
-  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrb_value queue = *(mrb_value *)sock->event_queue;
-  mrb_state *mrb = (mrb_state *)sock->vm;
-  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-
-static void
-mrb_ssl_socket_attach_event_queue(mrb_state *mrb, mrb_value self,
-                                  picorb_ssl_socket_t *ssl_sock)
-{
-  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
-  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
-  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
-  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
-  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
-  sock->vm = mrb;
-  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
-  *(mrb_value *)sock->event_queue = queue;
-}
-#else
-void
-SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
-{
-  (void)ssl_sock;
-}
-#endif
-
 /* Data type for SSLContext */
 static void
 mrb_ssl_context_free(mrb_state *mrb, void *ptr)
@@ -398,7 +364,8 @@ mrb_ssl_socket_initialize(mrb_state *mrb, mrb_value self)
   mrb_data_init(self, ssl_sock, &mrb_ssl_socket_type);
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrb_ssl_socket_attach_event_queue(mrb, self, ssl_sock);
+  picorb_socket_attach_event_queue(mrb, &self,
+                                   SSLSocket_event_socket(ssl_sock));
 #endif
 
   return self;
@@ -442,7 +409,8 @@ mrb_ssl_socket_s_open(mrb_state *mrb, mrb_value klass)
   struct RData *data = mrb_data_object_alloc(mrb, cls, ssl_sock, &mrb_ssl_socket_type);
   mrb_value self = mrb_obj_value(data);
   mrb_iv_set(mrb, self, MRB_IVSYM(ssl_context), ssl_context_obj);
-  mrb_ssl_socket_attach_event_queue(mrb, self, ssl_sock);
+  picorb_socket_attach_event_queue(mrb, &self,
+                                   SSLSocket_event_socket(ssl_sock));
   return self;
 #else
   if (!SSLSocket_connect(mrb, ssl_sock)) {

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -436,6 +436,15 @@ mrb_ssl_socket_s_open(mrb_state *mrb, mrb_value klass)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to set port");
   }
 
+#ifdef PICO_CYW43_ARCH_POLL
+  /* Create the instance before connecting so Ruby can wait on its Queue. */
+  struct RClass *cls = mrb_class_ptr(klass);
+  struct RData *data = mrb_data_object_alloc(mrb, cls, ssl_sock, &mrb_ssl_socket_type);
+  mrb_value self = mrb_obj_value(data);
+  mrb_iv_set(mrb, self, MRB_IVSYM(ssl_context), ssl_context_obj);
+  mrb_ssl_socket_attach_event_queue(mrb, self, ssl_sock);
+  return self;
+#else
   if (!SSLSocket_connect(mrb, ssl_sock)) {
 #if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
     const char *net_error = Net_get_last_error();
@@ -456,6 +465,7 @@ mrb_ssl_socket_s_open(mrb_state *mrb, mrb_value klass)
   mrb_iv_set(mrb, self, MRB_IVSYM(ssl_context), ssl_context_obj);
 
   return self;
+#endif
 }
 
 /* ssl_socket.connect */
@@ -618,8 +628,10 @@ mrb_ssl_socket_read_nonblock(mrb_state *mrb, mrb_value self)
   ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+#ifdef PICO_CYW43_ARCH_POLL
     picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
     if (sock) sock->event_pending = false;
+#endif
     if (read_buf != stack_buf) mrb_free(mrb, read_buf);
     return mrb_nil_value();
   }
@@ -727,6 +739,16 @@ mrb_ssl_socket_ready_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(SSLSocket_ready(mrb, ssl_sock));
 }
 
+static mrb_value
+mrb_ssl_socket_connection_timeout_ms(mrb_state *mrb, mrb_value self)
+{
+#ifdef PICORB_DEBUG
+  return mrb_fixnum_value(30000);
+#else
+  return mrb_fixnum_value(10000);
+#endif
+}
+
 void
 ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 {
@@ -759,13 +781,23 @@ ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   MRB_SET_INSTANCE_TT(ssl_socket_class, MRB_TT_DATA);
 
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(initialize), mrb_ssl_socket_initialize, MRB_ARGS_REQ(2));
+#ifdef PICO_CYW43_ARCH_POLL
+  mrb_define_class_method(mrb, ssl_socket_class, "__open_poll", mrb_ssl_socket_s_open, MRB_ARGS_REQ(3));
+#else
   mrb_define_class_method_id(mrb, ssl_socket_class, MRB_SYM(open), mrb_ssl_socket_s_open, MRB_ARGS_REQ(3));
+#endif
+#ifdef PICO_CYW43_ARCH_POLL
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connect_poll), mrb_ssl_socket_connect, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_state), mrb_ssl_socket_connection_state, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_timeout_ms), mrb_ssl_socket_connection_timeout_ms, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__finish_connect), mrb_ssl_socket_finish_connect, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__error_message), mrb_ssl_socket_error_message, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(send), mrb_ssl_socket_send, MRB_ARGS_REQ(2));
   mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__readpartial_poll), mrb_ssl_socket_readpartial, MRB_ARGS_REQ(1));
+#else
+  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(connect), mrb_ssl_socket_connect, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(readpartial), mrb_ssl_socket_readpartial, MRB_ARGS_REQ(1));
+#endif
+  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(send), mrb_ssl_socket_send, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(read_nonblock), mrb_ssl_socket_read_nonblock, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(close), mrb_ssl_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM_Q(closed), mrb_ssl_socket_closed_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/ssl_socket.c
@@ -5,9 +5,46 @@
 #include "mruby/data.h"
 #include "mruby/string.h"
 #include "mruby/variable.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "task.h"
+#endif
 
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
 #define E_EOF_ERROR    (mrb_class_get_id(mrb, MRB_SYM(EOFError)))
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
+{
+  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
+  if (!sock || !sock->event_queue || sock->event_pending) return;
+  mrb_value queue = *(mrb_value *)sock->event_queue;
+  mrb_state *mrb = (mrb_state *)sock->vm;
+  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
+}
+
+static void
+mrb_ssl_socket_attach_event_queue(mrb_state *mrb, mrb_value self,
+                                  picorb_ssl_socket_t *ssl_sock)
+{
+  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
+  sock->vm = mrb;
+  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
+  *(mrb_value *)sock->event_queue = queue;
+}
+#else
+void
+SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
+{
+  (void)ssl_sock;
+}
+#endif
 
 /* Data type for SSLContext */
 static void
@@ -360,6 +397,10 @@ mrb_ssl_socket_initialize(mrb_state *mrb, mrb_value self)
 
   mrb_data_init(self, ssl_sock, &mrb_ssl_socket_type);
 
+#ifdef PICO_CYW43_ARCH_POLL
+  mrb_ssl_socket_attach_event_queue(mrb, self, ssl_sock);
+#endif
+
   return self;
 }
 
@@ -439,6 +480,36 @@ mrb_ssl_socket_connect(mrb_state *mrb, mrb_value self)
   }
 
   return self;
+}
+
+static mrb_value
+mrb_ssl_socket_connection_state(mrb_state *mrb, mrb_value self)
+{
+  picorb_ssl_socket_t *ssl_sock;
+  ssl_sock = (picorb_ssl_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_ssl_socket_type);
+  if (!ssl_sock) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "SSL socket is not initialized");
+  }
+  return mrb_fixnum_value(SSLSocket_connection_state(mrb, ssl_sock));
+}
+
+static mrb_value
+mrb_ssl_socket_finish_connect(mrb_state *mrb, mrb_value self)
+{
+  picorb_ssl_socket_t *ssl_sock;
+  ssl_sock = (picorb_ssl_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_ssl_socket_type);
+  return mrb_bool_value(ssl_sock && SSLSocket_finish_connect(mrb, ssl_sock));
+}
+
+static mrb_value
+mrb_ssl_socket_error_message(mrb_state *mrb, mrb_value self)
+{
+  (void)self;
+#if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
+  const char *message = Net_get_last_error();
+  if (message && message[0]) return mrb_str_new_cstr(mrb, message);
+#endif
+  return mrb_nil_value();
 }
 
 /* ssl_socket.send(data, flags) */
@@ -547,6 +618,8 @@ mrb_ssl_socket_read_nonblock(mrb_state *mrb, mrb_value self)
   ssize_t received = SSLSocket_recv(mrb, ssl_sock, read_buf, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+    picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
+    if (sock) sock->event_pending = false;
     if (read_buf != stack_buf) mrb_free(mrb, read_buf);
     return mrb_nil_value();
   }
@@ -687,9 +760,12 @@ ssl_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(initialize), mrb_ssl_socket_initialize, MRB_ARGS_REQ(2));
   mrb_define_class_method_id(mrb, ssl_socket_class, MRB_SYM(open), mrb_ssl_socket_s_open, MRB_ARGS_REQ(3));
-  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(connect), mrb_ssl_socket_connect, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connect_poll), mrb_ssl_socket_connect, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__connection_state), mrb_ssl_socket_connection_state, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__finish_connect), mrb_ssl_socket_finish_connect, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__error_message), mrb_ssl_socket_error_message, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(send), mrb_ssl_socket_send, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(readpartial), mrb_ssl_socket_readpartial, MRB_ARGS_REQ(1));
+  mrb_define_private_method_id(mrb, ssl_socket_class, MRB_SYM(__readpartial_poll), mrb_ssl_socket_readpartial, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(read_nonblock), mrb_ssl_socket_read_nonblock, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM(close), mrb_ssl_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, ssl_socket_class, MRB_SYM_Q(closed), mrb_ssl_socket_closed_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/tcp_server.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_server.c
@@ -5,6 +5,30 @@
 #include "mruby/class.h"
 #include "mruby/data.h"
 #include "mruby/string.h"
+#include "mruby/variable.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "task.h"
+#endif
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+TCPServer_notify_accepted(picorb_tcp_server_t *server)
+{
+  void *queue_ptr = TCPServer_event_queue(server);
+  if (!queue_ptr || TCPServer_event_pending(server)) return;
+  mrb_state *mrb = (mrb_state *)TCPServer_vm(server);
+  mrb_value queue = *(mrb_value *)queue_ptr;
+  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
+    TCPServer_set_event_pending(server, true);
+  }
+}
+#else
+void
+TCPServer_notify_accepted(picorb_tcp_server_t *server)
+{
+  (void)server;
+}
+#endif
 
 /* Data type for TCPServer */
 static void
@@ -72,6 +96,16 @@ mrb_tcp_server_initialize(mrb_state *mrb, mrb_value self)
 
   mrb_data_init(self, server, &mrb_tcp_server_type);
 
+#ifdef PICO_CYW43_ARCH_POLL
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
+  void *queue_ptr = mrb_malloc(mrb, sizeof(mrb_value));
+  *(mrb_value *)queue_ptr = queue;
+  TCPServer_set_event_queue(server, mrb, queue_ptr);
+#endif
+
   return self;
 }
 
@@ -98,6 +132,16 @@ mrb_tcp_server_accept_nonblock(mrb_state *mrb, mrb_value self)
   /* Create TCPSocket object for client */
   tcp_socket_class = mrb_class_get_id(mrb, MRB_SYM(TCPSocket));
   client_obj = mrb_obj_value(mrb_data_object_alloc(mrb, tcp_socket_class, client, &mrb_socket_type));
+
+#ifdef PICO_CYW43_ARCH_POLL
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+  mrb_iv_set(mrb, client_obj, MRB_IVSYM(event_queue), queue);
+  client->vm = mrb;
+  client->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
+  *(mrb_value *)client->event_queue = queue;
+#endif
 
   return client_obj;
 }

--- a/mrbgems/picoruby-socket/src/mruby/tcp_server.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_server.c
@@ -15,18 +15,9 @@ void
 TCPServer_notify_accepted(picorb_tcp_server_t *server)
 {
   void *queue_ptr = TCPServer_event_queue(server);
-  if (!queue_ptr || TCPServer_event_pending(server)) return;
-  mrb_state *mrb = (mrb_state *)TCPServer_vm(server);
-  mrb_value queue = *(mrb_value *)queue_ptr;
-  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
-    TCPServer_set_event_pending(server, true);
-  }
-}
-#else
-void
-TCPServer_notify_accepted(picorb_tcp_server_t *server)
-{
-  (void)server;
+  bool pending = TCPServer_event_pending(server);
+  picorb_task_queue_notify(TCPServer_vm(server), queue_ptr, &pending);
+  TCPServer_set_event_pending(server, pending);
 }
 #endif
 
@@ -97,12 +88,12 @@ mrb_tcp_server_initialize(mrb_state *mrb, mrb_value self)
   mrb_data_init(self, server, &mrb_tcp_server_type);
 
 #ifdef PICO_CYW43_ARCH_POLL
-  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
-  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
-  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
-  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
-  void *queue_ptr = mrb_malloc(mrb, sizeof(mrb_value));
-  *(mrb_value *)queue_ptr = queue;
+  void *queue_ptr = NULL;
+  if (!picorb_task_queue_attach(mrb, &self, &queue_ptr)) {
+    TCPServer_close(mrb, server);
+    DATA_PTR(self) = NULL;
+    mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate event queue");
+  }
   TCPServer_set_event_queue(server, mrb, queue_ptr);
 #endif
 
@@ -134,13 +125,9 @@ mrb_tcp_server_accept_nonblock(mrb_state *mrb, mrb_value self)
   client_obj = mrb_obj_value(mrb_data_object_alloc(mrb, tcp_socket_class, client, &mrb_socket_type));
 
 #ifdef PICO_CYW43_ARCH_POLL
-  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
-  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
-  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
-  mrb_iv_set(mrb, client_obj, MRB_IVSYM(event_queue), queue);
-  client->vm = mrb;
-  client->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
-  *(mrb_value *)client->event_queue = queue;
+  if (!picorb_socket_attach_event_queue(mrb, &client_obj, client)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "failed to allocate event queue");
+  }
 #endif
 
   return client_obj;

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -286,16 +286,6 @@ mrb_tcp_socket_ready_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(Socket_ready(mrb, sock));
 }
 
-static mrb_value
-mrb_tcp_socket_connection_timeout_ms(mrb_state *mrb, mrb_value self)
-{
-#ifdef PICORB_DEBUG
-  return mrb_fixnum_value(30000);
-#else
-  return mrb_fixnum_value(10000);
-#endif
-}
-
 void
 tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 {
@@ -307,7 +297,6 @@ tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 #ifdef PICO_CYW43_ARCH_POLL
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__initialize_poll), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__connection_state), mrb_tcp_socket_connection_state, MRB_ARGS_NONE());
-  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__connection_timeout_ms), mrb_tcp_socket_connection_timeout_ms, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__error_message), mrb_tcp_socket_error_message, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__readpartial_poll), mrb_tcp_socket_readpartial, MRB_ARGS_REQ(1));
 #else

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -204,7 +204,9 @@ mrb_tcp_socket_read_nonblock(mrb_state *mrb, mrb_value self)
   ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+#ifdef PICO_CYW43_ARCH_POLL
     sock->event_pending = false;
+#endif
     if (read_buf != stack_buf) mrb_free(mrb, read_buf);
     return mrb_nil_value();
   }
@@ -309,6 +311,16 @@ mrb_tcp_socket_ready_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(Socket_ready(mrb, sock));
 }
 
+static mrb_value
+mrb_tcp_socket_connection_timeout_ms(mrb_state *mrb, mrb_value self)
+{
+#ifdef PICORB_DEBUG
+  return mrb_fixnum_value(30000);
+#else
+  return mrb_fixnum_value(10000);
+#endif
+}
+
 void
 tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
 {
@@ -317,11 +329,17 @@ tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   tcp_socket_class = mrb_define_class_id(mrb, MRB_SYM(TCPSocket), basic_socket_class);
   MRB_SET_INSTANCE_TT(tcp_socket_class, MRB_TT_DATA);
 
+#ifdef PICO_CYW43_ARCH_POLL
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__initialize_poll), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__connection_state), mrb_tcp_socket_connection_state, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__connection_timeout_ms), mrb_tcp_socket_connection_timeout_ms, MRB_ARGS_NONE());
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__error_message), mrb_tcp_socket_error_message, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(send), mrb_tcp_socket_send, MRB_ARGS_REQ(2));
   mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__readpartial_poll), mrb_tcp_socket_readpartial, MRB_ARGS_REQ(1));
+#else
+  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(initialize), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(readpartial), mrb_tcp_socket_readpartial, MRB_ARGS_REQ(1));
+#endif
+  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(send), mrb_tcp_socket_send, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(read_nonblock), mrb_tcp_socket_read_nonblock, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(close), mrb_tcp_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM_Q(closed), mrb_tcp_socket_closed_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -56,15 +56,6 @@ mrb_tcp_socket_initialize(mrb_state *mrb, mrb_value self)
     mrb_raise(mrb, E_RUNTIME_ERROR, "failed to create socket");
   }
 
-  /* Connect to remote host */
-  if (!TCPSocket_connect(mrb, sock, host, (int)port)) {
-    char errmsg[SOCKET_ERROR_MSG_LEN];
-    strncpy(errmsg, sock->errmsg, sizeof(errmsg) - 1);
-    errmsg[sizeof(errmsg) - 1] = '\0';
-    mrb_free(mrb, sock);
-    mrb_raise(mrb, E_SOCKET_ERROR, errmsg[0] ? errmsg : "failed to connect");
-  }
-
   mrb_data_init(self, sock, &mrb_socket_type);
 
 #ifdef PICO_CYW43_ARCH_POLL
@@ -77,7 +68,34 @@ mrb_tcp_socket_initialize(mrb_state *mrb, mrb_value self)
   *(mrb_value *)sock->event_queue = queue;
 #endif
 
+  /* Connect to remote host. RP2040 poll mode returns after starting the
+   * connection; Ruby waits on event_queue and checks __connection_state. */
+  if (!TCPSocket_connect(mrb, sock, host, (int)port)) {
+    mrb_raisef(mrb, E_SOCKET_ERROR, "%s",
+      sock->errmsg[0] ? sock->errmsg : "failed to connect");
+  }
+
   return self;
+}
+
+static mrb_value
+mrb_tcp_socket_connection_state(mrb_state *mrb, mrb_value self)
+{
+  picorb_socket_t *sock;
+  sock = (picorb_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_socket_type);
+  if (!sock) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "socket is not initialized");
+  }
+  return mrb_fixnum_value(TCPSocket_connection_state(mrb, sock));
+}
+
+static mrb_value
+mrb_tcp_socket_error_message(mrb_state *mrb, mrb_value self)
+{
+  picorb_socket_t *sock;
+  sock = (picorb_socket_t *)mrb_data_get_ptr(mrb, self, &mrb_socket_type);
+  if (!sock || !sock->errmsg[0]) return mrb_nil_value();
+  return mrb_str_new_cstr(mrb, sock->errmsg);
 }
 
 /* socket.send(data, flags) */
@@ -299,9 +317,11 @@ tcp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   tcp_socket_class = mrb_define_class_id(mrb, MRB_SYM(TCPSocket), basic_socket_class);
   MRB_SET_INSTANCE_TT(tcp_socket_class, MRB_TT_DATA);
 
-  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(initialize), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
+  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__initialize_poll), mrb_tcp_socket_initialize, MRB_ARGS_REQ(2));
+  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__connection_state), mrb_tcp_socket_connection_state, MRB_ARGS_NONE());
+  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__error_message), mrb_tcp_socket_error_message, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(send), mrb_tcp_socket_send, MRB_ARGS_REQ(2));
-  mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(readpartial), mrb_tcp_socket_readpartial, MRB_ARGS_REQ(1));
+  mrb_define_private_method_id(mrb, tcp_socket_class, MRB_SYM(__readpartial_poll), mrb_tcp_socket_readpartial, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(read_nonblock), mrb_tcp_socket_read_nonblock, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM(close), mrb_tcp_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, tcp_socket_class, MRB_SYM_Q(closed), mrb_tcp_socket_closed_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -12,25 +12,6 @@
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
 #define E_EOF_ERROR    (mrb_class_get_id(mrb, MRB_SYM(EOFError)))
 
-#ifdef PICO_CYW43_ARCH_POLL
-void
-TCPSocket_notify_readable(picorb_socket_t *sock)
-{
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrb_value queue = *(mrb_value *)sock->event_queue;
-  mrb_state *mrb = (mrb_state *)sock->vm;
-  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-#else
-void
-TCPSocket_notify_readable(picorb_socket_t *sock)
-{
-  (void)sock;
-}
-#endif
-
 /* TCPSocket.new(host, port) */
 static mrb_value
 mrb_tcp_socket_initialize(mrb_state *mrb, mrb_value self)
@@ -59,13 +40,7 @@ mrb_tcp_socket_initialize(mrb_state *mrb, mrb_value self)
   mrb_data_init(self, sock, &mrb_socket_type);
 
 #ifdef PICO_CYW43_ARCH_POLL
-  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
-  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
-  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
-  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
-  sock->vm = mrb;
-  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
-  *(mrb_value *)sock->event_queue = queue;
+  picorb_socket_attach_event_queue(mrb, &self, sock);
 #endif
 
   /* Connect to remote host. RP2040 poll mode returns after starting the

--- a/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/tcp_socket.c
@@ -4,9 +4,32 @@
 #include "mruby/string.h"
 #include "mruby/class.h"
 #include "mruby/data.h"
+#include "mruby/variable.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "task.h"
+#endif
 
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
 #define E_EOF_ERROR    (mrb_class_get_id(mrb, MRB_SYM(EOFError)))
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+TCPSocket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock || !sock->event_queue || sock->event_pending) return;
+  mrb_value queue = *(mrb_value *)sock->event_queue;
+  mrb_state *mrb = (mrb_state *)sock->vm;
+  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
+}
+#else
+void
+TCPSocket_notify_readable(picorb_socket_t *sock)
+{
+  (void)sock;
+}
+#endif
 
 /* TCPSocket.new(host, port) */
 static mrb_value
@@ -43,6 +66,16 @@ mrb_tcp_socket_initialize(mrb_state *mrb, mrb_value self)
   }
 
   mrb_data_init(self, sock, &mrb_socket_type);
+
+#ifdef PICO_CYW43_ARCH_POLL
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
+  sock->vm = mrb;
+  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
+  *(mrb_value *)sock->event_queue = queue;
+#endif
 
   return self;
 }
@@ -153,6 +186,7 @@ mrb_tcp_socket_read_nonblock(mrb_state *mrb, mrb_value self)
   ssize_t received = TCPSocket_recv(mrb, sock, read_buf, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+    sock->event_pending = false;
     if (read_buf != stack_buf) mrb_free(mrb, read_buf);
     return mrb_nil_value();
   }

--- a/mrbgems/picoruby-socket/src/mruby/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/udp_socket.c
@@ -257,9 +257,15 @@ udp_socket_init(mrb_state *mrb, struct RClass *basic_socket_class)
   MRB_SET_INSTANCE_TT(udp_socket_class, MRB_TT_DATA);
 
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(initialize), mrb_udp_socket_initialize, MRB_ARGS_NONE());
+#ifdef PICO_CYW43_ARCH_POLL
+  mrb_define_private_method_id(mrb, udp_socket_class, MRB_SYM(__bind_resolved), mrb_udp_socket_bind, MRB_ARGS_REQ(2));
+  mrb_define_private_method_id(mrb, udp_socket_class, MRB_SYM(__connect_resolved), mrb_udp_socket_connect, MRB_ARGS_REQ(2));
+  mrb_define_private_method_id(mrb, udp_socket_class, MRB_SYM(__send_resolved), mrb_udp_socket_send, MRB_ARGS_ARG(1, 3));
+#else
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(bind), mrb_udp_socket_bind, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(connect), mrb_udp_socket_connect, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(send), mrb_udp_socket_send, MRB_ARGS_ARG(1, 3));
+#endif
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(recvfrom_nonblock), mrb_udp_socket_recvfrom_nonblock, MRB_ARGS_ARG(1, 1));
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM(close), mrb_udp_socket_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, udp_socket_class, MRB_SYM_Q(closed), mrb_udp_socket_closed_p, MRB_ARGS_NONE());

--- a/mrbgems/picoruby-socket/src/mruby/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/udp_socket.c
@@ -12,25 +12,6 @@
 
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
 
-#ifdef PICO_CYW43_ARCH_POLL
-void
-UDPSocket_notify_readable(picorb_socket_t *sock)
-{
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrb_value queue = *(mrb_value *)sock->event_queue;
-  mrb_state *mrb = (mrb_state *)sock->vm;
-  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-#else
-void
-UDPSocket_notify_readable(picorb_socket_t *sock)
-{
-  (void)sock;
-}
-#endif
-
 /* UDPSocket.new() */
 static mrb_value
 mrb_udp_socket_initialize(mrb_state *mrb, mrb_value self)
@@ -50,13 +31,7 @@ mrb_udp_socket_initialize(mrb_state *mrb, mrb_value self)
   mrb_data_init(self, sock, &mrb_socket_type);
 
 #ifdef PICO_CYW43_ARCH_POLL
-  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
-  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
-  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
-  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
-  sock->vm = mrb;
-  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
-  *(mrb_value *)sock->event_queue = queue;
+  picorb_socket_attach_event_queue(mrb, &self, sock);
 #endif
 
   return self;

--- a/mrbgems/picoruby-socket/src/mruby/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/udp_socket.c
@@ -192,7 +192,9 @@ mrb_udp_socket_recvfrom_nonblock(mrb_state *mrb, mrb_value self)
 
   /* If no data available (non-blocking socket), return nil */
   if (received == 0) {
+#ifdef PICO_CYW43_ARCH_POLL
     sock->event_pending = false;
+#endif
     mrb_free(mrb, buf);
     return mrb_nil_value();
   }

--- a/mrbgems/picoruby-socket/src/mruby/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/udp_socket.c
@@ -16,10 +16,12 @@
 void
 UDPSocket_notify_readable(picorb_socket_t *sock)
 {
-  if (!sock || !sock->event_queue) return;
+  if (!sock || !sock->event_queue || sock->event_pending) return;
   mrb_value queue = *(mrb_value *)sock->event_queue;
   mrb_state *mrb = (mrb_state *)sock->vm;
-  (void)mrb_task_queue_push(mrb, queue, mrb_true_value());
+  if (mrb_task_queue_push(mrb, queue, mrb_true_value()) == MRB_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
 }
 #else
 void
@@ -190,6 +192,7 @@ mrb_udp_socket_recvfrom_nonblock(mrb_state *mrb, mrb_value self)
 
   /* If no data available (non-blocking socket), return nil */
   if (received == 0) {
+    sock->event_pending = false;
     mrb_free(mrb, buf);
     return mrb_nil_value();
   }

--- a/mrbgems/picoruby-socket/src/mruby/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mruby/udp_socket.c
@@ -5,8 +5,29 @@
 #include "mruby/array.h"
 #include "mruby/class.h"
 #include "mruby/data.h"
+#include "mruby/variable.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "task.h"
+#endif
 
 #define E_SOCKET_ERROR (mrb_class_get_id(mrb, MRB_SYM(SocketError)))
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+UDPSocket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock || !sock->event_queue) return;
+  mrb_value queue = *(mrb_value *)sock->event_queue;
+  mrb_state *mrb = (mrb_state *)sock->vm;
+  (void)mrb_task_queue_push(mrb, queue, mrb_true_value());
+}
+#else
+void
+UDPSocket_notify_readable(picorb_socket_t *sock)
+{
+  (void)sock;
+}
+#endif
 
 /* UDPSocket.new() */
 static mrb_value
@@ -25,6 +46,16 @@ mrb_udp_socket_initialize(mrb_state *mrb, mrb_value self)
   }
 
   mrb_data_init(self, sock, &mrb_socket_type);
+
+#ifdef PICO_CYW43_ARCH_POLL
+  struct RClass *task_class = mrb_class_get_id(mrb, MRB_SYM(Task));
+  struct RClass *queue_class = mrb_class_get_under_id(mrb, task_class, MRB_SYM(Queue));
+  mrb_value queue = mrb_obj_new(mrb, queue_class, 0, NULL);
+  mrb_iv_set(mrb, self, MRB_IVSYM(event_queue), queue);
+  sock->vm = mrb;
+  sock->event_queue = mrb_malloc(mrb, sizeof(mrb_value));
+  *(mrb_value *)sock->event_queue = queue;
+#endif
 
   return self;
 }

--- a/mrbgems/picoruby-socket/src/mrubyc/socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/socket.c
@@ -2,6 +2,116 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoruby.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "c_task_queue.h"
+
+mrbc_value
+picorb_task_queue_new(mrbc_vm *vm)
+{
+  mrbc_value queue = mrbc_instance_new(vm, MRBC_CLASS(Task_Queue), 0);
+
+  mrbc_value items = mrbc_array_new(vm, 0);
+  mrbc_instance_setiv(&queue, mrbc_str_to_symid("@items"), &items);
+  mrbc_decref(&items);
+
+  mrbc_value closed = mrbc_false_value();
+  mrbc_instance_setiv(&queue, mrbc_str_to_symid("@closed"), &closed);
+
+  return queue;
+}
+
+typedef struct {
+  mrbc_value queue;
+  void *request;
+} mrbc_dns_resolver;
+
+static void
+mrbc_dns_resolver_notify(void *arg)
+{
+  mrbc_dns_resolver *resolver = (mrbc_dns_resolver *)arg;
+  if (!resolver) return;
+  mrbc_value event = mrbc_true_value();
+  mrbc_task_queue_push(&resolver->queue, &event);
+}
+
+static void
+mrbc_dns_resolver_free(mrbc_value *self)
+{
+  mrbc_dns_resolver *resolver = (mrbc_dns_resolver *)self->instance->data;
+  if (!resolver) return;
+  if (resolver->request) Net_dns_abandon(resolver->request);
+}
+
+static void
+c_dns_resolver_new(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1 || GET_ARG(1).tt != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "host must be a String");
+    return;
+  }
+
+  const char *host = (const char *)GET_ARG(1).string->data;
+  mrbc_value self = mrbc_instance_new(vm, v->cls, sizeof(mrbc_dns_resolver));
+  mrbc_dns_resolver *resolver = (mrbc_dns_resolver *)self.instance->data;
+  resolver->request = NULL;
+  resolver->queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(&self, mrbc_str_to_symid("event_queue"), &resolver->queue);
+  mrbc_decref(&resolver->queue);
+  resolver->request = Net_dns_start(host, mrbc_dns_resolver_notify, resolver);
+  if (!resolver->request) {
+    mrbc_decref(&self);
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), Net_get_last_error());
+    return;
+  }
+  SET_RETURN(self);
+}
+
+static mrbc_dns_resolver *
+get_dns_resolver(mrbc_value *v)
+{
+  return (mrbc_dns_resolver *)v[0].instance->data;
+}
+
+static void
+c_dns_resolver_status(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_dns_resolver *resolver = get_dns_resolver(v);
+  SET_INT_RETURN(Net_dns_status(resolver->request));
+}
+
+static void
+c_dns_resolver_release(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_dns_resolver *resolver = get_dns_resolver(v);
+  if (resolver->request) {
+    Net_dns_release(resolver->request);
+    resolver->request = NULL;
+  }
+  SET_NIL_RETURN();
+}
+
+static void
+c_dns_resolver_abandon(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_dns_resolver *resolver = get_dns_resolver(v);
+  if (resolver->request) {
+    Net_dns_abandon(resolver->request);
+    resolver->request = NULL;
+  }
+  SET_NIL_RETURN();
+}
+
+static void
+mrbc_dns_resolver_init(mrbc_vm *vm)
+{
+  mrbc_class *resolver = mrbc_define_class(vm, "SocketDNSResolver", mrbc_class_object);
+  mrbc_define_destructor(resolver, mrbc_dns_resolver_free);
+  mrbc_define_method(vm, resolver, "new", c_dns_resolver_new);
+  mrbc_define_method(vm, resolver, "__status", c_dns_resolver_status);
+  mrbc_define_method(vm, resolver, "__release", c_dns_resolver_release);
+  mrbc_define_method(vm, resolver, "__abandon", c_dns_resolver_abandon);
+}
+#endif
 
 /* Socket type constants (matching socket.h) */
 #if defined(PICORB_PLATFORM_POSIX)
@@ -44,6 +154,10 @@ void
 mrbc_socket_init(mrbc_vm *vm)
 {
   mrbc_class *class_BasicSocket = mrbc_define_class(vm, "BasicSocket", mrbc_class_object);
+
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_dns_resolver_init(vm);
+#endif
 
   tcp_socket_init(vm, class_BasicSocket);
   udp_socket_init(vm, class_BasicSocket);

--- a/mrbgems/picoruby-socket/src/mrubyc/socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/socket.c
@@ -80,6 +80,19 @@ c_dns_resolver_status(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
+c_dns_resolver_address(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  mrbc_dns_resolver *resolver = get_dns_resolver(v);
+  char address[40];
+
+  if (Net_dns_get_address(resolver->request, address, sizeof(address)) != 0) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, address));
+}
+
+static void
 c_dns_resolver_release(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   mrbc_dns_resolver *resolver = get_dns_resolver(v);
@@ -108,6 +121,7 @@ mrbc_dns_resolver_init(mrbc_vm *vm)
   mrbc_define_destructor(resolver, mrbc_dns_resolver_free);
   mrbc_define_method(vm, resolver, "new", c_dns_resolver_new);
   mrbc_define_method(vm, resolver, "__status", c_dns_resolver_status);
+  mrbc_define_method(vm, resolver, "__address", c_dns_resolver_address);
   mrbc_define_method(vm, resolver, "__release", c_dns_resolver_release);
   mrbc_define_method(vm, resolver, "__abandon", c_dns_resolver_abandon);
 }

--- a/mrbgems/picoruby-socket/src/mrubyc/socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/socket.c
@@ -20,6 +20,51 @@ picorb_task_queue_new(mrbc_vm *vm)
   return queue;
 }
 
+void
+picorb_task_queue_notify(mrbc_vm *vm, void *queue_ptr, bool *pending)
+{
+  (void)vm;
+  if (!queue_ptr || !pending || *pending) return;
+  mrbc_value event = mrbc_true_value();
+  if (mrbc_task_queue_push((mrbc_value *)queue_ptr, &event) ==
+      MRBC_TASK_QUEUE_PUSH_OK) {
+    *pending = true;
+  }
+}
+
+bool
+picorb_task_queue_attach(mrbc_vm *vm, void *self_ptr, void **queue_ptr)
+{
+  mrbc_value *self = (mrbc_value *)self_ptr;
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(self, mrbc_str_to_symid("event_queue"), &queue);
+  *queue_ptr = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!*queue_ptr) {
+    mrbc_decref(&queue);
+    return false;
+  }
+  *(mrbc_value *)*queue_ptr = queue;
+  mrbc_decref(&queue);
+  return true;
+}
+
+bool
+picorb_socket_attach_event_queue(mrbc_vm *vm, void *self_ptr,
+                                  picorb_socket_t *sock)
+{
+  if (!picorb_task_queue_attach(vm, self_ptr, &sock->event_queue)) return false;
+  sock->vm = vm;
+  return true;
+}
+
+void
+picorb_socket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock) return;
+  picorb_task_queue_notify((mrbc_vm *)sock->vm, sock->event_queue,
+                           &sock->event_pending);
+}
+
 typedef struct {
   mrbc_value queue;
   void *request;

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -261,6 +261,24 @@ c_ssl_socket_connect(mrbc_vm *vm, mrbc_value *v, int argc)
 
 #ifdef PICO_CYW43_ARCH_POLL
 static void
+c_ssl_socket_set_connect_hostname(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1 || GET_ARG(1).tt != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "hostname is required");
+    return;
+  }
+
+  ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)v[0].instance->data;
+  if (!wrapper->ptr || !SSLSocket_set_connect_hostname(
+        vm, wrapper->ptr, (const char *)GET_ARG(1).string->data)) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to set connect hostname");
+    return;
+  }
+
+  SET_TRUE_RETURN();
+}
+
+static void
 c_ssl_socket_connection_state(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)v[0].instance->data;
@@ -1044,6 +1062,8 @@ ssl_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 
   mrbc_define_method(vm, class_SSLSocket, "new", c_ssl_socket_new);
 #ifdef PICO_CYW43_ARCH_POLL
+  mrbc_define_method(vm, class_SSLSocket, "__set_connect_hostname",
+                     c_ssl_socket_set_connect_hostname);
   mrbc_define_method(vm, class_SSLSocket, "__open_poll", c_ssl_socket_open);
   mrbc_define_method(vm, class_SSLSocket, "__connect_poll", c_ssl_socket_connect);
   mrbc_define_method(vm, class_SSLSocket, "__connection_state", c_ssl_socket_connection_state);

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -4,42 +4,6 @@
 #include "picoruby.h"
 #ifdef PICO_CYW43_ARCH_POLL
 #include "c_task_queue.h"
-
-void
-SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
-{
-  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrbc_value event = mrbc_true_value();
-  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
-      MRBC_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-
-static bool
-attach_event_queue(mrbc_vm *vm, mrbc_value *self,
-                   picorb_ssl_socket_t *ssl_sock)
-{
-  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(self, mrbc_str_to_symid("event_queue"), &queue);
-  sock->vm = vm;
-  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!sock->event_queue) {
-    mrbc_decref(&queue);
-    return false;
-  }
-  *(mrbc_value *)sock->event_queue = queue;
-  mrbc_decref(&queue);
-  return true;
-}
-#else
-void
-SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
-{
-  (void)ssl_sock;
-}
 #endif
 
 typedef struct {
@@ -156,7 +120,8 @@ c_ssl_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   mrbc_instance_setiv(&instance, mrbc_str_to_symid("ssl_context"), &ssl_context_obj);
 
 #ifdef PICO_CYW43_ARCH_POLL
-  if (!attach_event_queue(vm, &instance, wrapper->ptr)) {
+  if (!picorb_socket_attach_event_queue(vm, &instance,
+                                        SSLSocket_event_socket(wrapper->ptr))) {
     SSLSocket_close(vm, wrapper->ptr);
     wrapper->ptr = NULL;
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
@@ -229,7 +194,8 @@ c_ssl_socket_open(mrbc_vm *vm, mrbc_value *v, int argc)
 
 #ifdef PICO_CYW43_ARCH_POLL
   mrbc_instance_setiv(&instance, mrbc_str_to_symid("ssl_context"), &ssl_context_obj);
-  if (!attach_event_queue(vm, &instance, wrapper->ptr)) {
+  if (!picorb_socket_attach_event_queue(vm, &instance,
+                                        SSLSocket_event_socket(wrapper->ptr))) {
     SSLSocket_close(vm, wrapper->ptr);
     wrapper->ptr = NULL;
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -2,6 +2,45 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoruby.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "c_task_queue.h"
+
+void
+SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
+{
+  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
+  if (!sock || !sock->event_queue || sock->event_pending) return;
+  mrbc_value event = mrbc_true_value();
+  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
+      MRBC_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
+}
+
+static bool
+attach_event_queue(mrbc_vm *vm, mrbc_value *self,
+                   picorb_ssl_socket_t *ssl_sock)
+{
+  picorb_socket_t *sock = SSLSocket_event_socket(ssl_sock);
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(self, mrbc_str_to_symid("event_queue"), &queue);
+  sock->vm = vm;
+  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!sock->event_queue) {
+    mrbc_decref(&queue);
+    return false;
+  }
+  *(mrbc_value *)sock->event_queue = queue;
+  mrbc_decref(&queue);
+  return true;
+}
+#else
+void
+SSLSocket_notify_readable(picorb_ssl_socket_t *ssl_sock)
+{
+  (void)ssl_sock;
+}
+#endif
 
 typedef struct {
   picorb_ssl_socket_t *ptr;
@@ -113,8 +152,17 @@ c_ssl_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
   /* Store references for GC protection */
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@tcp_socket"), &tcp_socket_obj);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@ssl_context"), &ssl_context_obj);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("tcp_socket"), &tcp_socket_obj);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("ssl_context"), &ssl_context_obj);
+
+#ifdef PICO_CYW43_ARCH_POLL
+  if (!attach_event_queue(vm, &instance, wrapper->ptr)) {
+    SSLSocket_close(vm, wrapper->ptr);
+    wrapper->ptr = NULL;
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+#endif
 
   SET_RETURN(instance);
 }
@@ -155,6 +203,7 @@ c_ssl_socket_open(mrbc_vm *vm, mrbc_value *v, int argc)
   /* Create instance with wrapper structure */
   mrbc_value instance = mrbc_instance_new(vm, v->cls, sizeof(ssl_socket_wrapper_t));
   ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)instance.instance->data;
+  wrapper->vm = vm;
 
   /* Create SSL socket */
   wrapper->ptr = SSLSocket_create(vm, ctx_wrapper->ptr);
@@ -178,6 +227,16 @@ c_ssl_socket_open(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("ssl_context"), &ssl_context_obj);
+  if (!attach_event_queue(vm, &instance, wrapper->ptr)) {
+    SSLSocket_close(vm, wrapper->ptr);
+    wrapper->ptr = NULL;
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+  SET_RETURN(instance);
+#else
   /* Perform SSL handshake */
   if (!SSLSocket_connect(vm, wrapper->ptr)) {
 #if !defined(PICORB_PLATFORM_POSIX) && !defined(PICORB_PLATFORM_ESP32)
@@ -196,9 +255,10 @@ c_ssl_socket_open(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
   /* Store reference for GC protection */
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@ssl_context"), &ssl_context_obj);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("ssl_context"), &ssl_context_obj);
 
   SET_RETURN(instance);
+#endif
 }
 
 /*
@@ -232,6 +292,37 @@ c_ssl_socket_connect(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 }
+
+#ifdef PICO_CYW43_ARCH_POLL
+static void
+c_ssl_socket_connection_state(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)v[0].instance->data;
+  SET_INT_RETURN(SSLSocket_connection_state(vm, wrapper->ptr));
+}
+
+static void
+c_ssl_socket_finish_connect(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  ssl_socket_wrapper_t *wrapper = (ssl_socket_wrapper_t *)v[0].instance->data;
+  if (wrapper->ptr && SSLSocket_finish_connect(vm, wrapper->ptr)) {
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_ssl_socket_error_message(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  const char *message = Net_get_last_error();
+  if (message && message[0]) {
+    SET_RETURN(mrbc_string_new_cstr(vm, message));
+  } else {
+    SET_NIL_RETURN();
+  }
+}
+#endif
 
 /*
  * ssl_socket.send(data, flags) -> Integer
@@ -542,6 +633,16 @@ c_ssl_socket_ready_q(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
+static void
+c_ssl_socket_connection_timeout_ms(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+#ifdef PICORB_DEBUG
+  SET_INT_RETURN(30000);
+#else
+  SET_INT_RETURN(10000);
+#endif
+}
+
 /*
  * SSLContext.new() -> SSLContext
  */
@@ -799,7 +900,7 @@ c_ssl_context_set_ca_pem(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
-  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("@ca_pem"), &str);
+  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("ca_pem"), &str);
 
   if (!SSLContext_set_ca(vm, wrapper->ptr, (const void *)str.string->data, (size_t)str.string->size)) {
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to set CA certificate");
@@ -830,7 +931,7 @@ c_ssl_context_set_cert_pem(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
-  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("@cert_pem"), &str);
+  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("cert_pem"), &str);
 
   if (!SSLContext_set_cert(vm, wrapper->ptr, (const void *)str.string->data, (size_t)str.string->size)) {
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to set certificate");
@@ -861,7 +962,7 @@ c_ssl_context_set_key_pem(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
-  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("@key_pem"), &str);
+  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("key_pem"), &str);
 
   if (!SSLContext_set_key(vm, wrapper->ptr, (const void *)str.string->data, (size_t)str.string->size)) {
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to set key");
@@ -986,10 +1087,20 @@ ssl_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
   mrbc_define_destructor(class_SSLSocket, mrbc_ssl_socket_free);
 
   mrbc_define_method(vm, class_SSLSocket, "new", c_ssl_socket_new);
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_define_method(vm, class_SSLSocket, "__open_poll", c_ssl_socket_open);
+  mrbc_define_method(vm, class_SSLSocket, "__connect_poll", c_ssl_socket_connect);
+  mrbc_define_method(vm, class_SSLSocket, "__connection_state", c_ssl_socket_connection_state);
+  mrbc_define_method(vm, class_SSLSocket, "__connection_timeout_ms", c_ssl_socket_connection_timeout_ms);
+  mrbc_define_method(vm, class_SSLSocket, "__finish_connect", c_ssl_socket_finish_connect);
+  mrbc_define_method(vm, class_SSLSocket, "__error_message", c_ssl_socket_error_message);
+  mrbc_define_method(vm, class_SSLSocket, "__readpartial_poll", c_ssl_socket_readpartial);
+#else
   mrbc_define_method(vm, class_SSLSocket, "open", c_ssl_socket_open);
   mrbc_define_method(vm, class_SSLSocket, "connect", c_ssl_socket_connect);
-  mrbc_define_method(vm, class_SSLSocket, "send", c_ssl_socket_send);
   mrbc_define_method(vm, class_SSLSocket, "readpartial", c_ssl_socket_readpartial);
+#endif
+  mrbc_define_method(vm, class_SSLSocket, "send", c_ssl_socket_send);
   mrbc_define_method(vm, class_SSLSocket, "read_nonblock", c_ssl_socket_read_nonblock);
   mrbc_define_method(vm, class_SSLSocket, "close", c_ssl_socket_close);
   mrbc_define_method(vm, class_SSLSocket, "closed?", c_ssl_socket_closed_q);

--- a/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/ssl_socket.c
@@ -599,16 +599,6 @@ c_ssl_socket_ready_q(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
-static void
-c_ssl_socket_connection_timeout_ms(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-#ifdef PICORB_DEBUG
-  SET_INT_RETURN(30000);
-#else
-  SET_INT_RETURN(10000);
-#endif
-}
-
 /*
  * SSLContext.new() -> SSLContext
  */
@@ -1057,7 +1047,6 @@ ssl_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
   mrbc_define_method(vm, class_SSLSocket, "__open_poll", c_ssl_socket_open);
   mrbc_define_method(vm, class_SSLSocket, "__connect_poll", c_ssl_socket_connect);
   mrbc_define_method(vm, class_SSLSocket, "__connection_state", c_ssl_socket_connection_state);
-  mrbc_define_method(vm, class_SSLSocket, "__connection_timeout_ms", c_ssl_socket_connection_timeout_ms);
   mrbc_define_method(vm, class_SSLSocket, "__finish_connect", c_ssl_socket_finish_connect);
   mrbc_define_method(vm, class_SSLSocket, "__error_message", c_ssl_socket_error_message);
   mrbc_define_method(vm, class_SSLSocket, "__readpartial_poll", c_ssl_socket_readpartial);

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
@@ -2,6 +2,43 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoruby.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "c_task_queue.h"
+
+void
+TCPServer_notify_accepted(picorb_tcp_server_t *server)
+{
+  void *queue_ptr = TCPServer_event_queue(server);
+  if (!queue_ptr || TCPServer_event_pending(server)) return;
+  mrbc_value event = mrbc_true_value();
+  if (mrbc_task_queue_push((mrbc_value *)queue_ptr, &event) ==
+      MRBC_TASK_QUEUE_PUSH_OK) {
+    TCPServer_set_event_pending(server, true);
+  }
+}
+
+static bool
+attach_event_queue(mrbc_vm *vm, mrbc_value *self, picorb_socket_t *sock)
+{
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(self, mrbc_str_to_symid("event_queue"), &queue);
+  sock->vm = vm;
+  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!sock->event_queue) {
+    mrbc_decref(&queue);
+    return false;
+  }
+  *(mrbc_value *)sock->event_queue = queue;
+  mrbc_decref(&queue);
+  return true;
+}
+#else
+void
+TCPServer_notify_accepted(picorb_tcp_server_t *server)
+{
+  (void)server;
+}
+#endif
 
 /* Wrapper structure for storing TCP server pointer in instance->data */
 typedef struct {
@@ -88,6 +125,22 @@ c_tcp_server_new(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
+  void *queue_ptr = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!queue_ptr) {
+    mrbc_decref(&queue);
+    TCPServer_close(vm, wrapper->ptr);
+    wrapper->ptr = NULL;
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+  *(mrbc_value *)queue_ptr = queue;
+  mrbc_decref(&queue);
+  TCPServer_set_event_queue(wrapper->ptr, vm, queue_ptr);
+#endif
+
   SET_RETURN(instance);
 }
 
@@ -121,9 +174,18 @@ c_tcp_server_accept_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
    * Store the pointer directly to preserve LwIP callback arg.
    */
   mrbc_class *class_TCPSocket = mrbc_get_class_by_name("TCPSocket");
-  mrbc_value client_obj = mrbc_instance_new(vm, class_TCPSocket, sizeof(picorb_socket_t *));
-  picorb_socket_t **sock_ptr = (picorb_socket_t **)client_obj.instance->data;
-  *sock_ptr = client;
+  mrbc_value client_obj = mrbc_instance_new(vm, class_TCPSocket, sizeof(socket_wrapper_t));
+  socket_wrapper_t *client_wrapper = (socket_wrapper_t *)client_obj.instance->data;
+  client_wrapper->ptr = client;
+  client_wrapper->vm = vm;
+
+#ifdef PICO_CYW43_ARCH_POLL
+  if (!attach_event_queue(vm, &client_obj, client)) {
+    mrbc_decref(&client_obj);
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+#endif
 
   mrbc_incref(&v[0]);
   SET_RETURN(client_obj);

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
@@ -13,12 +13,6 @@ TCPServer_notify_accepted(picorb_tcp_server_t *server)
   picorb_task_queue_notify(TCPServer_vm(server), queue_ptr, &pending);
   TCPServer_set_event_pending(server, pending);
 }
-#else
-void
-TCPServer_notify_accepted(picorb_tcp_server_t *server)
-{
-  (void)server;
-}
 #endif
 
 /* Wrapper structure for storing TCP server pointer in instance->data */

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_server.c
@@ -9,28 +9,9 @@ void
 TCPServer_notify_accepted(picorb_tcp_server_t *server)
 {
   void *queue_ptr = TCPServer_event_queue(server);
-  if (!queue_ptr || TCPServer_event_pending(server)) return;
-  mrbc_value event = mrbc_true_value();
-  if (mrbc_task_queue_push((mrbc_value *)queue_ptr, &event) ==
-      MRBC_TASK_QUEUE_PUSH_OK) {
-    TCPServer_set_event_pending(server, true);
-  }
-}
-
-static bool
-attach_event_queue(mrbc_vm *vm, mrbc_value *self, picorb_socket_t *sock)
-{
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(self, mrbc_str_to_symid("event_queue"), &queue);
-  sock->vm = vm;
-  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!sock->event_queue) {
-    mrbc_decref(&queue);
-    return false;
-  }
-  *(mrbc_value *)sock->event_queue = queue;
-  mrbc_decref(&queue);
-  return true;
+  bool pending = TCPServer_event_pending(server);
+  picorb_task_queue_notify(TCPServer_vm(server), queue_ptr, &pending);
+  TCPServer_set_event_pending(server, pending);
 }
 #else
 void
@@ -126,18 +107,13 @@ c_tcp_server_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
-  void *queue_ptr = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!queue_ptr) {
-    mrbc_decref(&queue);
+  void *queue_ptr = NULL;
+  if (!picorb_task_queue_attach(vm, &instance, &queue_ptr)) {
     TCPServer_close(vm, wrapper->ptr);
     wrapper->ptr = NULL;
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
     return;
   }
-  *(mrbc_value *)queue_ptr = queue;
-  mrbc_decref(&queue);
   TCPServer_set_event_queue(wrapper->ptr, vm, queue_ptr);
 #endif
 
@@ -180,7 +156,7 @@ c_tcp_server_accept_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
   client_wrapper->vm = vm;
 
 #ifdef PICO_CYW43_ARCH_POLL
-  if (!attach_event_queue(vm, &client_obj, client)) {
+  if (!picorb_socket_attach_event_queue(vm, &client_obj, client)) {
     mrbc_decref(&client_obj);
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
     return;

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -6,25 +6,6 @@
 #include "c_task_queue.h"
 #endif
 
-#ifdef PICO_CYW43_ARCH_POLL
-void
-TCPSocket_notify_readable(picorb_socket_t *sock)
-{
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrbc_value event = mrbc_true_value();
-  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
-      MRBC_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-#else
-void
-TCPSocket_notify_readable(picorb_socket_t *sock)
-{
-  (void)sock;
-}
-#endif
-
 /*
  * Helper function to get socket pointer from instance->data.
  */
@@ -114,19 +95,12 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
-  sock->vm = vm;
-  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!sock->event_queue) {
-    mrbc_decref(&queue);
+  if (!picorb_socket_attach_event_queue(vm, &instance, sock)) {
     TCPSocket_close(vm, sock);
     picorb_free(vm, sock);
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
     return;
   }
-  *(mrbc_value *)sock->event_queue = queue;
-  mrbc_decref(&queue);
 #endif
 
   SET_RETURN(instance);
@@ -163,20 +137,13 @@ c_tcp_socket_initialize_poll(mrbc_vm *vm, mrbc_value *v, int argc)
   wrapper->ptr = sock;
   wrapper->vm = vm;
 
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("event_queue"), &queue);
-  sock->vm = vm;
-  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!sock->event_queue) {
-    mrbc_decref(&queue);
+  if (!picorb_socket_attach_event_queue(vm, &v[0], sock)) {
     TCPSocket_close(vm, sock);
     picorb_free(vm, sock);
     wrapper->ptr = NULL;
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
     return;
   }
-  *(mrbc_value *)sock->event_queue = queue;
-  mrbc_decref(&queue);
 
   if (!TCPSocket_connect(vm, sock, host, port)) {
     mrbc_raisef(vm, mrbc_get_class_by_name("SocketError"), "%s",

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -94,15 +94,6 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
 
-#ifdef PICO_CYW43_ARCH_POLL
-  if (!picorb_socket_attach_event_queue(vm, &instance, sock)) {
-    TCPSocket_close(vm, sock);
-    picorb_free(vm, sock);
-    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
-    return;
-  }
-#endif
-
   SET_RETURN(instance);
 #endif
 }
@@ -483,16 +474,6 @@ c_tcp_socket_ready_q(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
-static void
-c_tcp_socket_connection_timeout_ms(mrbc_vm *vm, mrbc_value *v, int argc)
-{
-#ifdef PICORB_DEBUG
-  SET_INT_RETURN(30000);
-#else
-  SET_INT_RETURN(10000);
-#endif
-}
-
 void
 tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 {
@@ -503,7 +484,6 @@ tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 #ifdef PICO_CYW43_ARCH_POLL
   mrbc_define_method(vm, class_TCPSocket, "__initialize_poll", c_tcp_socket_initialize_poll);
   mrbc_define_method(vm, class_TCPSocket, "__connection_state", c_tcp_socket_connection_state);
-  mrbc_define_method(vm, class_TCPSocket, "__connection_timeout_ms", c_tcp_socket_connection_timeout_ms);
   mrbc_define_method(vm, class_TCPSocket, "__error_message", c_tcp_socket_error_message);
   mrbc_define_method(vm, class_TCPSocket, "__readpartial_poll", c_tcp_socket_readpartial);
 #else

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -43,6 +43,10 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
 {
 #ifdef PICO_CYW43_ARCH_POLL
   mrbc_value instance = mrbc_instance_new(vm, v->cls, sizeof(socket_wrapper_t));
+  /* mrbc_instance_new does not clear instance data. Ruby initialize may
+   * raise before __initialize_poll assigns the wrapper fields, so initialize
+   * them before calling Ruby code for the destructor's safety. */
+  memset(instance.instance->data, 0, sizeof(socket_wrapper_t));
   v[0] = instance;
   mrbc_instance_call_initialize(vm, v, argc);
 #else

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -2,6 +2,28 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoruby.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "c_task_queue.h"
+#endif
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+TCPSocket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock || !sock->event_queue || sock->event_pending) return;
+  mrbc_value event = mrbc_true_value();
+  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
+      MRBC_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
+}
+#else
+void
+TCPSocket_notify_readable(picorb_socket_t *sock)
+{
+  (void)sock;
+}
+#endif
 
 /*
  * Helper function to get socket pointer from instance->data.
@@ -81,6 +103,23 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
                 "%s", errmsg[0] ? errmsg : "failed to connect");
     return;
   }
+
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_value queue = mrbc_instance_new(vm, MRBC_CLASS(Task_Queue), 0);
+  mrbc_send(vm, v, argc, &queue, "initialize", 0);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@event_queue"), &queue);
+  sock->vm = vm;
+  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!sock->event_queue) {
+    mrbc_decref(&queue);
+    TCPSocket_close(vm, sock);
+    picorb_free(vm, sock);
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+  *(mrbc_value *)sock->event_queue = queue;
+  mrbc_decref(&queue);
+#endif
 
   SET_RETURN(instance);
 }
@@ -232,6 +271,7 @@ c_tcp_socket_read_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
   ssize_t received = TCPSocket_recv(vm, sock, buffer, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+    sock->event_pending = false;
     if (buffer != stack_buf) picorb_free(vm, buffer);
     SET_NIL_RETURN();
     return;

--- a/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/tcp_socket.c
@@ -41,6 +41,11 @@ get_socket_ptr(mrbc_value *v)
 static void
 c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
 {
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_value instance = mrbc_instance_new(vm, v->cls, sizeof(socket_wrapper_t));
+  v[0] = instance;
+  mrbc_instance_call_initialize(vm, v, argc);
+#else
   if (argc != 2) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
     return;
@@ -105,9 +110,8 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrbc_value queue = mrbc_instance_new(vm, MRBC_CLASS(Task_Queue), 0);
-  mrbc_send(vm, v, argc, &queue, "initialize", 0);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@event_queue"), &queue);
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
   sock->vm = vm;
   sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
   if (!sock->event_queue) {
@@ -122,7 +126,79 @@ c_tcp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
 #endif
 
   SET_RETURN(instance);
+#endif
 }
+
+#ifdef PICO_CYW43_ARCH_POLL
+static void
+c_tcp_socket_initialize_poll(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 2 || GET_ARG(1).tt != MRBC_TT_STRING ||
+      GET_ARG(2).tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "host and port are required");
+    return;
+  }
+  int port = (int)GET_ARG(2).i;
+  const char *host = (const char *)GET_ARG(1).string->data;
+  if (port < 0 || 65535 < port) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "invalid port number");
+    return;
+  }
+
+  picorb_socket_t *sock = picorb_alloc(vm, sizeof(picorb_socket_t));
+  if (!sock) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate socket");
+    return;
+  }
+  if (!TCPSocket_create(vm, sock)) {
+    picorb_free(vm, sock);
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to create socket");
+    return;
+  }
+  socket_wrapper_t *wrapper = (socket_wrapper_t *)v[0].instance->data;
+  wrapper->ptr = sock;
+  wrapper->vm = vm;
+
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(&v[0], mrbc_str_to_symid("event_queue"), &queue);
+  sock->vm = vm;
+  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!sock->event_queue) {
+    mrbc_decref(&queue);
+    TCPSocket_close(vm, sock);
+    picorb_free(vm, sock);
+    wrapper->ptr = NULL;
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+  *(mrbc_value *)sock->event_queue = queue;
+  mrbc_decref(&queue);
+
+  if (!TCPSocket_connect(vm, sock, host, port)) {
+    mrbc_raisef(vm, mrbc_get_class_by_name("SocketError"), "%s",
+                sock->errmsg[0] ? sock->errmsg : "failed to connect");
+    return;
+  }
+  SET_NIL_RETURN();
+}
+
+static void
+c_tcp_socket_connection_state(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  SET_INT_RETURN(TCPSocket_connection_state(vm, get_socket_ptr(v)));
+}
+
+static void
+c_tcp_socket_error_message(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  picorb_socket_t *sock = get_socket_ptr(v);
+  if (!sock || !sock->errmsg[0]) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, sock->errmsg));
+}
+#endif
 /*
  * socket.send(data, flags) -> Integer
  */
@@ -271,7 +347,9 @@ c_tcp_socket_read_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
   ssize_t received = TCPSocket_recv(vm, sock, buffer, maxlen, true);
 
   if (received == PICORB_RECV_WOULD_BLOCK) {
+#ifdef PICO_CYW43_ARCH_POLL
     sock->event_pending = false;
+#endif
     if (buffer != stack_buf) picorb_free(vm, buffer);
     SET_NIL_RETURN();
     return;
@@ -434,6 +512,16 @@ c_tcp_socket_ready_q(mrbc_vm *vm, mrbc_value *v, int argc)
   }
 }
 
+static void
+c_tcp_socket_connection_timeout_ms(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+#ifdef PICORB_DEBUG
+  SET_INT_RETURN(30000);
+#else
+  SET_INT_RETURN(10000);
+#endif
+}
+
 void
 tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
 {
@@ -441,8 +529,16 @@ tcp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
   mrbc_define_destructor(class_TCPSocket, mrbc_socket_free);
 
   mrbc_define_method(vm, class_TCPSocket, "new", c_tcp_socket_new);
-  mrbc_define_method(vm, class_TCPSocket, "send", c_tcp_socket_send);
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_define_method(vm, class_TCPSocket, "__initialize_poll", c_tcp_socket_initialize_poll);
+  mrbc_define_method(vm, class_TCPSocket, "__connection_state", c_tcp_socket_connection_state);
+  mrbc_define_method(vm, class_TCPSocket, "__connection_timeout_ms", c_tcp_socket_connection_timeout_ms);
+  mrbc_define_method(vm, class_TCPSocket, "__error_message", c_tcp_socket_error_message);
+  mrbc_define_method(vm, class_TCPSocket, "__readpartial_poll", c_tcp_socket_readpartial);
+#else
   mrbc_define_method(vm, class_TCPSocket, "readpartial", c_tcp_socket_readpartial);
+#endif
+  mrbc_define_method(vm, class_TCPSocket, "send", c_tcp_socket_send);
   mrbc_define_method(vm, class_TCPSocket, "read_nonblock", c_tcp_socket_read_nonblock);
   mrbc_define_method(vm, class_TCPSocket, "close", c_tcp_socket_close);
   mrbc_define_method(vm, class_TCPSocket, "closed?", c_tcp_socket_closed_q);

--- a/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
@@ -6,25 +6,6 @@
 #include "c_task_queue.h"
 #endif
 
-#ifdef PICO_CYW43_ARCH_POLL
-void
-UDPSocket_notify_readable(picorb_socket_t *sock)
-{
-  if (!sock || !sock->event_queue || sock->event_pending) return;
-  mrbc_value event = mrbc_true_value();
-  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
-      MRBC_TASK_QUEUE_PUSH_OK) {
-    sock->event_pending = true;
-  }
-}
-#else
-void
-UDPSocket_notify_readable(picorb_socket_t *sock)
-{
-  (void)sock;
-}
-#endif
-
 /*
  * Helper function to get socket pointer from instance->data.
  */
@@ -67,18 +48,12 @@ c_udp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   wrapper->vm = vm;
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrbc_value queue = picorb_task_queue_new(vm);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
-  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
-  if (!sock->event_queue) {
-    mrbc_decref(&queue);
+  if (!picorb_socket_attach_event_queue(vm, &instance, sock)) {
     UDPSocket_close(vm, sock);
     picorb_free(vm, sock);
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
     return;
   }
-  *(mrbc_value *)sock->event_queue = queue;
-  mrbc_decref(&queue);
 #endif
 
   SET_RETURN(instance);

--- a/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
@@ -2,6 +2,25 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoruby.h"
+#ifdef PICO_CYW43_ARCH_POLL
+#include "c_task_queue.h"
+#endif
+
+#ifdef PICO_CYW43_ARCH_POLL
+void
+UDPSocket_notify_readable(picorb_socket_t *sock)
+{
+  if (!sock || !sock->event_queue) return;
+  mrbc_value event = mrbc_true_value();
+  (void)mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event);
+}
+#else
+void
+UDPSocket_notify_readable(picorb_socket_t *sock)
+{
+  (void)sock;
+}
+#endif
 
 /*
  * Helper function to get socket pointer from instance->data.
@@ -43,6 +62,22 @@ c_udp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   socket_wrapper_t *wrapper = (socket_wrapper_t *)instance.instance->data;
   wrapper->ptr = sock;
   wrapper->vm = vm;
+
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_value queue = mrbc_instance_new(vm, MRBC_CLASS(Task_Queue), 0);
+  mrbc_send(vm, v, argc, &queue, "initialize", 0);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@event_queue"), &queue);
+  sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
+  if (!sock->event_queue) {
+    mrbc_decref(&queue);
+    UDPSocket_close(vm, sock);
+    picorb_free(vm, sock);
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "failed to allocate event queue");
+    return;
+  }
+  *(mrbc_value *)sock->event_queue = queue;
+  mrbc_decref(&queue);
+#endif
 
   SET_RETURN(instance);
 }

--- a/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
@@ -67,9 +67,8 @@ c_udp_socket_new(mrbc_vm *vm, mrbc_value *v, int argc)
   wrapper->vm = vm;
 
 #ifdef PICO_CYW43_ARCH_POLL
-  mrbc_value queue = mrbc_instance_new(vm, MRBC_CLASS(Task_Queue), 0);
-  mrbc_send(vm, v, argc, &queue, "initialize", 0);
-  mrbc_instance_setiv(&instance, mrbc_str_to_symid("@event_queue"), &queue);
+  mrbc_value queue = picorb_task_queue_new(vm);
+  mrbc_instance_setiv(&instance, mrbc_str_to_symid("event_queue"), &queue);
   sock->event_queue = picorb_alloc(vm, sizeof(mrbc_value));
   if (!sock->event_queue) {
     mrbc_decref(&queue);
@@ -307,7 +306,9 @@ c_udp_socket_recvfrom_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* If no data available (non-blocking socket), return nil */
   if (received == 0) {
+#ifdef PICO_CYW43_ARCH_POLL
     sock->event_pending = false;
+#endif
     picorb_free(vm, buffer);
     SET_NIL_RETURN();
     return;
@@ -404,9 +405,15 @@ udp_socket_init(mrbc_vm *vm, mrbc_class *class_BasicSocket)
   mrbc_define_destructor(class_UDPSocket, mrbc_socket_free);
 
   mrbc_define_method(vm, class_UDPSocket, "new", c_udp_socket_new);
+#ifdef PICO_CYW43_ARCH_POLL
+  mrbc_define_method(vm, class_UDPSocket, "__bind_resolved", c_udp_socket_bind);
+  mrbc_define_method(vm, class_UDPSocket, "__connect_resolved", c_udp_socket_connect);
+  mrbc_define_method(vm, class_UDPSocket, "__send_resolved", c_udp_socket_send);
+#else
   mrbc_define_method(vm, class_UDPSocket, "bind", c_udp_socket_bind);
   mrbc_define_method(vm, class_UDPSocket, "connect", c_udp_socket_connect);
   mrbc_define_method(vm, class_UDPSocket, "send", c_udp_socket_send);
+#endif
   mrbc_define_method(vm, class_UDPSocket, "recvfrom_nonblock", c_udp_socket_recvfrom_nonblock);
   mrbc_define_method(vm, class_UDPSocket, "close", c_udp_socket_close);
   mrbc_define_method(vm, class_UDPSocket, "closed?", c_udp_socket_closed_q);

--- a/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
+++ b/mrbgems/picoruby-socket/src/mrubyc/udp_socket.c
@@ -10,9 +10,12 @@
 void
 UDPSocket_notify_readable(picorb_socket_t *sock)
 {
-  if (!sock || !sock->event_queue) return;
+  if (!sock || !sock->event_queue || sock->event_pending) return;
   mrbc_value event = mrbc_true_value();
-  (void)mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event);
+  if (mrbc_task_queue_push((mrbc_value *)sock->event_queue, &event) ==
+      MRBC_TASK_QUEUE_PUSH_OK) {
+    sock->event_pending = true;
+  }
 }
 #else
 void
@@ -304,6 +307,7 @@ c_udp_socket_recvfrom_nonblock(mrbc_vm *vm, mrbc_value *v, int argc)
 
   /* If no data available (non-blocking socket), return nil */
   if (received == 0) {
+    sock->event_pending = false;
     picorb_free(vm, buffer);
     SET_NIL_RETURN();
     return;

--- a/mrbgems/picoruby-time/src/mruby/time.c
+++ b/mrbgems/picoruby-time/src/mruby/time.c
@@ -103,11 +103,13 @@ new_from_unixtime_us(mrb_state *mrb, mrb_value klass, mrb_int unixtime_us)
 
   data->unixtime_us = unixtime_us + unixtime_offset * USEC;
   time_t unixtime = data->unixtime_us / USEC;
-  localtime_r(&unixtime, &data->tm);
 #if defined(PICORB_PLATFORM_POSIX)
+  localtime_r(&unixtime, &data->tm);
   data->timezone = timezone;
 #else
-  data->timezone = calculate_timezone_offset(unixtime);
+  data->timezone = ENV_get_timezone_offset();
+  time_t local_unixtime = unixtime - data->timezone;
+  gmtime_r(&local_unixtime, &data->tm);
 #endif
   return self;
 }
@@ -121,12 +123,15 @@ new_from_tm(mrb_state *mrb, mrb_value klass, struct tm *tm)
   mrb_value self = mrb_obj_value(Data_Wrap_Struct(mrb, cls, &mrb_time_type, data));
 
   time_t unixtime = mktime(tm);
+#if !defined(PICORB_PLATFORM_POSIX)
+  unixtime += ENV_get_timezone_offset();
+#endif
   data->unixtime_us = unixtime * USEC;
   memcpy(&data->tm, tm, sizeof(struct tm));
 #if defined(PICORB_PLATFORM_POSIX)
   data->timezone = timezone;
 #else
-  data->timezone = calculate_timezone_offset(unixtime);
+  data->timezone = ENV_get_timezone_offset();
 #endif
   return self;
 }

--- a/mrbgems/picoruby-time/src/mrubyc/time.c
+++ b/mrbgems/picoruby-time/src/mrubyc/time.c
@@ -75,13 +75,13 @@ new_from_unixtime_us(struct VM *vm, mrbc_value v[], mrbc_int_t unixtime_us)
   PICORB_TIME *data = (PICORB_TIME *)value.instance->data;
   data->unixtime_us = unixtime_us + unixtime_offset * USEC;
   time_t unixtime = data->unixtime_us / USEC;
-  localtime_r(&unixtime, &data->tm);
 #if defined(PICORB_PLATFORM_POSIX)
+  localtime_r(&unixtime, &data->tm);
   data->timezone = timezone;  /* global variable from time.h of glibc */
 #else
-  /* For non-POSIX platforms (e.g., RP2040 with newlib),
-   * calculate timezone offset by comparing localtime and gmtime */
-  data->timezone = calculate_timezone_offset(unixtime);
+  data->timezone = ENV_get_timezone_offset();
+  time_t local_unixtime = unixtime - data->timezone;
+  gmtime_r(&local_unixtime, &data->tm);
 #endif
   return value;
 }
@@ -92,14 +92,15 @@ new_from_tm(struct VM *vm, mrbc_value v[], struct tm *tm)
   mrbc_value value = mrbc_instance_new(vm, v->cls, sizeof(PICORB_TIME));
   PICORB_TIME *data = (PICORB_TIME *)value.instance->data;
   time_t unixtime = mktime(tm);
+#if !defined(PICORB_PLATFORM_POSIX)
+  unixtime += ENV_get_timezone_offset();
+#endif
   data->unixtime_us = unixtime * USEC;
   memcpy(&data->tm, tm, sizeof(struct tm));
 #if defined(PICORB_PLATFORM_POSIX)
   data->timezone = timezone;
 #else
-  /* For non-POSIX platforms (e.g., RP2040 with newlib),
-   * calculate timezone offset by comparing localtime and gmtime */
-  data->timezone = calculate_timezone_offset(unixtime);
+  data->timezone = ENV_get_timezone_offset();
 #endif
   return value;
 }

--- a/mrbgems/picoruby-time/src/time.c
+++ b/mrbgems/picoruby-time/src/time.c
@@ -1,37 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "../include/picogem_time.h"
-
-#if !defined(PICORB_PLATFORM_POSIX)
-static long
-calculate_timezone_offset(time_t unixtime)
-{
-  struct tm local_tm, utc_tm;
-  localtime_r(&unixtime, &local_tm);
-  gmtime_r(&unixtime, &utc_tm);
-
-  /* Calculate the difference in seconds between local time and UTC */
-  /* Note: mktime() interprets tm as local time, so we need to be careful */
-  long offset = 0;
-
-  /* Calculate hour and minute differences */
-  offset += (utc_tm.tm_hour - local_tm.tm_hour) * 3600;
-  offset += (utc_tm.tm_min - local_tm.tm_min) * 60;
-
-  /* Handle day boundary crossing */
-  if (utc_tm.tm_mday != local_tm.tm_mday) {
-    if (utc_tm.tm_mday > local_tm.tm_mday || (utc_tm.tm_mday == 1 && local_tm.tm_mday > 25)) {
-      /* UTC is ahead by one day */
-      offset += 86400;
-    } else {
-      /* UTC is behind by one day */
-      offset -= 86400;
-    }
-  }
-
-  return offset;
-}
-#endif
+#include "env.h"
 
 #if defined(PICORB_VM_MRUBY)
 
@@ -42,4 +12,3 @@ calculate_timezone_offset(time_t unixtime)
 #include "mrubyc/time.c"
 
 #endif
-


### PR DESCRIPTION
This pull request refactors the BLE event handling and environment variable management subsystems, improving reliability, responsiveness, and portability across platforms. The most significant changes include a new event queue mechanism for BLE events, removal of legacy packet/heartbeat polling, and proper handling of the `TZ` environment variable for time zone offsets, especially on RP2040. Additionally, the code now depends on `mruby-task` for event queue functionality.

### BLE Event Handling Refactor

* Replaced legacy packet/heartbeat polling with a unified event queue system using `Task::Queue`, improving responsiveness and simplifying the BLE event loop in `ble.rb`, `ble_hid.rb`, and `ble_uart.rb`. (`[[1]](diffhunk://#diff-c7f7f0e2a88512fe9d525b797c92282a8edd3847568f53b224aba9f0c8a3d29fR81)`, `[[2]](diffhunk://#diff-c7f7f0e2a88512fe9d525b797c92282a8edd3847568f53b224aba9f0c8a3d29fL117-R145)`, `[[3]](diffhunk://#diff-38c9dc323e4e9866bd965ccee1e00c54d7ffb443a7a203f801f708b526bba222L252-L263)`, `[[4]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R113-R130)`, `[[5]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6L129-R141)`)
* Updated the C and mruby/mrubyc bindings to push events (including packets and heartbeats) onto the event queue, with a cap on pending events and proper bookkeeping. (`[[1]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016R6-R50)`, `[[2]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016L64-L87)`, `[[3]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016R112-R114)`, `[[4]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016L183-R188)`, `[[5]](diffhunk://#diff-58d5df58f3c7a07f30f84616dcf4e001e782ac0b43709e19750f0f7dcd2f4a3cL12-L18)`, `[[6]](diffhunk://#diff-f321977cf23e1504a286b5fd736f7fe44f6b44442e5c02806f7b80eff8d1dcb8R3-R45)`, `[[7]](diffhunk://#diff-f321977cf23e1504a286b5fd736f7fe44f6b44442e5c02806f7b80eff8d1dcb8L62-L88)`, `[[8]](diffhunk://#diff-f321977cf23e1504a286b5fd736f7fe44f6b44442e5c02806f7b80eff8d1dcb8R116-R118)`, `[[9]](diffhunk://#diff-f321977cf23e1504a286b5fd736f7fe44f6b44442e5c02806f7b80eff8d1dcb8L149-R144)`, `[[10]](diffhunk://#diff-f321977cf23e1504a286b5fd736f7fe44f6b44442e5c02806f7b80eff8d1dcb8L188-L195)`)
* Added new private methods `_event_popped` and `_event_queue_cleared` for accurate event count management and queue state tracking. (`[[1]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016R6-R50)`, `[[2]](diffhunk://#diff-489004df977311c68ec2613e8599bc4445e08831b5f31334e1fab74fc3b5f016L183-R188)`, `[[3]](diffhunk://#diff-4d2454ca62a5d9603e905b31a6ed0d4431f14a923f465c4b6226bd8c9ed4af42L67-L85)`)

### BLE API and Signature Updates

* Updated BLE API signatures and removed obsolete methods like `pop_packet` and `pop_heartbeat` from Ruby and signature files, reflecting the new event-driven design. (`[[1]](diffhunk://#diff-4d2454ca62a5d9603e905b31a6ed0d4431f14a923f465c4b6226bd8c9ed4af42L67-L85)`, `[[2]](diffhunk://#diff-4eab2252815ff3edda46defd1ce07019477a47ec75aed53b76d7f2eb748dd693L30-R30)`)
* Changed user block invocation timing in `ble_uart.rb` to a fixed interval (`USER_BLOCK_INTERVAL_MS`) for more predictable scheduling. (`[[1]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6L41-R41)`, `[[2]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R113-R130)`, `[[3]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6L129-R141)`)

### Environment Variable and Timezone Handling

* Added `ENV_get_timezone_offset` to all platforms, with a robust implementation for RP2040 that parses and stores the offset from the `TZ` variable for local time conversion. (`[[1]](diffhunk://#diff-5ee1edf5dbde100ced7e88e58484c2fc2616592fc5218491ae8179a7d5a0c987R7-L9)`, `[[2]](diffhunk://#diff-98d2c7c3305ff365591c6940f8e73bf9b1131de5327f432606def9c374c709b4R30-R35)`, `[[3]](diffhunk://#diff-291f25fb191667ba05bdbaa340d67868ab3249586e9d82a88599038ba6dd2be4R63-R68)`, `[[4]](diffhunk://#diff-169d90c1d340e4b2ef49066cbd4040d06e22c03c46edc0e28588ac8260217808R1-R41)`, `[[5]](diffhunk://#diff-169d90c1d340e4b2ef49066cbd4040d06e22c03c46edc0e28588ac8260217808L16-R76)`)
* On RP2040, replaced standard environment variable functions with safe, static implementations to avoid heap usage and ensure firmware stability. (`[[1]](diffhunk://#diff-169d90c1d340e4b2ef49066cbd4040d06e22c03c46edc0e28588ac8260217808R1-R41)`, `[[2]](diffhunk://#diff-169d90c1d340e4b2ef49066cbd4040d06e22c03c46edc0e28588ac8260217808L16-R76)`)

### Build and Dependency Management

* Added a conditional dependency on `mruby-task` for the BLE gem when building for picoruby, ensuring the event queue is available. (`[mrbgems/picoruby-ble/mrbgem.rakeR7-L9](diffhunk://#diff-c145d7cc9e33bd89b9686d807ac637aa25a2c424309910b1cf613ab548463d9aR7-L9)`)

These changes collectively modernize BLE event handling, improve cross-platform support, and lay the groundwork for more robust and responsive BLE applications.