### PR TITLE
sqlite3: pragma helpers and readonly?/filename (Phase 2)

### DIFF
--- a/mrbgems/picoruby-sqlite3/README.md
+++ b/mrbgems/picoruby-sqlite3/README.md
@@ -86,6 +86,28 @@ dst.close
 The lower level `SQLite3::Backup` class (`new`, `step`, `finish`, `remaining`,
 `pagecount`) is available when you want to copy incrementally.
 
+### Pragmas and migrations
+
+`user_version` is the usual lever for on-device schema migrations, and the
+journal/synchronous pragmas trade durability for fewer flash writes:
+
+```ruby
+# Cut flash writes: keep the rollback journal in RAM, sync less aggressively
+db.journal_mode = :memory
+db.synchronous = 0
+
+# Migrate the schema based on a stored version stamp
+if db.user_version < 1
+  db.execute_batch("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT);")
+  db.user_version = 1
+end
+
+db.integrity_check   # => "ok"
+```
+
+Other pragmas are reachable with `db.pragma("name")` / `db.pragma("name", value)`
+or a raw `execute("PRAGMA ...")`.
+
 ## API
 
 ### Database Methods
@@ -101,8 +123,21 @@ The lower level `SQLite3::Backup` class (`new`, `step`, `finish`, `remaining`,
 - `transaction(mode = :deferred) { |db| }` / `commit` / `rollback` / `transaction_active?`
 - `last_insert_row_id`, `changes`, `total_changes`
 - `backup(dst, srcname: "main", dstname: "main")` - Copy into another database
+- `readonly?`, `filename`
 - `results_as_hash=` - Yield rows as Hash instead of Array
 - `close()` / `closed?()`
+
+### Pragma Methods
+
+Convenience accessors for the pragmas most useful on a microcontroller:
+
+- `user_version` / `user_version=` - schema version stamp for migrations
+- `journal_mode` / `journal_mode=` - e.g. `:memory` or `:off` to avoid journal writes
+- `synchronous` / `synchronous=`
+- `cache_size` / `cache_size=`, `page_size` / `page_size=`
+- `foreign_keys` / `foreign_keys=`, `auto_vacuum` / `auto_vacuum=`
+- `freelist_count`, `integrity_check`
+- `pragma(name, value = nil)` - generic query/set for any pragma
 
 ### Statement Methods
 

--- a/mrbgems/picoruby-sqlite3/mrblib/pragmas.rb
+++ b/mrbgems/picoruby-sqlite3/mrblib/pragmas.rb
@@ -1,0 +1,122 @@
+class SQLite3
+  # A focused subset of the sqlite3 gem's Pragmas, covering what is most useful
+  # on a microcontroller: schema migration (user_version) and flash tuning
+  # (journal_mode, synchronous, ...). Any other pragma is still reachable with
+  # #pragma or a raw execute("PRAGMA ...").
+  module Pragmas
+    # Run a PRAGMA. With no value it queries and returns the rows; with a value
+    # it sets and returns whatever rows the pragma emits (usually none).
+    def pragma(name, value = nil)
+      if value.nil?
+        execute("PRAGMA #{name}")
+      else
+        execute("PRAGMA #{name} = #{pragma_value(value)}")
+      end
+    end
+
+    # Schema version stamp. The usual lever for on-device migrations: bump it
+    # after applying a migration and compare it on the next boot.
+    def user_version
+      int_pragma("user_version")
+    end
+
+    def user_version=(version)
+      execute("PRAGMA user_version = #{version.to_i}")
+    end
+
+    # "delete", "truncate", "persist", "memory", "wal" or "off". "memory" and
+    # "off" avoid journal writes to flash at the cost of crash safety.
+    def journal_mode
+      get_first_value("PRAGMA journal_mode").to_s
+    end
+
+    def journal_mode=(mode)
+      execute("PRAGMA journal_mode = #{pragma_token(mode)}")
+    end
+
+    # 0 (off), 1 (normal), 2 (full) or 3 (extra). Lower values mean fewer flash
+    # syncs but less durability across power loss.
+    def synchronous
+      int_pragma("synchronous")
+    end
+
+    def synchronous=(mode)
+      execute("PRAGMA synchronous = #{pragma_token(mode)}")
+    end
+
+    def cache_size
+      int_pragma("cache_size")
+    end
+
+    def cache_size=(size)
+      execute("PRAGMA cache_size = #{size.to_i}")
+    end
+
+    def page_size
+      int_pragma("page_size")
+    end
+
+    def page_size=(size)
+      execute("PRAGMA page_size = #{size.to_i}")
+    end
+
+    # Foreign key enforcement is off by default in SQLite; turn it on per
+    # connection when you rely on it.
+    def foreign_keys
+      get_first_value("PRAGMA foreign_keys") == 1
+    end
+
+    def foreign_keys=(enabled)
+      execute("PRAGMA foreign_keys = #{enabled ? 'ON' : 'OFF'}")
+    end
+
+    def auto_vacuum
+      int_pragma("auto_vacuum")
+    end
+
+    def auto_vacuum=(mode)
+      execute("PRAGMA auto_vacuum = #{pragma_token(mode)}")
+    end
+
+    def freelist_count
+      int_pragma("freelist_count")
+    end
+
+    # Returns "ok" when the database is intact, otherwise a description of the
+    # first problem found. Useful after an unexpected power loss.
+    def integrity_check
+      get_first_value("PRAGMA integrity_check").to_s
+    end
+
+    private
+
+    # A single-value pragma read back as an Integer. Going through to_s keeps
+    # this total over every type SQLite may hand back (including nil).
+    def int_pragma(name)
+      get_first_value("PRAGMA #{name}").to_s.to_i
+    end
+
+    # A mode name (Symbol/String like :wal or "MEMORY") is a bare token, not a
+    # quoted value.
+    def pragma_token(value)
+      value.to_s
+    end
+
+    def pragma_value(value)
+      case value
+      when Integer, Symbol
+        value.to_s
+      when true
+        "ON"
+      when false
+        "OFF"
+      else
+        "'#{value.to_s.gsub("'", "''")}'"
+      end
+    end
+  end
+
+  class Database
+    include Pragmas
+  end
+end

--- a/mrbgems/picoruby-sqlite3/sig/database.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/database.rbs
@@ -1,5 +1,7 @@
 class SQLite3
   class Database
+    include SQLite3::Pragmas
+
     type sqlite3_row_t = Hash[String, String] | Array[String]
 
     def initialize: (String filename, ?results_as_hash: bool) ?{ (SQLite3::Database) -> void } -> void
@@ -35,6 +37,9 @@ class SQLite3
     def transaction_active?: () -> bool
 
     def backup: (SQLite3::Database dst, ?srcname: String, ?dstname: String) -> bool
+
+    def readonly?: () -> bool
+    def filename: () -> String?
   end
 end
 

--- a/mrbgems/picoruby-sqlite3/sig/pragmas.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/pragmas.rbs
@@ -1,0 +1,36 @@
+class SQLite3
+  # What the pragma helpers need from their host (Database provides these).
+  # Used as the module self type to avoid a circular include with Database.
+  interface _PragmaExec
+    def execute: (String sql, ?Array[untyped] bind_vars) -> untyped
+    def get_first_value: (String sql, ?Array[untyped] bind_vars) -> untyped
+  end
+
+  # A focused subset of the sqlite3 gem's pragma helpers. Mixed into Database.
+  module Pragmas : _PragmaExec
+    def pragma: (String name, ?untyped value) -> Array[untyped]
+
+    def user_version: () -> Integer
+    def user_version=: (Integer version) -> untyped
+    def journal_mode: () -> String
+    def journal_mode=: (String | Symbol mode) -> untyped
+    def synchronous: () -> Integer
+    def synchronous=: (Integer | String | Symbol mode) -> untyped
+    def cache_size: () -> Integer
+    def cache_size=: (Integer size) -> untyped
+    def page_size: () -> Integer
+    def page_size=: (Integer size) -> untyped
+    def foreign_keys: () -> bool
+    def foreign_keys=: (bool enabled) -> untyped
+    def auto_vacuum: () -> Integer
+    def auto_vacuum=: (Integer | String | Symbol mode) -> untyped
+    def freelist_count: () -> Integer
+    def integrity_check: () -> String
+
+    private
+
+    def int_pragma: (String name) -> Integer
+    def pragma_token: (untyped value) -> String
+    def pragma_value: (untyped value) -> String
+  end
+end

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
@@ -128,6 +128,22 @@ mrb_Database_transaction_active_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(sqlite3_get_autocommit(open_db_state(mrb, self)->db) == 0);
 }
 
