### PR TITLE
sqlite3 :memory: databases and IndexedDB bridge improvement

### DIFF
--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb.rb
@@ -5,9 +5,27 @@ rescue LoadError
 end
 
 module IndexedDB
+  # How long an onblocked open may wait before it fails with BlockedError.
+  BLOCKED_TIMEOUT_MS = 5000
+
   # True when the browser exposes globalThis.indexedDB.
   def self.available?
     !JS.global[:indexedDB].nil?
+  end
+
+  # Unwrap a tagged bridge result ({ ok: true, value: } | { ok: false,
+  # name:, message: }) into the value or a typed exception. The EM_JS
+  # helpers always RESOLVE tags -- a rejection would reach Ruby as a bare
+  # message string with the error class lost.
+  def self.__unwrap(tagged)
+    err_name = tagged[:name]
+    return tagged[:value] if err_name.nil?
+    name = err_name.to_s
+    message = tagged[:message].to_s
+    if name == "PicoRubyBlockedTimeout"
+      raise BlockedError.new(message)
+    end
+    raise error_for(name, message)
   end
 
   # Open (and upgrade) a database.
@@ -21,11 +39,21 @@ module IndexedDB
   # a schema upgrade is triggered. Schema mutations are valid only there.
   # `await` MUST NOT be used inside the upgrade block.
   #
-  # When `IndexedDB.available?` is false, the call falls back to an
+  # When IndexedDB is unusable in this environment, the fallback is an
   # in-memory implementation with the same API surface (no persistence).
-  def self.open(name, version: 1, fallback: true, &block)
+  # `fallback: true` applies ONLY to availability: a missing
+  # globalThis.indexedDB, or an open failing with SecurityError /
+  # InvalidStateError (private modes). Quota, version, and data errors
+  # always raise typed -- silently substituting an empty in-memory store
+  # would masquerade as losing previously persisted data.
+  def self.open(name, version: 1, fallback: true, blocked_timeout_ms: BLOCKED_TIMEOUT_MS, &block)
     if available?
-      open_real(name, version, &block)
+      begin
+        open_real(name, version, blocked_timeout_ms, &block)
+      rescue SecurityError, InvalidStateError => e
+        raise e unless fallback
+        open_fallback(name, version, &block)
+      end
     elsif fallback
       open_fallback(name, version, &block)
     else
@@ -36,7 +64,7 @@ module IndexedDB
   class << self
     private
 
-    def open_real(name, version, &block)
+    def open_real(name, version, blocked_timeout_ms, &block)
       callback_id = 0
       if block
         user_block = block
@@ -51,9 +79,16 @@ module IndexedDB
         JS::Object::CALLBACKS[callback_id] = proc_obj
       end
 
-      promise = Helper.open_with_upgrade(name.to_s, version.to_i, callback_id)
-      raw_db = promise.await
-      JS::Object::CALLBACKS.delete(callback_id) if callback_id != 0
+      raw_db = nil
+      begin
+        promise = Helper.open_with_upgrade(name.to_s, version.to_i, callback_id,
+                                           blocked_timeout_ms.to_i)
+        raw_db = IndexedDB.__unwrap(promise.await)
+      ensure
+        # Without the ensure, a raise out of await/unwrap would leak the
+        # registration forever.
+        JS::Object::CALLBACKS.delete(callback_id) if callback_id != 0
+      end
       Database.new(raw_db, name: name, upgrading: false)
     end
 

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_batch.rb
@@ -39,7 +39,7 @@ module IndexedDB
 
     def await_complete
       promise = Helper.transaction_to_promise(@tx)
-      promise.await
+      IndexedDB.__unwrap(promise.await)
       nil
     end
 

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_errors.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_errors.rb
@@ -8,9 +8,49 @@ module IndexedDB
   # Raised when an open() request fails (req.error or rejected promise).
   class OpenError < Error; end
 
-  # Raised when versionchange is blocked because another connection still
-  # holds an older version of the database.
+  # Raised when versionchange stayed blocked past the bounded wait (another
+  # connection held an older version of the database for too long).
   class BlockedError < Error; end
+
+  # DOMException-backed errors from the tagged JS bridge. #name preserves the
+  # DOMException name even for names that have no dedicated subclass here.
+  class RequestError < Error
+    attr_reader :name
+
+    def initialize(name, message)
+      @name = name
+      super("#{name}: #{message}")
+    end
+  end
+
+  # Availability errors: the browser context has no usable IndexedDB (private
+  # mode and similar). These are the ONLY errors the in-memory fallback of
+  # IndexedDB.open applies to.
+  class SecurityError < RequestError; end
+  class InvalidStateError < RequestError; end
+
+  # Storage exists but the operation failed. NEVER silently replaced by the
+  # in-memory fallback: substituting an empty store would masquerade as data
+  # loss.
+  class QuotaExceededError < RequestError; end
+  class VersionError < RequestError; end
+  class AbortError < RequestError; end
+
+  DOM_ERROR_CLASSES = {
+    "SecurityError" => SecurityError,
+    "InvalidStateError" => InvalidStateError,
+    "QuotaExceededError" => QuotaExceededError,
+    "VersionError" => VersionError,
+    "AbortError" => AbortError,
+  }
+
+  # Convert a tagged failure ({ ok: false, name:, message: }) into a typed
+  # exception. Unknown DOMException names get the generic RequestError, with
+  # the original name readable via #name.
+  def self.error_for(name, message)
+    klass = DOM_ERROR_CLASSES[name] || RequestError
+    klass.new(name, message)
+  end
 
   # Raised when Ruby code attempts to await a result inside a Database#batch
   # block. IDB transactions auto-commit at every JS event-loop turn, and every

