### PR TITLE
Bound WASM test runtime to fail fast instead of hanging

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,6 +21,7 @@ jobs:
   test-steep:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
 
@@ -42,6 +43,7 @@ jobs:
   test-picoruby:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
 
@@ -63,6 +65,7 @@ jobs:
   test-femtoruby:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
 
@@ -84,6 +87,7 @@ jobs:
   test-wasm:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
 

--- a/mrbgems/picoruby-wasm/tools/wasm-runner.mjs
+++ b/mrbgems/picoruby-wasm/tools/wasm-runner.mjs
@@ -74,6 +74,14 @@ async function main() {
   let exitCode = 0;
   let idleCount = 0;
   const MAX_IDLE = 100;  // Exit after N consecutive idle cycles
+  // Hard wall-clock cap. The only reliable completion signal is the Ruby
+  // script reaching its end and setting __picotestDone; the idle fallback does
+  // not fire while scheduler-driven GC keeps reporting pending. If a test
+  // suspends (sleep_ms / await) and never resumes, nothing else bounds the run,
+  // so a single stuck test would block the reader (IO.popen) for hours. This
+  // turns that into a fast, reported failure. Override via env for slow hosts.
+  const MAX_WALL_MS = Number(process.env.PICORB_WASM_TEST_TIMEOUT_MS || 120000);
+  const startedAt = Date.now();
   const runStepStatus = Module._mrb_run_step_status
     ? () => Module.ccall('mrb_run_step_status', 'number', [], [])
     : () => {
@@ -85,6 +93,15 @@ async function main() {
     : () => 0;
 
   while (true) {
+    if (Date.now() - startedAt > MAX_WALL_MS) {
+      process.stderr.write(
+        `wasm-runner: timed out after ${MAX_WALL_MS}ms without completion ` +
+        `signal for ${scriptPath} (a test likely suspended and never resumed).\n`
+      );
+      exitCode = 1;
+      break;
+    }
+
     const status = runStepStatus();
     if (status < 0) {
       exitCode = 1;


### PR DESCRIPTION
The WASM picotest path had no wall-clock upper bound. A test class runs via wasm-runner.mjs, whose loop only exits on three conditions: a step error, the Ruby script reaching its end and setting __picotestDone, or 100 consecutive idle cycles. The idle fallback does not fire while scheduler-driven GC keeps reporting pending (gcSchedulerPending() == 1 resets idleCount every cycle), so __picotestDone is in practice the only reliable completion signal.

If a test suspends (sleep_ms / Promise#await) and never resumes, that signal is never emitted, the loop never breaks, and the picotest runner (IO.popen { io.read }) blocks on the child's stdout with no timeout. A single stuck test therefore hangs the whole job until GitHub's 6h default kills it, with no diagnostic left behind.

Add two backstops:
- wasm-runner.mjs: a hard wall-clock cap (default 120s, overridable via PICORB_WASM_TEST_TIMEOUT_MS) that exits non-zero with a message naming the script, turning a hang into a reported crash the runner surfaces.
- c-cpp.yml: timeout-minutes on every job so a bypass still fails in minutes, not hours.

This does not fix the underlying flaky resume race in the WASM scheduler; it bounds it and preserves a diagnostic so the culprit test can be identified next time.