+static mrb_value
+mrb_Database_readonly_p(mrb_state *mrb, mrb_value self)
+{
+  /* sqlite3_db_readonly returns 1 (read-only), 0 (read-write) or -1 (no such
+     database name); treat the -1 case as false */
+  return mrb_bool_value(sqlite3_db_readonly(open_db_state(mrb, self)->db, "main") == 1);
+}
+
+static mrb_value
+mrb_Database_filename(mrb_state *mrb, mrb_value self)
+{
+  const char *name = sqlite3_db_filename(open_db_state(mrb, self)->db, "main");
+  /* A temporary or in-memory database reports an empty name */
+  return (name && name[0]) ? mrb_str_new_cstr(mrb, name) : mrb_nil_value();
+}
+
 /*
  * execute_batch(sql) -> nil
  *
@@ -169,4 +185,6 @@ mrb_init_class_SQLite3_Database(mrb_state *mrb, struct RClass *class_SQLite3)
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(total_changes), mrb_Database_total_changes, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM_Q(transaction_active), mrb_Database_transaction_active_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(execute_batch), mrb_Database_execute_batch, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM_Q(readonly), mrb_Database_readonly_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(filename), mrb_Database_filename, MRB_ARGS_NONE());
 }

--- a/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
+++ b/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
@@ -358,4 +358,72 @@ class Sqlite3Test < Picotest::Test
     assert_raise(SQLite3::Exception) { db.changes }
     assert_raise(SQLite3::Exception) { db.execute_batch("SELECT 1") }
   end
+
+  def test_user_version
+    db = SQLite3::Database.new("/uv.db")
+    assert_equal(0, db.user_version)
+    db.user_version = 3
+    assert_equal(3, db.user_version)
+    db.close
+    # Persists with the database
+    SQLite3::Database.new("/uv.db") do |reopened|
+      assert_equal(3, reopened.user_version)
+    end
+  end
+
+  def test_journal_mode
+    db = SQLite3::Database.new("/journal.db")
+    db.journal_mode = :memory
+    assert_equal("memory", db.journal_mode)
+    db.close
+  end
+
+  def test_synchronous
+    db = SQLite3::Database.new("/sync.db")
+    db.synchronous = 0
+    assert_equal(0, db.synchronous)
+    db.synchronous = :full
+    assert_equal(2, db.synchronous)
+    db.close
+  end
+
+  def test_page_and_cache_size
+    db = SQLite3::Database.new("/sizes.db")
+    assert(db.page_size >= 512)
+    db.cache_size = 200
+    assert_equal(200, db.cache_size)
+    db.close
+  end
+
+  def test_foreign_keys
+    db = SQLite3::Database.new("/fk.db")
+    assert_false(db.foreign_keys)
+    db.foreign_keys = true
+    assert_true(db.foreign_keys)
+    db.foreign_keys = false
+    assert_false(db.foreign_keys)
+    db.close
+  end
+
+  def test_integrity_check
+    db = fresh_db("/integrity.db")
+    db.execute("INSERT INTO users (name) VALUES (?)", ["Alice"])
+    assert_equal("ok", db.integrity_check)
+    db.close
+  end
+
+  def test_generic_pragma
+    db = SQLite3::Database.new("/generic_pragma.db")
+    db.pragma("user_version", 7)
+    assert_equal([[7]], db.pragma("user_version"))
+    db.close
+  end
+
+  def test_readonly_and_filename
+    db = SQLite3::Database.new("/meta_db.db")
+    assert_false(db.readonly?)
+    # sqlite reports the (VFS relative) path it was opened with
+    assert_true(db.filename.include?("meta_db.db"))
+    db.close
+  end
 end


### PR DESCRIPTION
## Summary

Phase 2 of the CRuby `sqlite3` gem compatibility work (stacked on #467),
focused on the pragmas that matter on a microcontroller: schema migration and
trading durability for fewer flash writes.

> Base is `picoruby-sqlite3-phase1` (#467). Retarget to `master` once #467 merges.

### `SQLite3::Pragmas` (mixed into `Database`)
- `user_version` / `user_version=` — schema version stamp for on-device migrations
- `journal_mode` / `journal_mode=` — e.g. `:memory` or `:off` to avoid rollback journal writes to flash
- `synchronous` / `synchronous=`, `cache_size`, `page_size`
- `foreign_keys` / `foreign_keys=`, `auto_vacuum`
- `freelist_count`, `integrity_check`
- generic `pragma(name, value = nil)`

### `Database` (C)
- `readonly?`, `filename`

The pragma helpers are pure Ruby over `#execute` / `#get_first_value`, so they
add no C surface. Integer readers go through `to_s.to_i` to stay total over
every type SQLite may return.

## Test plan
- `rake test:gems:picoruby[picoruby-sqlite3]` — 74 assertions, all passing
- `rake test:gems:steep` — no type errors (`sig/pragmas.rbs` uses a `_PragmaExec`
  interface self type to avoid a circular include with `Database`)
- README documents the new pragma API and a migration example

🤖 Generated with [Claude Code](https://claude.com/claude-code)