--- a/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
+++ b/mrbgems/picoruby-indexeddb/mrblib/indexeddb_store.rb
@@ -179,7 +179,7 @@ module IndexedDB
 
     def await_request(req)
       promise = Helper.request_to_promise(req)
-      promise.await
+      IndexedDB.__unwrap(promise.await)
     end
 
     def to_js_key(key)

--- a/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
+++ b/mrbgems/picoruby-indexeddb/sig/indexeddb.rbs
@@ -6,20 +6,37 @@ module IndexedDB
   class AwaitInBatchError < Error end
   class SchemaError < Error end
 
+  # DOMException-backed errors from the tagged JS bridge.
+  class RequestError < Error
+    attr_reader name: String
+    def initialize: (String name, String message) -> void
+  end
+  class SecurityError < RequestError end
+  class InvalidStateError < RequestError end
+  class QuotaExceededError < RequestError end
+  class VersionError < RequestError end
+  class AbortError < RequestError end
+
+  DOM_ERROR_CLASSES: Hash[String, singleton(RequestError)]
+  BLOCKED_TIMEOUT_MS: Integer
+
+  def self.error_for: (String name, String message) -> RequestError
+  def self.__unwrap: (untyped tagged) -> untyped
+
   # Either backend (real IDB or in-memory fallback) implements the same
   # observable API. Returned from IndexedDB.open and yielded to upgrade blocks.
   type db_like = Database | InMemoryDatabase
   type store_like = Store | InMemoryStore
 
   def self.available?: () -> bool
-  def self.open: (String name, ?version: Integer, ?fallback: bool) ?{ (db_like, Integer, Integer) -> void } -> db_like
+  def self.open: (String name, ?version: Integer, ?fallback: bool, ?blocked_timeout_ms: Integer) ?{ (db_like, Integer, Integer) -> void } -> db_like
 
-  private def self.open_real: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> Database
+  private def self.open_real: (String name, Integer version, Integer blocked_timeout_ms) ?{ (db_like, Integer, Integer) -> void } -> Database
   private def self.open_fallback: (String name, Integer version) ?{ (db_like, Integer, Integer) -> void } -> InMemoryDatabase
 
   module Helper
     def self.request_to_promise: (untyped js_request) -> untyped
-    def self.open_with_upgrade: (String name, Integer version, Integer callback_id) -> untyped
+    def self.open_with_upgrade: (String name, Integer version, Integer callback_id, Integer blocked_timeout_ms) -> untyped
     def self.transaction_to_promise: (untyped js_transaction) -> untyped
   end
 

--- a/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
+++ b/mrbgems/picoruby-indexeddb/src/indexeddb_helper.c
@@ -27,7 +27,7 @@ extern mrb_value wrap_ref_as_js_object(mrb_state *mrb, int ref_id);
  * Three entry points:
  *   1. idb_request_to_promise(req_ref_id)
  *      Wraps an IDBRequest in a Promise so Ruby can use JS::Promise#await.
- *   2. idb_open_with_upgrade(name, version, upgrade_callback_id)
+ *   2. idb_open_with_upgrade(name, version, upgrade_callback_id, blocked_ms)
  *      Opens a database. Inside onupgradeneeded the registered Ruby callback
  *      is invoked synchronously via call_ruby_callback_sync_generic so that
  *      schema mutations (createObjectStore / createIndex) run on the JS
@@ -36,6 +36,14 @@ extern mrb_value wrap_ref_as_js_object(mrb_state *mrb, int ref_id);
  *      Wraps an IDBTransaction's oncomplete/onerror/onabort events as a
  *      single Promise. Used by Database#batch to atomically commit a group
  *      of write operations.
