### PR TITLE
Add ESP32 port for mruby-task's switch hook.

### DIFF
--- a/mrbgems/picoruby-mruby/ports/esp32/task.c
+++ b/mrbgems/picoruby-mruby/ports/esp32/task.c
@@ -1,0 +1,9 @@
+#include "task_hal.h"
+
+void
+mrb_hal_task_switch_hook(mrb_state *mrb, mrb_task_switch_reason reason)
+{
+  (void)mrb;
+  (void)reason;
+  /* Nothing to service on this platform */
+}


### PR DESCRIPTION
Pulling the latest commit https://github.com/picoruby/picoruby/commit/54ebcebed1b15f6be6ac58dda41de04c11633b69 into https://github.com/picoruby/R2P2-ESP32 caused a build error.

This PR fixes it.

## Error encountered

```
FAILED: R2P2-ESP32.elf
/home/yuhei/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20260121/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: /home/yuhei/ghq/github.com/picoruby/R2P2-ESP32/components/picoruby-esp32/picoruby/build/esp32-picoruby/lib/libmruby.a(task.o):(.literal.task_run_body+0x4): undefined reference to `mrb_hal_task_switch_hook'
/home/yuhei/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20260121/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: /home/yuhei/ghq/github.com/picoruby/R2P2-ESP32/components/picoruby-esp32/picoruby/build/esp32-picoruby/lib/libmruby.a(task.o): in function `task_run_body':
task.c:(.text.task_run_body+0x5a): undefined reference to `mrb_hal_task_switch_hook'
/home/yuhei/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20260121/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: task.c:(.text.task_run_body+0x83): undefined reference to `mrb_hal_task_switch_hook'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

## Cause

Commit https://github.com/picoruby/picoruby/commit/0e06f7c8b304934dbdc0eb36aafed1e6def544e9 added ports for RP2040, but no equivalent exists for ESP32.

## Fix

Added the corresponding directory and source code, implementing the function that was causing the link error.
