### PR TITLE
sqlite3: transactions, backup, and convenience methods (Phase 1)

### DIFF
--- a/mrbgems/picoruby-sqlite3/README.md
+++ b/mrbgems/picoruby-sqlite3/README.md
@@ -57,6 +57,35 @@ end
 db.close
 ```
 
+### Transactions
+
+Wrapping many writes in one transaction turns them into a single commit, which
+is the main way to cut flash write wear on a microcontroller:
+
+```ruby
+db.transaction do |t|
+  1000.times { |i| t.execute("INSERT INTO log (n) VALUES (?)", [i]) }
+end
+# Committed once here; rolled back automatically if the block raises
+```
+
+`commit` / `rollback` / `transaction_active?` are also available for manual
+control.
+
+### Backup
+
+Copy a database into another open database (for example, snapshot a working
+database to a second file on flash):
+
+```ruby
+dst = SQLite3::Database.new("/backup.sqlite3")
+db.backup(dst)   # copies every page in one step
+dst.close
+```
+
+The lower level `SQLite3::Backup` class (`new`, `step`, `finish`, `remaining`,
+`pagecount`) is available when you want to copy incrementally.
+
 ## API
 
 ### Database Methods
@@ -64,7 +93,14 @@ db.close
 - `SQLite3::Database.new(filename, results_as_hash: false)` - Open/create database
 - `execute(sql, bind_vars = [])` - Execute SQL with optional bindings
 - `execute(sql, bind_vars = []) { |row| }` - Execute with block iteration
+- `execute_batch(sql)` - Run a script of several statements (no bindings)
+- `query(sql, bind_vars = [])` - Like `execute` but returns a `ResultSet`
+- `get_first_row(sql, bind_vars = [])` - First row, or `nil`
+- `get_first_value(sql, bind_vars = [])` - First column of the first row, or `nil`
 - `prepare(sql)` - Return a `SQLite3::Statement`
+- `transaction(mode = :deferred) { |db| }` / `commit` / `rollback` / `transaction_active?`
+- `last_insert_row_id`, `changes`, `total_changes`
+- `backup(dst, srcname: "main", dstname: "main")` - Copy into another database
 - `results_as_hash=` - Yield rows as Hash instead of Array
 - `close()` / `closed?()`
 
@@ -76,7 +112,18 @@ db.close
 
 ### Errors
 
-Failures raise `SQLite3::Exception`, a subclass of `StandardError`.
+Failures raise `SQLite3::Exception`, a subclass of `StandardError`. A few common
+result codes raise a dedicated subclass so they can be rescued individually
+(each is still a `SQLite3::Exception`):
+
+| Exception | SQLite result code |
+|--------------------------------|--------------------|
+| `SQLite3::ConstraintException` | `SQLITE_CONSTRAINT` |
+| `SQLite3::BusyException`       | `SQLITE_BUSY`       |
+| `SQLite3::ReadOnlyException`   | `SQLITE_READONLY`   |
+| `SQLite3::FullException`       | `SQLITE_FULL`       |
+| `SQLite3::CorruptException`    | `SQLITE_CORRUPT`    |
+| `SQLite3::IOException`         | `SQLITE_IOERR`      |
 
 ## Supported Types
 

--- a/mrbgems/picoruby-sqlite3/include/sqlite3.h
+++ b/mrbgems/picoruby-sqlite3/include/sqlite3.h
@@ -28,16 +28,25 @@ typedef struct {
   bool done_p;
 } DbStatement;
 
+typedef struct {
+  sqlite3_backup *bk;
+} DbBackup;
+
 #if defined(PICORB_VM_MRUBY)
 
 extern const struct mrb_data_type mrb_sqlite3_database_type;
 extern const struct mrb_data_type mrb_sqlite3_statement_type;
+extern const struct mrb_data_type mrb_sqlite3_backup_type;
 
 struct RClass *mrb_sqlite3_exception_class(mrb_state *mrb);
+/* Maps a primary SQLite result code to the matching SQLite3::* exception
+   subclass, falling back to SQLite3::Exception for codes without one. */
+struct RClass *mrb_sqlite3_exception_class_for(mrb_state *mrb, int status);
 void prb_sqlite3_raise(mrb_state *mrb, sqlite3 *db, int status);
 
 void mrb_init_class_SQLite3_Database(mrb_state *mrb, struct RClass *class_SQLite3);
 void mrb_init_class_SQLite3_Statement(mrb_state *mrb, struct RClass *class_SQLite3);
+void mrb_init_class_SQLite3_Backup(mrb_state *mrb, struct RClass *class_SQLite3);
 
 #endif
 

--- a/mrbgems/picoruby-sqlite3/mrblib/database.rb
+++ b/mrbgems/picoruby-sqlite3/mrblib/database.rb
@@ -49,5 +49,69 @@ class SQLite3
         stmt.close unless stmt.closed?
       end
     end
+
+    # Like #execute but returns a ResultSet you step through yourself. With a
+    # block the ResultSet is yielded and closed for you.
+    def query(sql, bind_vars = [])
+      stmt = prepare(sql)
+      stmt.bind_params(*bind_vars) unless bind_vars.empty?
+      result = SQLite3::ResultSet.new(self, stmt)
+      return result unless block_given?
+      begin
+        yield result
+      ensure
+        result.close
+      end
+    end
+
+    def get_first_row(sql, bind_vars = [])
+      execute(sql, bind_vars).first
+    end
+
+    def get_first_value(sql, bind_vars = [])
+      execute(sql, bind_vars) do |row|
+        return row.is_a?(Array) ? row[0] : row.values.first
+      end
+      nil
+    end
+
+    # Wrap a block in a transaction. Committing on success and rolling back on
+    # an exception. On flash backed storage this is the main lever for cutting
+    # write wear: many INSERTs in one transaction become a single commit.
+    def transaction(mode = :deferred)
+      execute("BEGIN #{mode.to_s.upcase} TRANSACTION")
+      return true unless block_given?
+      aborting = false
+      begin
+        yield self
+      rescue
+        aborting = true
+        raise
+      ensure
+        aborting ? rollback : commit
+      end
+    end
+
+    def commit
+      execute("COMMIT TRANSACTION")
+      true
+    end
+
+    def rollback
+      execute("ROLLBACK TRANSACTION")
+      true
+    end
+
+    # Copy this database into an already open destination database. Passing -1
+    # to Backup#step copies every remaining page, so one step finishes the copy.
+    def backup(dst, srcname: "main", dstname: "main")
+      b = SQLite3::Backup.new(dst, dstname, self, srcname)
+      begin
+        b.step(-1)
+      ensure
+        b.finish
+      end
+      true
+    end
   end
 end

--- a/mrbgems/picoruby-sqlite3/sig/backup.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/backup.rbs
@@ -1,0 +1,16 @@
+class SQLite3
+  # Online backup of one database into another, mirroring the sqlite3 gem.
+  # step() returns one of the constants below.
+  class Backup
+    OK: Integer
+    DONE: Integer
+    BUSY: Integer
+    LOCKED: Integer
+
+    def self.new: (SQLite3::Database dst, String dstname, SQLite3::Database src, String srcname) -> SQLite3::Backup
+    def step: (Integer pages) -> Integer
+    def finish: () -> nil
+    def remaining: () -> Integer
+    def pagecount: () -> Integer
+  end
+end

--- a/mrbgems/picoruby-sqlite3/sig/database.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/database.rbs
@@ -17,6 +17,24 @@ class SQLite3
                | (String sql, ?Array[sqlite3_bind_t] bind_vars) { (untyped) -> untyped } -> nil
     def prepare: (String sql) { (SQLite3::Statement) -> untyped } -> nil
                | (String sql) -> SQLite3::Statement
+
+    def query: (String sql, ?Array[sqlite3_bind_t] bind_vars) -> SQLite3::ResultSet
+             | (String sql, ?Array[sqlite3_bind_t] bind_vars) { (SQLite3::ResultSet) -> untyped } -> untyped
+    def get_first_row: (String sql, ?Array[sqlite3_bind_t] bind_vars) -> (Array[sqlite3_var_t] | Hash[String, sqlite3_var_t])?
+    def get_first_value: (String sql, ?Array[sqlite3_bind_t] bind_vars) -> sqlite3_var_t
+
+    def execute_batch: (String sql) -> nil
+    def last_insert_row_id: () -> Integer
+    def changes: () -> Integer
+    def total_changes: () -> Integer
+
+    def transaction: (?Symbol mode) -> bool
+                   | (?Symbol mode) { (SQLite3::Database) -> untyped } -> untyped
+    def commit: () -> bool
+    def rollback: () -> bool
+    def transaction_active?: () -> bool
+
+    def backup: (SQLite3::Database dst, ?srcname: String, ?dstname: String) -> bool
   end
 end
 

--- a/mrbgems/picoruby-sqlite3/sig/exception.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/exception.rbs
@@ -2,4 +2,24 @@ class SQLite3
   # @sidebar error
   class Exception < StandardError
   end
+
+  # Raised for the SQLite result codes that most often need distinct handling
+  # on a microcontroller. Other result codes raise the base Exception.
+  class ConstraintException < Exception
+  end
+
+  class BusyException < Exception
+  end
+
+  class ReadOnlyException < Exception
+  end
+
+  class FullException < Exception
+  end
+
+  class CorruptException < Exception
+  end
+
+  class IOException < Exception
+  end
 end

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_backup.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_backup.c
@@ -1,0 +1,157 @@
+#include <mruby/class.h>
+#include <mruby/data.h>
+#include <mruby/presym.h>
+#include <mruby/string.h>
+#include <mruby/variable.h>
+
+static void
+mrb_sqlite3_backup_free(mrb_state *mrb, void *ptr)
+{
+  DbBackup *bk = (DbBackup *)ptr;
+  if (bk == NULL) return;
+  if (bk->bk) {
+    /* Finishing an unfinished backup reaches the VFS */
+    prb_vfs_suspend_calls(true);
+    sqlite3_backup_finish(bk->bk);
+    prb_vfs_suspend_calls(false);
+    bk->bk = NULL;
+  }
+  mrb_free(mrb, bk);
+}
+
+const struct mrb_data_type mrb_sqlite3_backup_type = {
+  "SQLite3::Backup", mrb_sqlite3_backup_free,
+};
+
+static DbBackup *
+backup(mrb_state *mrb, mrb_value self)
+{
+  return (DbBackup *)mrb_data_get_ptr(mrb, self, &mrb_sqlite3_backup_type);
+}
+
+static sqlite3 *
+db_handle_of(mrb_state *mrb, mrb_value db_obj)
+{
+  DbState *state = (DbState *)mrb_data_get_ptr(mrb, db_obj, &mrb_sqlite3_database_type);
+  if (state->closed || state->db == NULL) {
+    mrb_raise(mrb, mrb_sqlite3_exception_class(mrb), "cannot use a closed database");
+  }
+  return state->db;
+}
+
+/*
+ * SQLite3::Backup.new(dst_db, dst_name, src_db, src_name)
+ *
+ * `dst_name`/`src_name` are database names, usually "main". The two databases
+ * commonly live on the same mounted volume; copying across volumes served by
+ * different drivers is not supported by the VFS bridge.
+ */
+static mrb_value
+mrb_s_backup_new(mrb_state *mrb, mrb_value klass)
+{
+  mrb_value dst_db, src_db;
+  const char *dst_name, *src_name;
+  mrb_get_args(mrb, "ozoz", &dst_db, &dst_name, &src_db, &src_name);
+
+  sqlite3 *dst = db_handle_of(mrb, dst_db);
+  sqlite3 *src = db_handle_of(mrb, src_db);
+
+  DbBackup *bk = (DbBackup *)mrb_malloc(mrb, sizeof(DbBackup));
+  bk->bk = NULL;
+  mrb_value self = mrb_obj_value(
+    Data_Wrap_Struct(mrb, mrb_class_ptr(klass), &mrb_sqlite3_backup_type, bk));
+
+  bk->bk = sqlite3_backup_init(dst, dst_name, src, src_name);
+  if (bk->bk == NULL) {
+    /* The failure reason is recorded on the destination connection */
+    prb_sqlite3_raise(mrb, dst, sqlite3_errcode(dst));
+    /* prb_sqlite3_raise only raises for non-OK codes; guard the odd case */
+    mrb_raise(mrb, mrb_sqlite3_exception_class(mrb), "could not initialize backup");
+  }
+
+  /* Keep both connections alive for the lifetime of the backup handle */
+  mrb_iv_set(mrb, self, MRB_IVSYM(dst), dst_db);
+  mrb_iv_set(mrb, self, MRB_IVSYM(src), src_db);
+  return self;
+}
+
+static DbBackup *
+open_backup(mrb_state *mrb, mrb_value self)
+{
+  DbBackup *bk = backup(mrb, self);
+  if (bk->bk == NULL) {
+    mrb_raise(mrb, mrb_sqlite3_exception_class(mrb), "backup is already finished");
+  }
+  return bk;
+}
+
+/*
+ * step(pages) -> Integer
+ *
+ * Copies up to `pages` pages (a negative value copies all remaining pages).
+ * Returns SQLite3::Backup::DONE when finished, ::OK when more pages remain, or
+ * ::BUSY / ::LOCKED when the source is momentarily unavailable. Any other
+ * result raises.
+ */
+static mrb_value
+mrb_backup_step(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pages;
+  mrb_get_args(mrb, "i", &pages);
+  sqlite3_backup *bk = open_backup(mrb, self)->bk;
+
+  int rc = sqlite3_backup_step(bk, (int)pages);
+  switch (rc) {
+    case SQLITE_OK:
+    case SQLITE_DONE:
+    case SQLITE_BUSY:
+    case SQLITE_LOCKED:
+      return mrb_fixnum_value(rc);
+    default:
+      prb_sqlite3_raise(mrb, NULL, rc);
+      return mrb_nil_value();
+  }
+}
+
+static mrb_value
+mrb_backup_finish(mrb_state *mrb, mrb_value self)
+{
+  DbBackup *bk = backup(mrb, self);
+  if (bk->bk) {
+    sqlite3_backup_finish(bk->bk);
+    bk->bk = NULL;
+  }
+  return mrb_nil_value();
+}
+
+static mrb_value
+mrb_backup_remaining(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(sqlite3_backup_remaining(open_backup(mrb, self)->bk));
+}
+
+static mrb_value
+mrb_backup_pagecount(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(sqlite3_backup_pagecount(open_backup(mrb, self)->bk));
+}
+
+void
+mrb_init_class_SQLite3_Backup(mrb_state *mrb, struct RClass *class_SQLite3)
+{
+  struct RClass *class_SQLite3_Backup = mrb_define_class_under_id(
+    mrb, class_SQLite3, MRB_SYM(Backup), mrb->object_class);
+  MRB_SET_INSTANCE_TT(class_SQLite3_Backup, MRB_TT_CDATA);
+
+  /* step() return codes, so callers can drive the loop CRuby style */
+  mrb_define_const_id(mrb, class_SQLite3_Backup, MRB_SYM(OK), mrb_fixnum_value(SQLITE_OK));
+  mrb_define_const_id(mrb, class_SQLite3_Backup, MRB_SYM(DONE), mrb_fixnum_value(SQLITE_DONE));
+  mrb_define_const_id(mrb, class_SQLite3_Backup, MRB_SYM(BUSY), mrb_fixnum_value(SQLITE_BUSY));
+  mrb_define_const_id(mrb, class_SQLite3_Backup, MRB_SYM(LOCKED), mrb_fixnum_value(SQLITE_LOCKED));
+
+  mrb_define_class_method_id(mrb, class_SQLite3_Backup, MRB_SYM(new), mrb_s_backup_new, MRB_ARGS_REQ(4));
+  mrb_define_method_id(mrb, class_SQLite3_Backup, MRB_SYM(step), mrb_backup_step, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_SQLite3_Backup, MRB_SYM(finish), mrb_backup_finish, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Backup, MRB_SYM(remaining), mrb_backup_remaining, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Backup, MRB_SYM(pagecount), mrb_backup_pagecount, MRB_ARGS_NONE());
+}

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
@@ -28,6 +28,16 @@ db_state(mrb_state *mrb, mrb_value self)
   return (DbState *)mrb_data_get_ptr(mrb, self, &mrb_sqlite3_database_type);
 }
 
+static DbState *
+open_db_state(mrb_state *mrb, mrb_value self)
+{
+  DbState *state = db_state(mrb, self);
+  if (state->closed || state->db == NULL) {
+    mrb_raise(mrb, mrb_sqlite3_exception_class(mrb), "cannot use a closed database");
+  }
+  return state;
+}
+
 /*
  * SQLite3::Database._open(driver, path)
  *
@@ -91,6 +101,59 @@ mrb_Database_closed_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(db_state(mrb, self)->closed);
 }
 
+static mrb_value
+mrb_Database_last_insert_row_id(mrb_state *mrb, mrb_value self)
+{
+  sqlite3_int64 id = sqlite3_last_insert_rowid(open_db_state(mrb, self)->db);
+  /* rowid is 64-bit; these builds define MRB_INT64, so mrb_int_value keeps it */
+  return mrb_int_value(mrb, (mrb_int)id);
+}
+
+static mrb_value
+mrb_Database_changes(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(sqlite3_changes(open_db_state(mrb, self)->db));
+}
+
+static mrb_value
+mrb_Database_total_changes(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(sqlite3_total_changes(open_db_state(mrb, self)->db));
+}
+
+static mrb_value
+mrb_Database_transaction_active_p(mrb_state *mrb, mrb_value self)
+{
+  /* Outside a transaction SQLite is in autocommit mode */
+  return mrb_bool_value(sqlite3_get_autocommit(open_db_state(mrb, self)->db) == 0);
+}
+
+/*
+ * execute_batch(sql) -> nil
+ *
+ * Runs a script of one or more semicolon separated statements, discarding any
+ * rows they produce. Handy for schema setup and migrations. Parameter binding
+ * is not supported here (use #execute for that).
+ */
+static mrb_value
+mrb_Database_execute_batch(mrb_state *mrb, mrb_value self)
+{
+  const char *sql;
+  mrb_get_args(mrb, "z", &sql);
+  sqlite3 *db = open_db_state(mrb, self)->db;
+
+  char *errmsg = NULL;
+  int rc = sqlite3_exec(db, sql, NULL, NULL, &errmsg);
+  if (rc != SQLITE_OK) {
+    /* sqlite3_exec owns errmsg; copy it into an exception before freeing */
+    mrb_value message = errmsg ? mrb_str_new_cstr(mrb, errmsg)
+                               : mrb_str_new_lit(mrb, "SQLite3 error");
+    if (errmsg) sqlite3_free(errmsg);
+    mrb_raise(mrb, mrb_sqlite3_exception_class_for(mrb, rc), RSTRING_PTR(message));
+  }
+  return mrb_nil_value();
+}
+
 void
 mrb_init_class_SQLite3_Database(mrb_state *mrb, struct RClass *class_SQLite3)
 {
@@ -101,4 +164,9 @@ mrb_init_class_SQLite3_Database(mrb_state *mrb, struct RClass *class_SQLite3)
   mrb_define_class_method_id(mrb, class_SQLite3_Database, MRB_SYM(_open), mrb_s__open, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(close), mrb_Database_close, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM_Q(closed), mrb_Database_closed_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(last_insert_row_id), mrb_Database_last_insert_row_id, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(changes), mrb_Database_changes, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(total_changes), mrb_Database_total_changes, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM_Q(transaction_active), mrb_Database_transaction_active_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(execute_batch), mrb_Database_execute_batch, MRB_ARGS_REQ(1));
 }

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_sqlite3.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_sqlite3.c
@@ -8,16 +8,46 @@ mrb_sqlite3_exception_class(mrb_state *mrb)
   return mrb_class_get_under_id(mrb, class_SQLite3, MRB_SYM(Exception));
 }
 
+struct RClass *
+mrb_sqlite3_exception_class_for(mrb_state *mrb, int status)
+{
+  /* All subclasses are defined in gem_init below, so the lookup always
+     succeeds; presym symbols keep this free of runtime string interning. */
+  struct RClass *class_SQLite3 = mrb_class_get_id(mrb, MRB_SYM(SQLite3));
+  mrb_sym sym;
+  switch (status & 0xFF) {
+    case SQLITE_CONSTRAINT: sym = MRB_SYM(ConstraintException); break;
+    case SQLITE_BUSY:       sym = MRB_SYM(BusyException);       break;
+    case SQLITE_READONLY:   sym = MRB_SYM(ReadOnlyException);   break;
+    case SQLITE_FULL:       sym = MRB_SYM(FullException);       break;
+    case SQLITE_CORRUPT:    sym = MRB_SYM(CorruptException);    break;
+    case SQLITE_IOERR:      sym = MRB_SYM(IOException);         break;
+    default:                return mrb_sqlite3_exception_class(mrb);
+  }
+  return mrb_class_get_under_id(mrb, class_SQLite3, sym);
+}
+
 void
 mrb_picoruby_sqlite3_gem_init(mrb_state *mrb)
 {
   struct RClass *class_SQLite3 = mrb_define_class_id(mrb, MRB_SYM(SQLite3), mrb->object_class);
 
-  /* Defined here rather than in mrblib so that the C code can always raise it */
-  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(Exception), mrb->eStandardError_class);
+  /* Defined here rather than in mrblib so that the C code can always raise it.
+     The subset of subclasses mirrors the sqlite3 gem for the result codes that
+     matter most on a microcontroller (constraint violations plus the flash
+     failure modes: full, corrupt, I/O error). */
+  struct RClass *class_Exception =
+    mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(Exception), mrb->eStandardError_class);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(ConstraintException), class_Exception);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(BusyException), class_Exception);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(ReadOnlyException), class_Exception);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(FullException), class_Exception);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(CorruptException), class_Exception);
+  mrb_define_class_under_id(mrb, class_SQLite3, MRB_SYM(IOException), class_Exception);
 
   mrb_init_class_SQLite3_Database(mrb, class_SQLite3);
   mrb_init_class_SQLite3_Statement(mrb, class_SQLite3);
+  mrb_init_class_SQLite3_Backup(mrb, class_SQLite3);
 }
 
 void

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_statement.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_statement.c
@@ -46,7 +46,7 @@ prb_sqlite3_raise(mrb_state *mrb, sqlite3 *db, int status)
   if ((status & 0xFF) == SQLITE_OK) return;
   const char *err = db ? sqlite3_errmsg(db) : NULL;
   if (err == NULL) err = "SQLite3 error";
-  mrb_raise(mrb, mrb_sqlite3_exception_class(mrb), err);
+  mrb_raise(mrb, mrb_sqlite3_exception_class_for(mrb, status), err);
 }
 
 static mrb_value

--- a/mrbgems/picoruby-sqlite3/src/sqlite3_backup.c
+++ b/mrbgems/picoruby-sqlite3/src/sqlite3_backup.c
@@ -1,0 +1,7 @@
+#include "../include/sqlite3.h"
+
+#if defined(PICORB_VM_MRUBY)
+
+#include "mruby/sqlite3_backup.c"
+
+#endif

--- a/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
+++ b/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
@@ -182,4 +182,180 @@ class Sqlite3Test < Picotest::Test
       end
     end
   end
+
+  def test_constraint_violation_raises_subclass
+    db = fresh_db("/constraint.db")
+    db.execute("INSERT INTO users (id, name) VALUES (1, 'Alice')")
+    # Reusing the primary key violates the UNIQUE constraint
+    assert_raise(SQLite3::ConstraintException) do
+      db.execute("INSERT INTO users (id, name) VALUES (1, 'Bob')")
+    end
+    # The subclass is still a SQLite3::Exception for generic rescues
+    assert_true(SQLite3::ConstraintException.ancestors.include?(SQLite3::Exception))
+    db.close
+  end
+
+  def test_last_insert_row_id
+    db = fresh_db("/rowid.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    assert_equal(1, db.last_insert_row_id)
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Bob"])
+    assert_equal(2, db.last_insert_row_id)
+    db.close
+  end
+
+  def test_changes_and_total_changes
+    db = fresh_db("/changes.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Bob"])
+    db.execute("UPDATE users SET age = 1")
+    assert_equal(2, db.changes)
+    # 1 (Alice) + 1 (Bob) + 2 (UPDATE touches both rows)
+    assert_equal(4, db.total_changes)
+    db.close
+  end
+
+  def test_execute_batch
+    db = SQLite3::Database.new("/batch.db")
+    db.execute_batch(<<~SQL)
+      DROP TABLE IF EXISTS a;
+      CREATE TABLE a (id INTEGER);
+      INSERT INTO a VALUES (1);
+      INSERT INTO a VALUES (2);
+    SQL
+    assert_equal([[1], [2]], db.execute("SELECT id FROM a ORDER BY id"))
+    db.close
+  end
+
+  def test_execute_batch_error_raises
+    db = SQLite3::Database.new("/batch_err.db")
+    assert_raise(SQLite3::Exception) do
+      db.execute_batch("CREATE TABLE ok (id INTEGER); INVALID SQL HERE;")
+    end
+    db.close
+  end
+
+  def test_get_first_row
+    db = fresh_db("/first_row.db")
+    db.execute("INSERT INTO users (name, age) VALUES (?, ?)", ["Alice", 30])
+    db.execute("INSERT INTO users (name, age) VALUES (?, ?)", ["Bob", 25])
+    assert_equal([1, "Alice", 30], db.get_first_row("SELECT id, name, age FROM users ORDER BY id"))
+    assert_nil(db.get_first_row("SELECT * FROM users WHERE name = ?", ["Nobody"]))
+    db.close
+  end
+
+  def test_get_first_value
+    db = fresh_db("/first_value.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Bob"])
+    assert_equal(2, db.get_first_value("SELECT COUNT(*) FROM users"))
+    assert_equal("Alice", db.get_first_value("SELECT name FROM users ORDER BY id"))
+    assert_nil(db.get_first_value("SELECT name FROM users WHERE name = ?", ["Nobody"]))
+    db.close
+  end
+
+  def test_query_without_block
+    db = fresh_db("/query.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    result = db.query("SELECT name FROM users")
+    assert_equal(["Alice"], result.next)
+    assert_nil(result.next)
+    result.close
+    db.close
+  end
+
+  def test_query_with_block_closes
+    db = fresh_db("/query_block.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    captured = nil
+    db.query("SELECT name FROM users") do |result|
+      captured = result
+      assert_equal(["Alice"], result.next)
+    end
+    assert_true(captured.closed?)
+    db.close
+  end
+
+  def test_transaction_active
+    db = fresh_db("/txn_active.db")
+    assert_false(db.transaction_active?)
+    db.transaction
+    assert_true(db.transaction_active?)
+    db.commit
+    assert_false(db.transaction_active?)
+    db.close
+  end
+
+  def test_transaction_block_commits
+    db = fresh_db("/txn_commit.db")
+    db.transaction do |t|
+      t.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+      t.execute("INSERT INTO users (name) VALUES (?)", ["Bob"])
+    end
+    assert_false(db.transaction_active?)
+    assert_equal(2, db.get_first_value("SELECT COUNT(*) FROM users"))
+    db.close
+  end
+
+  def test_transaction_block_rolls_back_on_error
+    db = fresh_db("/txn_rollback.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Seed"])
+    assert_raise(RuntimeError) do
+      db.transaction do |t|
+        t.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+        raise "boom"
+      end
+    end
+    assert_false(db.transaction_active?)
+    # Only the pre-transaction row survives
+    assert_equal(1, db.get_first_value("SELECT COUNT(*) FROM users"))
+    db.close
+  end
+
+  def test_manual_rollback
+    db = fresh_db("/manual_rollback.db")
+    db.transaction
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    db.rollback
+    assert_equal(0, db.get_first_value("SELECT COUNT(*) FROM users"))
+    db.close
+  end
+
+  def test_backup_copies_database
+    src = fresh_db("/backup_src.db")
+    src.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    src.execute("INSERT INTO users (name) VALUES (?)", ["Bob"])
+
+    dst = SQLite3::Database.new("/backup_dst.db")
+    src.backup(dst)
+    src.close
+
+    assert_equal([[1, "Alice", nil], [2, "Bob", nil]],
+      dst.execute("SELECT id, name, age FROM users ORDER BY id"))
+    dst.close
+  end
+
+  def test_backup_class_step_reports_done
+    src = fresh_db("/backup_step_src.db")
+    src.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    dst = SQLite3::Database.new("/backup_step_dst.db")
+
+    b = SQLite3::Backup.new(dst, "main", src, "main")
+    assert_true(b.pagecount >= 0)
+    status = b.step(-1)
+    assert_equal(SQLite3::Backup::DONE, status)
+    assert_equal(0, b.remaining)
+    b.finish
+    assert_equal("Alice", dst.get_first_value("SELECT name FROM users"))
+    src.close
+    dst.close
+  end
+
+  def test_closed_database_guard
+    db = fresh_db("/closed_guard.db")
+    db.close
+    assert_raise(SQLite3::Exception) { db.last_insert_row_id }
+    assert_raise(SQLite3::Exception) { db.changes }
+    assert_raise(SQLite3::Exception) { db.execute_batch("SELECT 1") }
+  end
 end


### PR DESCRIPTION
## Summary

First batch of expanding `picoruby-sqlite3` toward CRuby `sqlite3` gem
compatibility, prioritizing what is useful on a microcontroller. API is kept
CRuby-compatible.

### Database
- `transaction(mode = :deferred) { |db| }` with `commit` / `rollback` /
  `transaction_active?` — batching writes in one transaction is the main lever
  for cutting flash write wear
- `last_insert_row_id`, `changes`, `total_changes`
- `execute_batch(sql)` for multi-statement scripts (schema / migrations)
- `query`, `get_first_row`, `get_first_value` convenience readers

### Backup
- `SQLite3::Backup` (`new` / `step` / `finish` / `remaining` / `pagecount`)
- `Database#backup(dst)` convenience that copies in one step — handy for
  snapshotting a working database to another file on flash

### Exceptions (practical subset)
Map the SQLite result codes that most need distinct handling to
`SQLite3::Exception` subclasses: `ConstraintException`, `BusyException`,
`ReadOnlyException`, and the flash failure modes `FullException`,
`CorruptException`, `IOException`. Other codes still raise the base
`Exception`. Classes are defined with presym symbols so they add no
runtime-interned symbols (RAM) on the target.

Deferred by design: the full CRuby exception hierarchy and `create_function`.

## Test plan
- `rake test:gems:picoruby[picoruby-sqlite3]` — 59 assertions, all passing
- `rake test:gems:steep` — no type errors
- rbs signatures updated (`sig/backup.rbs` added); README documents the new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)