+ *
+ * All three RESOLVE a tagged result instead of rejecting:
+ *   success: { ok: true,  value: <result> }
+ *   failure: { ok: false, name: <DOMException name>, message: <message> }
+ * The generic JS Promise bridge preserves only error messages on rejection,
+ * so a rejected DOMException would reach Ruby as a bare string and error
+ * CLASSES would be indistinguishable. Ruby (IndexedDB.__unwrap) converts the
+ * failure tag into a typed exception.
  *****************************************************/
 
 EM_JS(int, idb_request_to_promise, (int req_ref_id), {
@@ -45,11 +53,14 @@ EM_JS(int, idb_request_to_promise, (int req_ref_id), {
       console.error('idb_request_to_promise: invalid ref_id', req_ref_id);
       return -1;
     }
-    const promise = new Promise((resolve, reject) => {
-      req.onsuccess = () => { resolve(req.result); };
+    const promise = new Promise((resolve) => {
+      req.onsuccess = () => { resolve({ ok: true, value: req.result }); };
       req.onerror = () => {
-        const msg = (req.error && req.error.message) || 'IDB request failed';
-        reject(new Error(msg));
+        resolve({
+          ok: false,
+          name: (req.error && req.error.name) || 'UnknownError',
+          message: (req.error && req.error.message) || 'IDB request failed'
+        });
       };
     });
     return globalThis.picorubyRefs.push(promise) - 1;
@@ -59,7 +70,7 @@ EM_JS(int, idb_request_to_promise, (int req_ref_id), {
   }
 });
 
-EM_JS(int, idb_open_with_upgrade, (const char *name_ptr, int version, uintptr_t callback_id), {
+EM_JS(int, idb_open_with_upgrade, (const char *name_ptr, int version, uintptr_t callback_id, int blocked_timeout_ms), {
   try {
     const name = UTF8ToString(name_ptr);
     const idb = globalThis.indexedDB;
@@ -98,14 +109,44 @@ EM_JS(int, idb_open_with_upgrade, (const char *name_ptr, int version, uintptr_t 
       }
     };
 
-    const promise = new Promise((resolve, reject) => {
-      req.onsuccess = () => { resolve(req.result); };
+    const promise = new Promise((resolve) => {
+      /* onblocked is not a failure by itself: the blocking connection may
+         close at any moment and let the open finish. Wait for it with a
+         bounded timer; only its expiry is reported (as a tag Ruby maps to
+         IndexedDB::BlockedError). An open that succeeds AFTER the timeout
+         already settled the promise is closed immediately -- nobody can
+         receive that connection anymore. */
+      let settled = false;
+      let blockedTimer = null;
+      const settle = (result) => {
+        if (settled) return;
+        settled = true;
+        if (blockedTimer) { clearTimeout(blockedTimer); blockedTimer = null; }
+        resolve(result);
+      };
+      req.onsuccess = () => {
+        if (settled) {
+          try { req.result.close(); } catch (e) {}
+          return;
+        }
+        settle({ ok: true, value: req.result });
+      };
       req.onerror = () => {
-        const msg = (req.error && req.error.message) || 'IDB open failed';
-        reject(new Error(msg));
+        settle({
+          ok: false,
+          name: (req.error && req.error.name) || 'UnknownError',
+          message: (req.error && req.error.message) || 'IDB open failed'
+        });
       };
       req.onblocked = () => {
-        reject(new Error('IDB open blocked: another connection holds an older version'));
+        if (settled || blockedTimer) return;
+        blockedTimer = setTimeout(() => {
+          settle({
+            ok: false,
+            name: 'PicoRubyBlockedTimeout',
+            message: 'IDB open blocked: another connection held an older version past the timeout'
+          });
+        }, blocked_timeout_ms);
       };
     });
     return globalThis.picorubyRefs.push(promise) - 1;
@@ -122,15 +163,21 @@ EM_JS(int, idb_transaction_to_promise, (int tx_ref_id), {
       console.error('idb_transaction_to_promise: invalid ref_id', tx_ref_id);
       return -1;
     }
-    const promise = new Promise((resolve, reject) => {
-      tx.oncomplete = () => { resolve(true); };
+    const promise = new Promise((resolve) => {
+      tx.oncomplete = () => { resolve({ ok: true, value: true }); };
       tx.onerror = () => {
-        const msg = (tx.error && tx.error.message) || 'IDB transaction error';
-        reject(new Error(msg));
+        resolve({
+          ok: false,
+          name: (tx.error && tx.error.name) || 'UnknownError',
+          message: (tx.error && tx.error.message) || 'IDB transaction error'
+        });
       };
       tx.onabort = () => {
-        const msg = (tx.error && tx.error.message) || 'IDB transaction aborted';
-        reject(new Error(msg));
+        resolve({
+          ok: false,
+          name: (tx.error && tx.error.name) || 'AbortError',
+          message: (tx.error && tx.error.message) || 'IDB transaction aborted'
+        });
       };
     });
     return globalThis.picorubyRefs.push(promise) - 1;
@@ -191,10 +238,12 @@ mrb_idb_helper_transaction_to_promise(mrb_state *mrb, mrb_value self)
 }
 
 /*
- * IndexedDB::Helper.open_with_upgrade(name, version, callback_id) -> JS::Promise
+ * IndexedDB::Helper.open_with_upgrade(name, version, callback_id, blocked_timeout_ms)
+ *   -> JS::Promise
  *
  * callback_id may be 0 to skip the upgrade hook (e.g. when opening at the
- * current version with no schema work to do).
+ * current version with no schema work to do). blocked_timeout_ms bounds how
+ * long an onblocked open may wait before it settles as a BlockedError tag.
  */
 static mrb_value
 mrb_idb_helper_open_with_upgrade(mrb_state *mrb, mrb_value self)
@@ -202,9 +251,11 @@ mrb_idb_helper_open_with_upgrade(mrb_state *mrb, mrb_value self)
   const char *name;
   mrb_int version;
   mrb_int callback_id;
-  mrb_get_args(mrb, "zii", &name, &version, &callback_id);
+  mrb_int blocked_timeout_ms;
+  mrb_get_args(mrb, "ziii", &name, &version, &callback_id, &blocked_timeout_ms);
 
-  int promise_id = idb_open_with_upgrade(name, (int)version, (uintptr_t)callback_id);
+  int promise_id = idb_open_with_upgrade(name, (int)version, (uintptr_t)callback_id,
+                                         (int)blocked_timeout_ms);
   if (promise_id < 0) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "idb_open_with_upgrade failed");
   }
@@ -224,7 +275,7 @@ mrb_picoruby_indexeddb_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(request_to_promise),
     mrb_idb_helper_request_to_promise, MRB_ARGS_REQ(1));
   mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(open_with_upgrade),
-    mrb_idb_helper_open_with_upgrade, MRB_ARGS_REQ(3));
+    mrb_idb_helper_open_with_upgrade, MRB_ARGS_REQ(4));
   mrb_define_module_function_id(mrb, module_Helper, MRB_SYM(transaction_to_promise),
     mrb_idb_helper_transaction_to_promise, MRB_ARGS_REQ(1));
 }

--- a/mrbgems/picoruby-indexeddb/test/bridge_test.rb
+++ b/mrbgems/picoruby-indexeddb/test/bridge_test.rb
@@ -1,0 +1,226 @@
+# Tests for the tagged EM_JS bridge: typed errors, availability-only
+# fallback, the bounded onblocked wait, and open-callback cleanup.
+#
+# The Node test runtime has no real IndexedDB, so these tests install small
+# JS fakes (request / transaction / indexedDB objects whose handler setters
+# fire asynchronously) and drive the real bridge code through them. The
+# fakes only fake the DOM side; the EM_JS promises, the tag unwrapping, and
+# the error classification under test are the production code paths.
+class IndexedDBBridgeTest < Picotest::Test
+  FAKE_JS = <<~JS
+    globalThis.__fakeIdb = {
+      lateClosed: false,
+      makeSuccessRequest: (value) => {
+        const req = { result: value };
+        Object.defineProperty(req, 'onsuccess', {
+          set(fn) { setTimeout(fn, 0); }
+        });
+        return req;
+      },
+      makeErrorRequest: (name, message) => {
+        const req = { error: { name: name, message: message } };
+        Object.defineProperty(req, 'onerror', {
+          set(fn) { setTimeout(fn, 0); }
+        });
+        return req;
+      },
+      makeAbortTransaction: (name, message) => {
+        const tx = { error: { name: name, message: message } };
+        Object.defineProperty(tx, 'onabort', {
+          set(fn) { setTimeout(fn, 0); }
+        });
+        return tx;
+      },
+      install: (mode, name, message, lateDelay) => {
+        globalThis.__fakeIdb.lateClosed = false;
+        globalThis.indexedDB = {
+          open: (dbname, version) => {
+            const req = {};
+            if (mode === 'error') {
+              req.error = { name: name, message: message };
+              Object.defineProperty(req, 'onerror', {
+                set(fn) { setTimeout(fn, 0); }
+              });
+            } else if (mode === 'success') {
+              req.result = { close: () => {} };
+              Object.defineProperty(req, 'onsuccess', {
+                set(fn) { setTimeout(fn, 0); }
+              });
+            } else if (mode === 'blocked_forever') {
+              Object.defineProperty(req, 'onblocked', {
+                set(fn) { setTimeout(fn, 0); }
+              });
+            } else if (mode === 'blocked_late_success') {
+              req.result = {
+                close: () => { globalThis.__fakeIdb.lateClosed = true; }
+              };
+              Object.defineProperty(req, 'onsuccess', {
+                set(fn) { setTimeout(fn, lateDelay); }
+              });
+              Object.defineProperty(req, 'onblocked', {
+                set(fn) { setTimeout(fn, 0); }
+              });
+            }
+            return req;
+          }
+        };
+      },
+      uninstall: () => { delete globalThis.indexedDB; },
+      waitTimer: (ms) => new Promise((resolve) => {
+        setTimeout(() => { resolve({ ok: true, value: true }); }, ms);
+      })
+    };
+  JS
+
+  def setup
+    skip "wasm only" unless wasm?
+    JS.global.eval(FAKE_JS)
+  end
+
+  def fakes
+    JS.global[:__fakeIdb]
+  end
+
+  def with_fake_idb(mode, name = "", message = "", late_delay = 0)
+    fakes.install(mode, name, message, late_delay)
+    begin
+      yield
+    ensure
+      fakes.uninstall
+    end
+  end
+
+  # ---- request path ----
+
+  def test_tagged_request_success
+    req = fakes.makeSuccessRequest(42)
+    promise = IndexedDB::Helper.request_to_promise(req)
+    assert_equal(42, IndexedDB.__unwrap(promise.await).to_i)
+  end
+
+  def test_tagged_request_error_is_typed
+    req = fakes.makeErrorRequest("QuotaExceededError", "quota is full")
+    promise = IndexedDB::Helper.request_to_promise(req)
+    caught = nil
+    begin
+      IndexedDB.__unwrap(promise.await)
+    rescue IndexedDB::QuotaExceededError => e
+      caught = e
+    end
+    assert_not_nil(caught)
+    assert_equal("QuotaExceededError", caught.name)
+    assert_true(caught.message.include?("quota is full"))
+  end
+
+  def test_tagged_request_unknown_name_keeps_name
+    req = fakes.makeErrorRequest("SomethingWeirdError", "who knows")
+    promise = IndexedDB::Helper.request_to_promise(req)
+    caught = nil
+    begin
+      IndexedDB.__unwrap(promise.await)
+    rescue IndexedDB::RequestError => e
+      caught = e
+    end
+    assert_not_nil(caught)
+    assert_equal(IndexedDB::RequestError, caught.class)
+    assert_equal("SomethingWeirdError", caught.name)
+  end
+
+  # ---- transaction path ----
+
+  def test_tagged_transaction_abort_is_typed
+    tx = fakes.makeAbortTransaction("AbortError", "rolled back")
+    promise = IndexedDB::Helper.transaction_to_promise(tx)
+    caught = nil
+    begin
+      IndexedDB.__unwrap(promise.await)
+    rescue IndexedDB::AbortError => e
+      caught = e
+    end
+    assert_not_nil(caught)
+    assert_equal("AbortError", caught.name)
+  end
+
+  # ---- open path: availability-only fallback ----
+
+  def test_open_security_error_falls_back_to_in_memory
+    with_fake_idb("error", "SecurityError", "denied") do
+      db = IndexedDB.open("bridge_sec_fb")
+      assert_true(db.is_a?(IndexedDB::InMemoryDatabase))
+    end
+  end
+
+  def test_open_security_error_raises_without_fallback
+    with_fake_idb("error", "SecurityError", "denied") do
+      assert_raise(IndexedDB::SecurityError) do
+        IndexedDB.open("bridge_sec_raise", fallback: false)
+      end
+    end
+  end
+
+  def test_open_invalid_state_error_falls_back
+    with_fake_idb("error", "InvalidStateError", "no storage here") do
+      db = IndexedDB.open("bridge_ise_fb")
+      assert_true(db.is_a?(IndexedDB::InMemoryDatabase))
+    end
+  end
+
+  def test_open_quota_error_never_falls_back
+    with_fake_idb("error", "QuotaExceededError", "disk full") do
+      assert_raise(IndexedDB::QuotaExceededError) do
+        IndexedDB.open("bridge_quota", fallback: true)
+      end
+    end
+  end
+
+  def test_open_success_returns_real_database
+    with_fake_idb("success") do
+      db = IndexedDB.open("bridge_ok")
+      assert_true(db.is_a?(IndexedDB::Database))
+    end
+  end
+
+  # ---- open path: bounded onblocked wait ----
+
+  def test_open_blocked_times_out_as_blocked_error
+    with_fake_idb("blocked_forever") do
+      assert_raise(IndexedDB::BlockedError) do
+        IndexedDB.open("bridge_blocked", blocked_timeout_ms: 50)
+      end
+    end
+  end
+
+  def test_open_blocked_late_success_closes_connection
+    with_fake_idb("blocked_late_success", "", "", 150) do
+      assert_raise(IndexedDB::BlockedError) do
+        IndexedDB.open("bridge_blocked_late", blocked_timeout_ms: 50)
+      end
+      # The open succeeds ~100ms after the timeout already settled the
+      # promise; the bridge must close that orphan connection immediately.
+      # Awaiting short JS timers (not Ruby sleep) keeps the JS event loop
+      # turning so the pending late-success setTimeout can fire; one long
+      # await would trip the test runner's idle-exit bound instead.
+      i = 0
+      while i < 30
+        break if fakes[:lateClosed].to_s == "true"
+        fakes.waitTimer(10).await
+        i += 1
+      end
+      assert_equal("true", fakes[:lateClosed].to_s)
+    end
+  end
+
+  # ---- open path: callback registry cleanup ----
+
+  def test_open_failure_cleans_callback_registry
+    with_fake_idb("error", "SecurityError", "denied") do
+      size_before = JS::Object::CALLBACKS.size
+      assert_raise(IndexedDB::SecurityError) do
+        IndexedDB.open("bridge_cleanup", fallback: false) do |db, old_v, new_v|
+          # never runs; exists to force callback registration
+        end
+      end
+      assert_equal(size_before, JS::Object::CALLBACKS.size)
+    end
+  end
+end

--- a/mrbgems/picoruby-sqlite3/README.md
+++ b/mrbgems/picoruby-sqlite3/README.md
@@ -40,7 +40,18 @@ db.close     # close also auto-persists
   Task scheduler.
 - `serialize` / `deserialize` expose the raw snapshot bytes if you want to store
   them elsewhere.
+- `SQLite3::Database.new(":memory:")` works like CRuby's sqlite3 gem on
+  every target: a private in-memory database bound to no file and no
+  snapshot name. Nothing is restored on open, `persist` raises, and `close`
+  persists nothing (a plain close). Use it when your application or
+  framework owns the snapshot lifecycle itself via `serialize` /
+  `deserialize` instead of the built-in store.
 - The database is bounded by available wasm memory.
+- `Statement#readonly?` exposes `sqlite3_stmt_readonly()`. Note SQLite's
+  classification: statements that change connection state but not database
+  content (`PRAGMA query_only`, `ATTACH`, `DETACH`, transaction control)
+  report read-only too -- access control built on this method must reject
+  those separately.
 
 The rest of the API (execute, transactions, pragmas, backup, ...) is identical
 to the microcontroller build.

--- a/mrbgems/picoruby-sqlite3/mrblib/database.rb
+++ b/mrbgems/picoruby-sqlite3/mrblib/database.rb
@@ -12,7 +12,18 @@ class SQLite3
   class Database
     class << self
       def new(filename, results_as_hash: false)
-        db = if defined?(VFS)
+        db = if filename == ":memory:"
+          # CRuby sqlite3 compatible: a private in-memory database bound to
+          # no file and, on wasm, to no snapshot name. Nothing is restored on
+          # open and #close persists nothing. Each ":memory:" handle is its
+          # own independent database.
+          mem = _open_memory
+          # Keep sort/temp structures off the (driverless) VFS. The wasm
+          # build fixes this at compile time (SQLITE_TEMP_STORE=3); other
+          # targets get the runtime equivalent here.
+          mem.execute("PRAGMA temp_store = 2") if defined?(VFS)
+          mem
+        elsif defined?(VFS)
           volume, path = VFS.sanitize_and_split(filename)
           # The driver prepends its own prefix, so every path SQLite derives
           # from this one (journals, temporary files) stays valid too
@@ -147,7 +158,12 @@ class SQLite3
 
       # Snapshot the current database into IndexedDB under its name.
       def persist
-        self.class.__store[@db_name] = Base64.encode64(serialize)
+        name = @db_name
+        unless name
+          raise SQLite3::Exception.new(
+            "cannot persist a database that has no snapshot name (\":memory:\")")
+        end
+        self.class.__store[name] = Base64.encode64(serialize)
         true
       end
 

--- a/mrbgems/picoruby-sqlite3/sig/database.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/database.rbs
@@ -4,9 +4,13 @@ class SQLite3
 
     type sqlite3_row_t = Hash[String, String] | Array[String]
 
+    # ":memory:" as filename opens a private in-memory database (CRuby
+    # sqlite3 compatible): no file, no snapshot name, nothing restored or
+    # persisted, one independent database per handle.
     def initialize: (String filename, ?results_as_hash: bool) ?{ (SQLite3::Database) -> void } -> void
     def self.open: (String filename) ?{ (SQLite3::Database) -> void } -> SQLite3::Database
     private def self._open: (VFS::driver_t driver, String path) -> SQLite3::Database
+    private def self._open_memory: () -> SQLite3::Database
 
     attr_accessor results_as_hash: bool
 
@@ -43,7 +47,7 @@ class SQLite3
 
     # picoruby.wasm only: in-memory database + IndexedDB snapshot persistence.
     STORE_NAME: String
-    @db_name: String
+    @db_name: String?
     def serialize: () -> String
     def deserialize: (String bytes) -> SQLite3::Database
     def persist: () -> bool
@@ -51,7 +55,6 @@ class SQLite3
     # stay public even though they are internal.
     def _restore_from_store: (String name) -> SQLite3::Database
     def self.__store: () -> untyped
-    private def self._open_memory: () -> SQLite3::Database
     private def __close_without_persist: () -> void
   end
 end

--- a/mrbgems/picoruby-sqlite3/sig/statement.rbs
+++ b/mrbgems/picoruby-sqlite3/sig/statement.rbs
@@ -17,6 +17,11 @@ class SQLite3
     def reset!: -> self
     def active?: -> bool
     def done?: -> bool
+    # sqlite3_stmt_readonly(): true iff the statement makes no direct change
+    # to database content. PRAGMA query_only / ATTACH / DETACH report true
+    # too (they change connection state, not content) -- reject those
+    # separately when building access control on this.
+    def readonly?: -> bool
     def column_count: -> Integer
     def columns: -> Array[String]
     def column_name: (Integer index) -> String

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_database.c
@@ -171,13 +171,13 @@ mrb_Database_execute_batch(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
-#if defined(PICORB_PLATFORM_WASM)
 /*
- * On picoruby.wasm the database has no filesystem to live on: SQLite's VFS
- * callbacks are synchronous, but the runtime can only reach browser storage
- * asynchronously (task suspend + Promise). So the working database is a native
- * in-memory SQLite database, and persistence is done in Ruby by snapshotting the
- * bytes with #serialize / #deserialize to IndexedDB at await points.
+ * A private in-memory database (":memory:" in CRuby's sqlite3 gem). On
+ * picoruby.wasm this is also the working database behind the named form:
+ * SQLite's VFS callbacks are synchronous, but the wasm runtime can only reach
+ * browser storage asynchronously (task suspend + Promise), so persistence is
+ * done in Ruby by snapshotting the bytes with #serialize / #deserialize at
+ * await points.
  */
 static mrb_value
 mrb_s__open_memory(mrb_state *mrb, mrb_value klass)
@@ -203,6 +203,7 @@ mrb_s__open_memory(mrb_state *mrb, mrb_value klass)
   return self;
 }
 
+#if defined(PICORB_PLATFORM_WASM)
 /* serialize -> String : the whole "main" database as a byte string */
 static mrb_value
 mrb_Database_serialize(mrb_state *mrb, mrb_value self)
@@ -262,8 +263,8 @@ mrb_init_class_SQLite3_Database(mrb_state *mrb, struct RClass *class_SQLite3)
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(execute_batch), mrb_Database_execute_batch, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM_Q(readonly), mrb_Database_readonly_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(filename), mrb_Database_filename, MRB_ARGS_NONE());
-#if defined(PICORB_PLATFORM_WASM)
   mrb_define_class_method_id(mrb, class_SQLite3_Database, MRB_SYM(_open_memory), mrb_s__open_memory, MRB_ARGS_NONE());
+#if defined(PICORB_PLATFORM_WASM)
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(serialize), mrb_Database_serialize, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Database, MRB_SYM(deserialize), mrb_Database_deserialize, MRB_ARGS_REQ(1));
 #endif

--- a/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_statement.c
+++ b/mrbgems/picoruby-sqlite3/src/mruby/sqlite3_statement.c
@@ -176,6 +176,21 @@ mrb_done_p(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(statement(mrb, self)->done_p);
 }
 
+/*
+ * readonly? -> bool
+ *
+ * sqlite3_stmt_readonly(): true iff the statement makes no direct change to
+ * the content of the database file. Statements that only change connection
+ * state (PRAGMA query_only, ATTACH, DETACH, BEGIN/COMMIT) report true as
+ * well; callers building access control on this must reject those
+ * separately.
+ */
+static mrb_value
+mrb_Statement_readonly_p(mrb_state *mrb, mrb_value self)
+{
+  return mrb_bool_value(sqlite3_stmt_readonly(open_statement(mrb, self)->st) != 0);
+}
+
 static mrb_value
 mrb_column_count(mrb_state *mrb, mrb_value self)
 {
@@ -280,6 +295,7 @@ mrb_init_class_SQLite3_Statement(mrb_state *mrb, struct RClass *class_SQLite3)
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM(step), mrb_step, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM_B(reset), mrb_reset_bang, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM_Q(done), mrb_done_p, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM_Q(readonly), mrb_Statement_readonly_p, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM(column_count), mrb_column_count, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM(bind_param), mrb_bind_param, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_SQLite3_Statement, MRB_SYM(column_name), mrb_column_name, MRB_ARGS_REQ(1));

--- a/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
+++ b/mrbgems/picoruby-sqlite3/test/sqlite3_test.rb
@@ -436,7 +436,122 @@ class Sqlite3Test < Picotest::Test
     db.close
   end
 
+  def test_statement_readonly_p
+    db = fresh_db("/stmt_ro.db")
+    db.prepare("SELECT id FROM users") do |stmt|
+      assert_true(stmt.readonly?)
+    end
+    db.prepare("INSERT INTO users (name) VALUES (?)") do |stmt|
+      assert_false(stmt.readonly?)
+    end
+    db.prepare("UPDATE users SET name = 'x'") do |stmt|
+      assert_false(stmt.readonly?)
+    end
+    db.prepare("DELETE FROM users") do |stmt|
+      assert_false(stmt.readonly?)
+    end
+    db.prepare("CREATE TABLE stmt_ro_extra (id INTEGER)") do |stmt|
+      assert_false(stmt.readonly?)
+    end
+    db.close
+  end
+
+  def test_statement_readonly_p_connection_state_quirk
+    # Pin the documented SQLite quirk: statements that change connection
+    # state but not database content are classified read-only by
+    # sqlite3_stmt_readonly(). Access control built on #readonly? must
+    # reject these separately.
+    db = fresh_db("/stmt_ro_quirk.db")
+    db.prepare("ATTACH DATABASE ':memory:' AS quirk_aux") do |stmt|
+      assert_true(stmt.readonly?)
+    end
+    db.prepare("PRAGMA query_only = ON") do |stmt|
+      assert_true(stmt.readonly?)
+    end
+    db.close
+  end
+
+  def test_statement_readonly_p_on_closed_statement_raises
+    db = fresh_db("/stmt_ro_closed.db")
+    stmt = db.prepare("SELECT id FROM users")
+    stmt.close
+    assert_raise(SQLite3::Exception) { stmt.readonly? }
+    db.close
+  end
+
+  # ---- ":memory:" databases (CRuby sqlite3 compatible, every target) ----
+
+  def test_memory_database_cruby_compat
+    db = SQLite3::Database.new(":memory:")
+    db.execute("CREATE TABLE t (v TEXT)")
+    db.execute("INSERT INTO t (v) VALUES (?)", ["in memory"])
+    assert_equal([["in memory"]], db.execute("SELECT v FROM t"))
+    assert_nil(db.filename)
+    db.close
+    assert_true(db.closed?)
+  end
+
+  def test_memory_database_block_form_closes
+    captured = SQLite3::Database.new(":memory:") { |db| db }
+    assert_true(captured.closed?)
+  end
+
+  def test_memory_databases_are_independent
+    # Like CRuby/SQLite: every ":memory:" handle is its own private database
+    a = SQLite3::Database.new(":memory:")
+    b = SQLite3::Database.new(":memory:")
+    a.execute("CREATE TABLE only_in_a (v TEXT)")
+    assert_equal([], b.execute("SELECT name FROM sqlite_master WHERE type='table'"))
+    a.close
+    b.close
+  end
+
   # ---- wasm-only: in-memory DB + IndexedDB snapshot persistence ----
+
+  def test_wasm_memory_database_persist_raises
+    skip "wasm only" unless wasm?
+    db = SQLite3::Database.new(":memory:")
+    # No snapshot name: persist has nowhere coherent to write
+    assert_raise(SQLite3::Exception) { db.persist }
+    db.close
+  end
+
+  def test_wasm_memory_database_close_leaves_no_snapshot
+    skip "wasm only" unless wasm?
+    keys_before = SQLite3::Database.__store.keys
+    db = SQLite3::Database.new(":memory:")
+    db.execute("CREATE TABLE t (v TEXT)")
+    db.execute("INSERT INTO t (v) VALUES (?)", ["gone"])
+    db.close
+    assert_equal(keys_before, SQLite3::Database.__store.keys)
+  end
+
+  def test_wasm_memory_database_serialize_round_trip
+    skip "wasm only" unless wasm?
+    bytes = nil
+    SQLite3::Database.new(":memory:") do |db|
+      db.execute("CREATE TABLE t (v TEXT)")
+      db.execute("INSERT INTO t (v) VALUES (?)", ["carried"])
+      bytes = db.serialize
+    end
+    other = SQLite3::Database.new(":memory:")
+    other.deserialize(bytes)
+    assert_equal([["carried"]], other.execute("SELECT v FROM t"))
+    other.close
+  end
+
+  def test_wasm_named_db_behavior_unchanged
+    skip "wasm only" unless wasm?
+    # Regression guard for the named (snapshot-bound) form: auto-persist on
+    # close and restore on reopen keep working alongside ":memory:".
+    db = SQLite3::Database.new("named_regression")
+    db.execute("CREATE TABLE t (v TEXT)")
+    db.execute("INSERT INTO t (v) VALUES (?)", ["still here"])
+    db.close
+    SQLite3::Database.new("named_regression") do |reopened|
+      assert_equal([["still here"]], reopened.execute("SELECT v FROM t"))
+    end
+  end
 
   def test_wasm_explicit_persist_and_restore
     skip "wasm only" unless wasm?


### PR DESCRIPTION
## SQLite3

* SQLite3::Database.new(":memory:") now works like CRuby's sqlite3 gem on every target: a private in-memory database bound to no file and no snapshot name. Nothing is restored on open, #persist raises, and #close persists nothing. _open_memory loses its wasm gate (its VFS aux methods never touch the driver); VFS targets set temp_store=2 at open so temp structures stay off the driverless VFS. The named form and its STORE_NAME auto-persistence are unchanged.

* SQLite3::Statement#readonly? wraps sqlite3_stmt_readonly(). The SQLite classification quirk (PRAGMA query_only / ATTACH / DETACH report read-only because they change connection state, not content) is documented and pinned by tests.

## IndexedDB

**Error handling and propagation improvements:**

* All promise-based JS bridges (`request_to_promise`, `open_with_upgrade`, `transaction_to_promise`) now always resolve with a tagged result (`{ ok: true, value: ... }` or `{ ok: false, name:, message: }`), allowing Ruby to distinguish error types and propagate them as typed exceptions rather than generic messages. [[1]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeR39-R46) [[2]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL48-R63) [[3]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL101-R149) [[4]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL125-R180) [[5]](diffhunk://#diff-791d43bc3b44443d182959c45623fd22d2c1207c3ed49556149a1e2e97288443R8-R30) [[6]](diffhunk://#diff-72ee976a1f9e56aad0c48e39d5e2dddf879891f307e736a445bfcd082e07aa87L11-R54)
* Introduced the `IndexedDB.__unwrap` helper to convert tagged JS results into values or raise the appropriate Ruby exception, including new `RequestError` subclasses for DOMException names. [[1]](diffhunk://#diff-791d43bc3b44443d182959c45623fd22d2c1207c3ed49556149a1e2e97288443R8-R30) [[2]](diffhunk://#diff-72ee976a1f9e56aad0c48e39d5e2dddf879891f307e736a445bfcd082e07aa87L11-R54) [[3]](diffhunk://#diff-6dc3e10f93c544160a844e55ca64ae6fdfe8710afb14c50084a6fdfa88c7ee0dR9-R39)
* Added `IndexedDB.error_for` to map DOMException names to Ruby exception classes, with unknown names defaulting to a generic `RequestError`. [[1]](diffhunk://#diff-72ee976a1f9e56aad0c48e39d5e2dddf879891f307e736a445bfcd082e07aa87L11-R54) [[2]](diffhunk://#diff-6dc3e10f93c544160a844e55ca64ae6fdfe8710afb14c50084a6fdfa88c7ee0dR9-R39)

**API and behavior changes:**

* Added a `blocked_timeout_ms` parameter (defaulting to `BLOCKED_TIMEOUT_MS = 5000`) to `IndexedDB.open` and all underlying layers, bounding how long an open can be blocked by another connection before failing with a `BlockedError`. [[1]](diffhunk://#diff-791d43bc3b44443d182959c45623fd22d2c1207c3ed49556149a1e2e97288443L24-R56) [[2]](diffhunk://#diff-791d43bc3b44443d182959c45623fd22d2c1207c3ed49556149a1e2e97288443L39-R67) [[3]](diffhunk://#diff-6dc3e10f93c544160a844e55ca64ae6fdfe8710afb14c50084a6fdfa88c7ee0dR9-R39) [[4]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL30-R30) [[5]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL62-R73) [[6]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL194-R258)
* Updated all relevant method signatures and type signatures in Ruby and C to support the new parameters and result tagging. [[1]](diffhunk://#diff-6dc3e10f93c544160a844e55ca64ae6fdfe8710afb14c50084a6fdfa88c7ee0dR9-R39) [[2]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL194-R258) [[3]](diffhunk://#diff-d0e61d4026d42634a6b214bec3261009456836238a1040a14f3f58eae9c74aaeL227-R278)

**Internal consistency and resource management:**

* Ensured that JS callback registrations are always cleaned up even if an error occurs during `await`/`unwrap`, preventing resource leaks.
* Updated all internal calls that await JS promises to use the new `__unwrap` logic for consistent error handling. [[1]](diffhunk://#diff-4253d7e8818b7fe6e5252d12405f6cdb2c7b36602195e713858c5f8b56ab92ccL42-R42) [[2]](diffhunk://#diff-f34681819b452f3658fe34f5182f06606990b3249b69b44a06a546522ce73272L182-R182)

These changes make error handling more robust, provide clearer failure modes to Ruby code, and prevent silent data loss scenarios.