### PR TITLE
picoruby-wasm: add synchronous dispatch mode to addEventListener

### DIFF
--- a/mrbgems/picoruby-wasm/README.md
+++ b/mrbgems/picoruby-wasm/README.md
@@ -14,6 +14,9 @@ PicoRuby.wasm uses a task suspension model instead of Emscripten's ASYNCIFY:
 - Scheduler-driven GC is enabled by default so GC work is driven from scheduler
   idle points rather than latency-sensitive allocation paths
 - Async operations (setTimeout, fetch, addEventListener) suspend the current task, cleanly exiting the `setjmp` scope
+- `addEventListener(..., sync: true)` opts out of that: the block runs on the JavaScript
+  dispatch stack so `preventDefault` and user-activation-gated APIs work, at the cost of
+  not being able to suspend
 - When the Promise resolves, the task resumes on a fresh C stack with a new `setjmp`
 - Ruby exceptions therefore work correctly across async boundaries without ASYNCIFY overhead
 

--- a/mrbgems/picoruby-wasm/demo/www/ble_irb_demo.html
+++ b/mrbgems/picoruby-wasm/demo/www/ble_irb_demo.html
@@ -177,10 +177,14 @@
       end
 
       def bind_input_events(inp)
+        # do_eval waits on the BLE UART, so it needs an asynchronous listener.
         inp.addEventListener('keydown') do |ev|
+          do_eval if ev[:key].to_s == "Enter"
+        end
+        # History navigation has to suppress the caret-moving default action,
+        # which only works from a listener that runs during dispatch.
+        inp.addEventListener('keydown', sync: true) do |ev|
           case ev[:key].to_s
-          when "Enter"
-            do_eval
           when "ArrowUp"
             ev.preventDefault
             navigate_history(-1)

--- a/mrbgems/picoruby-wasm/demo/www/dom_apis.html
+++ b/mrbgems/picoruby-wasm/demo/www/dom_apis.html
@@ -36,6 +36,13 @@
       results.appendChild(div)
     end
 
+    # cancelable is required for preventDefault to be observable
+    def mouse_event_options
+      options = JS.global.create_object
+      options[:cancelable] = true
+      options
+    end
+
     test_case("createElement") do
       elem = doc.createElement('div')
       raise "createElement failed" unless elem
@@ -122,6 +129,32 @@
 
       raise "addEventListener failed" unless callback_id
       JS::Object.removeEventListener(callback_id)
+    end
+
+    test_case("addEventListener sync: true runs during dispatch") do
+      btn = doc.createElement('button')
+      order = []
+
+      callback_id = btn.addEventListener('click', sync: true) do |event|
+        order << :handler
+        event.preventDefault
+      end
+
+      order << :before
+      cancelled = !btn.dispatchEvent(JS.global[:MouseEvent].new('click', mouse_event_options))
+      order << :after
+
+      raise "handler did not run inline (got #{order.inspect})" unless order == [:before, :handler, :after]
+      raise "preventDefault had no effect" unless cancelled
+      JS::Object.removeEventListener(callback_id)
+    end
+
+    test_case("addEventListener once: true fires once") do
+      btn = doc.createElement('button')
+      count = 0
+      btn.addEventListener('click', sync: true, once: true) { |event| count += 1 }
+      2.times { btn.dispatchEvent(JS.global[:MouseEvent].new('click', mouse_event_options)) }
+      raise "expected 1 call, got #{count}" unless count == 1
     end
 
     test_case("removeAttribute") do

--- a/mrbgems/picoruby-wasm/demo/www/terminal.html
+++ b/mrbgems/picoruby-wasm/demo/www/terminal.html
@@ -472,7 +472,11 @@
         move_callback_id = nil
         up_callback_id   = nil
 
-        resizer.addEventListener('mousedown') do
+        # The whole drag is synchronous: separate listeners get separate queues,
+        # so an asynchronous mousemove and mouseup have no guaranteed order
+        # relative to each other, and the listeners registered here would only
+        # take effect a scheduler tick after the button went down.
+        resizer.addEventListener('mousedown', sync: true) do
           if move_callback_id
             JS::Object.removeEventListener(move_callback_id)
             move_callback_id = nil
@@ -484,7 +488,7 @@
           body.style.userSelect = 'none'
           body.style.cursor = 'col-resize'
 
-          move_callback_id = @doc.addEventListener('mousemove') do |e|
+          move_callback_id = @doc.addEventListener('mousemove', sync: true) do |e|
             rect        = editor_container.getBoundingClientRect()
             new_left_x  = e.clientX.to_f - rect.left.to_f
             max_x       = rect.width.to_f - 20.0
@@ -495,7 +499,7 @@
             dfu_log_el.style.flex = right_ratio.to_s
           end
 
-          up_callback_id = @doc.addEventListener('mouseup') do
+          up_callback_id = @doc.addEventListener('mouseup', sync: true) do
             body.style.userSelect = ''
             body.style.cursor = ''
             if move_callback_id

--- a/mrbgems/picoruby-wasm/docs/architecture.md
+++ b/mrbgems/picoruby-wasm/docs/architecture.md
@@ -188,7 +188,33 @@ mrb->c = &tcb->c;  // Switch context
 // Never share mrb_context between tasks
 ```
 
-### 5. Test Exception Handling After Changes
+### 5. Never Suspend Inside a Synchronous Listener
+
+`addEventListener(..., sync: true)` runs the Ruby block from
+`call_ruby_callback_sync_event()` (`src/mruby/js.c`), on the JavaScript event
+dispatch stack. There is no task to suspend there, so the dispatch takes
+`mrb->task.scheduler_lock` for its duration, turning every asynchronous Task API
+(`mrb_suspend_task`, blocking `Task::Queue#pop`, ...) into a clean `RuntimeError`.
+
+```c
+// CORRECT - call the block on the current context, catching any longjmp
+mrb->task.scheduler_lock++;
+mrb_value r = mrb_protect_error(mrb, sync_dispatch_body, &args, &error);
+mrb->task.scheduler_lock--;
+
+// WRONG - DO NOT DO THIS
+mrb_funcall(mrb, block, "call", 1, event);  // an exception longjmps into the JS frame
+```
+
+Two entry situations, both handled by the above:
+
+- **Between host loop steps**: `execute_task()` has restored `mrb->c` to the root
+  context and `mrb->jmp` is `NULL`. `mrb_protect_error` installs the jmpbuf.
+- **Re-entrant** (Ruby called `element.click` / `dispatchEvent`): `mrb->c` is the
+  running task's context with a `cci > 0` frame below, which is the ordinary
+  `mrb_yield` re-entrancy the VM already handles.
+
+### 6. Test Exception Handling After Changes
 
 After any modification to task scheduling, async operations, or exception handling:
 
@@ -225,6 +251,7 @@ picoruby-wasm/
   - `js_add_event_listener()`: DOM event handling
   - `js_set_timeout()`: Timer scheduling
   - `call_ruby_callback()`: Generic callback invocation
+  - `call_ruby_callback_sync_event()`: Synchronous listener dispatch (`sync: true`)
 
 - **`../../picoruby-mruby/src/task.c`**
   - `mrb_suspend_task()`: Suspends task, exits setjmp scope
@@ -301,7 +328,7 @@ JavaScript object references are stored in `globalThis.picorubyRefs` array:
 const newRefId = globalThis.picorubyRefs.push(element) - 1;
 ```
 
-**Current Limitation**: References are never removed, leading to potential memory leaks in long-running applications. See Future Considerations section in main README.
+**Current Limitation**: References are never removed, leading to potential memory leaks in long-running applications. The one exception is synchronous listener dispatch: the event's reference has a bounded lifetime (the DOM makes the event inert once dispatch returns), so `js_add_event_listener` releases it right after the handler returns.
 
 ### Task Contexts
 

--- a/mrbgems/picoruby-wasm/docs/async_operations.md
+++ b/mrbgems/picoruby-wasm/docs/async_operations.md
@@ -3,6 +3,7 @@
 | Pattern | Use Case | Blocks Task? | Repeatable? | Cancelable? |
 |---------|----------|-------------|-------------|-------------|
 | `addEventListener` | DOM events | No | Yes | Yes |
+| `addEventListener(sync: true)` | DOM events needing `preventDefault` or user activation | Runs inline | Yes | Yes |
 | `setTimeout` | Delayed execution | No | No | Yes |
 | `await` / `then` | Any JS Promise | Yes | No | No |
 
@@ -18,6 +19,14 @@ end
 # Remove when done
 JS::Object.removeEventListener(callback_id)
 ```
+
+The block runs as a separate task, after the browser has finished dispatching the
+event. When the handler must run *during* dispatch — to call `preventDefault`, or to
+reach an API gated on transient user activation — pass `sync: true`; see
+[callback.md](callback.md#synchronous-listeners) for the constraints that come with it.
+
+`capture:`, `once:` and `passive:` are also accepted and map to the DOM listener
+options.
 
 ## Timers
 

--- a/mrbgems/picoruby-wasm/docs/callback.md
+++ b/mrbgems/picoruby-wasm/docs/callback.md
@@ -1,10 +1,11 @@
 # Callbacks in PicoRuby.wasm
 
-Two callback types exist, with fundamentally different execution models:
+Three callback types exist, with fundamentally different execution models:
 
 | Type | How Called | Blocks JS? | Can sleep_ms? |
 |------|-----------|-----------|---------------|
 | **Async** (addEventListener, setTimeout, await/then) | Via scheduler as a new task | No | Yes |
+| **Sync listener** (addEventListener with `sync: true`) | Synchronously from JS, on the dispatch stack | Yes | No |
 | **Generic** (register_callback) | Synchronously from JS | Yes | No |
 
 ## Async Callbacks
@@ -35,6 +36,57 @@ callback_id = button.addEventListener('click') { ... }
 JS::Object.removeEventListener(callback_id)
 ```
 
+For convenience, an asynchronous listener automatically calls `preventDefault()` on
+`submit` events and on `click` events targeting an `<a>` tag, so Ruby handlers can act
+as SPA navigation handlers. This does not apply to synchronous listeners, which call
+`preventDefault` themselves.
+
+## Synchronous Listeners
+
+`addEventListener` accepts `sync: true`, plus the DOM listener options `capture:`,
+`once:` and `passive:`. A synchronous listener runs the block *on the JavaScript event
+dispatch stack*, before `dispatchEvent` returns.
+
+```ruby
+input.addEventListener('keydown', sync: true) do |event|
+  event.preventDefault if event[:key].to_s == 'ArrowUp'
+end
+
+# passive is browser-default unless given; touch and wheel listeners need it
+# explicitly disabled to be able to preventDefault
+canvas.addEventListener('touchstart', sync: true, passive: false) do |event|
+  event.preventDefault
+end
+```
+
+Use it when the handler needs any of:
+
+- `preventDefault` / `stopPropagation` — an async handler runs after dispatch has
+  finished, so both are no-ops there
+- transient user activation — `navigator.serial.requestPort`,
+  `navigator.bluetooth.requestDevice`, `AudioContext#resume`, `requestFullscreen`,
+  clipboard writes, `window.open`
+- `event.currentTarget` / `event.composedPath()`, which the DOM invalidates once
+  dispatch ends
+
+**Constraints.** The block cannot suspend, so anything that would raises
+`RuntimeError` inside it:
+
+- `fetch`, `Promise#await` / `#then`, `JS::Response#to_binary`
+- blocking `Task::Queue#pop`
+- `Task#join` / `#suspend` / `#resume` / `#terminate`
+
+Merely *scheduling* work is fine: `Task.new`, `setTimeout` and registering an
+asynchronous `addEventListener` all work from inside a synchronous handler; the
+spawned block simply runs later, on the scheduler.
+
+`sleep` / `sleep_ms` do not raise, but block the browser's main thread in real time.
+Keep synchronous handlers short: they run inside the JavaScript event loop, so any
+work done there delays rendering and input, exactly as a JS handler would.
+
+The `JS::Event` passed to the block is released when the handler returns; holding on
+to it and reading it later yields `nil`.
+
 ## Generic Callbacks
 
 Registered once; callable from JS synchronously. Used when a JS library expects a direct return value (e.g., Chart.js formatters).
@@ -50,7 +102,9 @@ end
 const label = globalThis.picorubyGenericCallbacks['formatYen'](1234);
 ```
 
-**Do not use `sleep_ms` or any task-switching inside generic callbacks** - it will raise an error.
+Generic callbacks run through the same synchronous dispatch as `sync: true` listeners,
+so the same constraints apply: **no `fetch` / `await` / blocking `Task::Queue#pop`**
+(they raise `RuntimeError`), and `sleep` blocks the browser's main thread in real time.
 
 ### Avoid High-Frequency Generic Callbacks
 

--- a/mrbgems/picoruby-wasm/docs/callback.md
+++ b/mrbgems/picoruby-wasm/docs/callback.md
@@ -69,7 +69,7 @@ Use it when the handler needs any of:
 - `event.currentTarget` / `event.composedPath()`, which the DOM invalidates once
   dispatch ends
 
-**Constraints.** The block cannot suspend, so anything that would raises
+**Constraints.** The block cannot suspend, so anything that would suspend raises
 `RuntimeError` inside it:
 
 - `fetch`, `Promise#await` / `#then`, `JS::Response#to_binary`

--- a/mrbgems/picoruby-wasm/mrblib/js.rb
+++ b/mrbgems/picoruby-wasm/mrblib/js.rb
@@ -34,7 +34,7 @@ module JS
       EVENT_QUEUES[callback_id] = q
       CALLBACKS[callback_id]    = block
       EVENT_TASKS[callback_id]  = Task.new(name: "js-cb-#{callback_id}") do
-        loop do
+        while true
           ev = q.pop
           break if ev.nil?
           begin
@@ -55,11 +55,35 @@ module JS
       q&.close
     end
 
-    def addEventListener(event_type, &block)
+    # sync: true runs the block on the JS event dispatch stack, so
+    # preventDefault / stopPropagation and APIs gated on transient user
+    # activation work. In exchange the block must not suspend: fetch, await and
+    # blocking Task::Queue#pop raise inside it. Spawning is still fine
+    # (Task.new, setTimeout, registering an async listener).
+    # capture / once / passive map to the DOM listener options; passive is
+    # left to the browser default unless given explicitly.
+    def addEventListener(event_type, sync: false, capture: false, once: false, passive: nil, &block)
       callback_id = block.object_id
-      _add_event_listener(callback_id, event_type)
-      JS::Object._spawn_event_consumer(callback_id, block)
+      if sync
+        JS::Object::CALLBACKS[callback_id] = block
+      else
+        JS::Object._spawn_event_consumer(callback_id, block)
+      end
+      _add_event_listener(callback_id, event_type, sync, capture, once,
+                          passive.nil? ? -1 : (passive ? 1 : 0))
       callback_id
+    end
+
+    # Called from C (call_ruby_callback_sync_event) for sync: true listeners.
+    def self._dispatch_sync(callback_id, event, once)
+      block = CALLBACKS[callback_id]
+      CALLBACKS.delete(callback_id) if once
+      return unless block
+      begin
+        block.call(event)
+      rescue => e
+        $stderr.puts "Callback #{callback_id}: #{e.class}: #{e.message}"
+      end
     end
 
     def self.register_callback(name, &block)
@@ -71,8 +95,14 @@ module JS
 
     def self.removeEventListener(callback_id)
       return false unless callback_id
+      # A sync listener has no consumer task to clean up after it, and a
+      # once-listener that already fired makes the JS call return false, so
+      # drop the block unconditionally.
+      CALLBACKS.delete(callback_id)
       begin
-        result = JS.global._js_remove_event_listener_wrapper(callback_id)
+        # _removeEventListener is the C path; it works in Node too, unlike
+        # the window-only _js_remove_event_listener_wrapper helper.
+        result = JS.global._removeEventListener(callback_id)
         _close_event_queue(callback_id) if result
         result
       rescue

--- a/mrbgems/picoruby-wasm/npm/picoruby/README.md
+++ b/mrbgems/picoruby-wasm/npm/picoruby/README.md
@@ -118,6 +118,24 @@ end
 
 Ruby exceptions raised inside callbacks are caught correctly by `rescue`/`ensure`.
 
+### Synchronous listeners
+
+An event handler normally runs as a task, after the browser has finished dispatching
+the event. Pass `sync: true` to run it during dispatch instead — required for
+`preventDefault` / `stopPropagation` and for APIs gated on transient user activation
+(Web Serial, Web Bluetooth, `AudioContext#resume`, fullscreen, clipboard):
+
+```ruby
+form.addEventListener('submit', sync: true) do |event|
+  event.preventDefault
+end
+```
+
+`capture:`, `once:` and `passive:` are accepted too. A synchronous handler cannot
+suspend: `fetch`, `await` and blocking queue reads raise inside it, and it blocks the
+browser's main thread while it runs. Scheduling work for later (`Task.new`,
+`setTimeout`, registering an async listener) is fine.
+
 ## Debugging
 
 Use the **PicoRuby Debugger** Chrome extension to inspect running applications

--- a/mrbgems/picoruby-wasm/sig/js.rbs
+++ b/mrbgems/picoruby-wasm/sig/js.rbs
@@ -37,8 +37,9 @@ module JS
     def to_a: () -> ::Array[untyped]
 
     # Event Handling
-    def addEventListener: (String event_type) { (JS::Event event) -> void } -> Integer
+    def addEventListener: (String event_type, ?sync: bool, ?capture: bool, ?once: bool, ?passive: bool?) { (JS::Event event) -> void } -> Integer
     def self.removeEventListener: (Integer callback_id) -> bool
+    def self._dispatch_sync: (Integer callback_id, JS::Event event, bool once) -> void
     def self.register_callback: (String name) { (*untyped args) -> untyped } -> Integer
     def self._spawn_event_consumer: (Integer callback_id, Proc block) -> Integer
     def self._close_event_queue: (Integer callback_id) -> (Task::Queue | nil)
@@ -100,11 +101,11 @@ module JS
     def removeItem: (String key) -> void
 
     def _js_remove_event_listener_wrapper: (Integer callback_id) -> bool
+    def _removeEventListener: (Integer callback_id) -> bool
 
     private def method_missing: (Symbol method_name, *untyped args) -> untyped
-    private def _add_event_listener: (Integer callback_id, String event_type) -> nil
+    private def _add_event_listener: (Integer callback_id, String event_type, bool sync, bool capture, bool once, Integer passive) -> nil
     private def self._register_callback: (Integer callback_id, String name) -> nil
-    private def _removeEventListener: (Integer callback_id) -> bool
     private def _fetch_and_suspend: (String url, Integer callback_id) -> nil
     private def _fetch_with_options_and_suspend: (String url, String options_json, Integer callback_id) -> nil
     private def _await_and_suspend: (Integer callback_id) -> nil

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -13,8 +13,6 @@
 #include "mruby/variable.h"
 #include "mruby/proc.h"
 
-#include "mruby_compiler.h"
-#include "mrc_utils.h"
 #include "task.h"
 
 #include <stdbool.h>
@@ -85,7 +83,9 @@ EM_JS(void, init_js_refs, (), {
       if (!globalThis.picorubyEventHandlers) return false;
       const info = globalThis.picorubyEventHandlers[callback_id];
       if (!info) return false;
-      info.target.removeEventListener(info.type, info.handler);
+      // The capture flag must match the one used at registration time,
+      // otherwise the listener is not removed.
+      info.target.removeEventListener(info.type, info.handler, !!info.capture);
       delete globalThis.picorubyEventHandlers[callback_id];
       return true;
     };
@@ -747,32 +747,84 @@ EM_JS(void, setup_promise_handler, (int promise_id, uintptr_t callback_id, uintp
   );
 });
 
-EM_JS(void, js_add_event_listener, (int ref_id, uintptr_t callback_id, const char* event_type), {
+/*
+ * Register a DOM event listener.
+ *
+ * sync    : run the Ruby block on the JS dispatch stack (see
+ *           call_ruby_callback_sync_event) instead of queueing it for the
+ *           scheduler. Only a synchronous listener can preventDefault or use
+ *           APIs gated on transient user activation.
+ * capture / once : DOM listener options.
+ * passive : -1 leaves it to the browser default, 0 / 1 set it explicitly.
+ */
+EM_JS(void, js_add_event_listener,
+      (int ref_id, uintptr_t callback_id, const char* event_type,
+       int sync, int capture, int once, int passive), {
   const target = globalThis.picorubyRefs[ref_id];
   const type = UTF8ToString(event_type);
+  const isSync = !!sync;
+  const isOnce = !!once;
+  const isCapture = !!capture;
+
+  // Pass an options object only when something differs from the DOM default:
+  // an explicit {passive: false} would change the behaviour of touch / wheel
+  // listeners that the browser otherwise makes passive.
+  let options = undefined;
+  if (isCapture || isOnce || passive >= 0) {
+    options = { capture: isCapture, once: isOnce };
+    if (passive >= 0) options.passive = (passive === 1);
+  }
+
   const handler = (event) => {
     // Check if handler still exists before calling
     if (!globalThis.picorubyEventHandlers || !globalThis.picorubyEventHandlers[callback_id]) {
       return;
     }
+    // The DOM already dropped a once-listener by the time it runs; drop our
+    // bookkeeping too, before any re-entrant dispatch can observe it.
+    if (isOnce) {
+      delete globalThis.picorubyEventHandlers[callback_id];
+    }
     // Prevent default for submit events and click events on <a> tags
-    // This allows Ruby event handlers to work as SPA navigation handlers
-    if (type === 'submit' || (type === 'click' && target.tagName === 'A')) {
+    // This allows Ruby event handlers to work as SPA navigation handlers.
+    // Asynchronous listeners only: a synchronous one calls preventDefault
+    // itself, and a passive listener is not allowed to.
+    if (!isSync && passive !== 1 &&
+        (type === 'submit' || (type === 'click' && target.tagName === 'A'))) {
       event.preventDefault();
     }
     const eventRefId = globalThis.picorubyRefs.push(event) - 1;
-    ccall(
-      'call_ruby_callback',
-      'void',
-      ['number', 'number'],
-      [callback_id, eventRefId]
-    );
+    if (isSync) {
+      try {
+        ccall(
+          'call_ruby_callback_sync_event',
+          'void',
+          ['number', 'number', 'number'],
+          [callback_id, eventRefId, isOnce ? 1 : 0]
+        );
+      } finally {
+        // The event is inert once dispatch returns, so its ref has a bounded
+        // lifetime - unlike the queued path, which leaks one slot per event.
+        delete globalThis.picorubyRefs[eventRefId];
+      }
+    } else {
+      ccall(
+        isOnce ? 'call_ruby_callback_oneshot' : 'call_ruby_callback',
+        'void',
+        ['number', 'number'],
+        [callback_id, eventRefId]
+      );
+    }
   };
-  target.addEventListener(type, handler);
+  if (options) {
+    target.addEventListener(type, handler, options);
+  } else {
+    target.addEventListener(type, handler);
+  }
   if (!globalThis.picorubyEventHandlers) {
     globalThis.picorubyEventHandlers = {};
   }
-  globalThis.picorubyEventHandlers[callback_id] = { target, type, handler };
+  globalThis.picorubyEventHandlers[callback_id] = { target, type, handler, capture: isCapture };
 });
 
 EM_JS(void, js_register_generic_callback, (uintptr_t callback_id, const char* callback_name), {
@@ -886,7 +938,7 @@ EM_JS(bool, js_remove_event_listener, (uintptr_t callback_id), {
     if (!globalThis.picorubyEventHandlers) return false;
     const info = globalThis.picorubyEventHandlers[callback_id];
     if (!info) return false;
-    info.target.removeEventListener(info.type, info.handler);
+    info.target.removeEventListener(info.type, info.handler, !!info.capture);
     delete globalThis.picorubyEventHandlers[callback_id];
     return true;
   } catch(e) {
@@ -1410,6 +1462,91 @@ call_ruby_callback_oneshot(uintptr_t callback_id, int event_ref_id)
   close_event_queue(global_mrb, callback_id);
 }
 
+/*
+ * Synchronous listener dispatch (addEventListener with sync: true).
+ *
+ * Unlike the queued path above, the Ruby block runs right here, on the JS
+ * event dispatch stack, so preventDefault / stopPropagation and APIs gated on
+ * transient user activation still work.
+ *
+ * Two entry situations, both fine:
+ *   - between host loop steps: execute_task() has restored mrb->c to root_c
+ *     and mrb->jmp is NULL. mrb_protect_error installs the jmpbuf.
+ *   - re-entrant (Ruby called el.click / dispatchEvent): mrb->c is the running
+ *     task's context with a cci > 0 frame below us, which is the ordinary
+ *     mrb_yield re-entrancy the VM already handles.
+ */
+typedef struct sync_dispatch_args {
+  mrb_int  callback_id;
+  mrb_value event;
+  mrb_bool once;
+} sync_dispatch_args;
+
+static mrb_value
+sync_inspect_body(mrb_state *mrb, void *ud)
+{
+  return mrb_inspect(mrb, *(mrb_value *)ud);
+}
+
+static mrb_value
+sync_dispatch_body(mrb_state *mrb, void *ud)
+{
+  sync_dispatch_args *a = (sync_dispatch_args *)ud;
+  mrb_value argv[3];
+  argv[0] = mrb_fixnum_value(a->callback_id);
+  argv[1] = a->event;
+  argv[2] = mrb_bool_value(a->once);
+  return mrb_funcall_argv(mrb, mrb_obj_value(class_JS_Object),
+                          MRB_SYM(_dispatch_sync), 3, argv);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void
+call_ruby_callback_sync_event(uintptr_t callback_id, int event_ref_id, int once)
+{
+  mrb_state *mrb = global_mrb;
+  if (!mrb) return;
+
+  /* scheduler_lock is a uint8_t counter; task_check_scheduler_lock() turns
+     every asynchronous Task API (await, fetch, blocking Queue#pop, ...) into a
+     clean RuntimeError while it is held. Bail out rather than wrap around. */
+  if (mrb->task.scheduler_lock == UINT8_MAX) {
+    fprintf(stderr, "Callback %lu: synchronous dispatch nested too deeply\n",
+            (unsigned long)callback_id);
+    return;
+  }
+
+  int ai = mrb_gc_arena_save(mrb);
+
+  sync_dispatch_args args;
+  args.callback_id = (mrb_int)callback_id;
+  args.event       = event_ref_to_ruby(mrb, event_ref_id);
+  args.once        = once ? TRUE : FALSE;
+
+  mrb_bool error = FALSE;
+  mrb->task.scheduler_lock++;
+  /* mrb_protect_error() catches any longjmp, so the decrement always runs. */
+  mrb_value result = mrb_protect_error(mrb, sync_dispatch_body, &args, &error);
+  mrb->task.scheduler_lock--;
+
+  /* JS::Object._dispatch_sync rescues StandardError itself; anything reaching
+     here is a non-StandardError or a failure of the rescue clause. */
+  if (error) {
+    mrb_bool inspect_error = FALSE;
+    mrb_value msg = mrb_protect_error(mrb, sync_inspect_body, &result, &inspect_error);
+    if (inspect_error || !mrb_string_p(msg)) {
+      fprintf(stderr, "Callback %lu: (failed to inspect exception)\n",
+              (unsigned long)callback_id);
+    }
+    else {
+      fprintf(stderr, "Callback %lu: %s\n", (unsigned long)callback_id, RSTRING_PTR(msg));
+    }
+  }
+  if (mrb->exc) mrb->exc = NULL;
+
+  mrb_gc_arena_restore(mrb, ai);
+}
+
 
 EMSCRIPTEN_KEEPALIVE
 void
@@ -1482,77 +1619,77 @@ resume_binary_task(uintptr_t mrb_ptr, uintptr_t task_ptr, uintptr_t callback_id,
   mrb_resume_task(mrb, task);
 }
 
+/*
+ * Generic callback dispatch: JS::Object.register_callback, and any Ruby block
+ * handed to a JS method (js_create_callback_function).
+ *
+ * Same synchronous model as call_ruby_callback_sync_event above - call the
+ * block on the current context under scheduler_lock, catching any longjmp -
+ * with the block's return value converted back for JavaScript.
+ */
+typedef struct generic_dispatch_args {
+  mrb_int   callback_id;
+  mrb_value args;  /* Array of already-converted arguments */
+} generic_dispatch_args;
+
+static mrb_value
+generic_dispatch_body(mrb_state *mrb, void *ud)
+{
+  generic_dispatch_args *a = (generic_dispatch_args *)ud;
+  mrb_value callbacks = mrb_const_get(mrb, mrb_obj_value(class_JS_Object),
+                                      mrb_intern_lit(mrb, "CALLBACKS"));
+  if (!mrb_hash_p(callbacks)) return mrb_nil_value();
+  mrb_value block = mrb_hash_get(mrb, callbacks, mrb_fixnum_value(a->callback_id));
+  if (mrb_nil_p(block)) return mrb_nil_value();
+  return mrb_funcall_argv(mrb, block, MRB_SYM(call),
+                          RARRAY_LEN(a->args), RARRAY_PTR(a->args));
+}
+
 EMSCRIPTEN_KEEPALIVE
 int
 call_ruby_callback_sync_generic(uintptr_t callback_id, int *arg_ref_ids, int argc)
 {
-  if (!global_mrb) {
+  mrb_state *mrb = global_mrb;
+  if (!mrb) return -1;
+
+  if (mrb->task.scheduler_lock == UINT8_MAX) {
+    fprintf(stderr, "Generic callback %lu: synchronous dispatch nested too deeply\n",
+            (unsigned long)callback_id);
     return -1;
   }
 
-  // Convert JavaScript arguments to Ruby array
-  mrb_value args_array = mrb_ary_new_capa(global_mrb, argc);
+  int ai = mrb_gc_arena_save(mrb);
+
+  generic_dispatch_args args;
+  args.callback_id = (mrb_int)callback_id;
+  args.args = mrb_ary_new_capa(mrb, argc);
   for (int i = 0; i < argc; i++) {
-    mrb_value arg_value = js_ref_to_ruby_value(global_mrb, arg_ref_ids[i]);
-    mrb_ary_push(global_mrb, args_array, arg_value);
+    mrb_ary_push(mrb, args.args, js_ref_to_ruby_value(mrb, arg_ref_ids[i]));
   }
 
-  // Store arguments in global variable $js_callback_args
-  mrb_value callback_args = mrb_gv_get(global_mrb, MRB_GVSYM(js_callback_args));
-  if (mrb_nil_p(callback_args)) {
-    callback_args = mrb_hash_new(global_mrb);
-    mrb_gv_set(global_mrb, MRB_GVSYM(js_callback_args), callback_args);
-  }
-  int args_id = (int)callback_id;
-  mrb_hash_set(global_mrb, callback_args, mrb_fixnum_value(args_id), args_array);
+  mrb_bool error = FALSE;
+  mrb->task.scheduler_lock++;
+  mrb_value result = mrb_protect_error(mrb, generic_dispatch_body, &args, &error);
+  mrb->task.scheduler_lock--;
 
-  // Generate script to call the callback
-  static char script[512];
-  snprintf(script, sizeof(script),
-    "JS::Object::CALLBACKS[%lu]&.call(*$js_callback_args[%d])",
-    callback_id, args_id);
-
-  // Compile the script
-  mrc_ccontext *cc = mrc_ccontext_new(global_mrb);
-  const uint8_t *script_ptr = (const uint8_t *)script;
-  size_t size = strlen(script);
-  mrc_irep *irep = mrc_load_string_cxt(cc, &script_ptr, size);
-
-  if (!irep) {
-    mrc_ccontext_free(cc);
-    return -1;
-  }
-
-  // Create a Proc from the compiled irep
-  mrc_resolve_intern(cc, irep);
-  struct RProc *proc = mrb_proc_new(global_mrb, (const mrb_irep *)irep);
-  proc->c = NULL;
-  mrb_value proc_val = mrb_obj_value(proc);
-
-  // Execute the proc synchronously (no additional arguments needed)
-  mrb_value result = mrb_execute_proc_synchronously(global_mrb, proc_val, 0, NULL);
-
-  // Clean up
-  mrb_hash_delete_key(global_mrb, callback_args, mrb_fixnum_value(args_id));
-  mrc_irep_free(cc, irep);
-  mrc_ccontext_free(cc);
-
-  // Handle exception
-  if (global_mrb->exc) {
-    mrb_value exc = mrb_obj_value(global_mrb->exc);
-    global_mrb->exc = NULL;
-    mrb_value exc_str = mrb_inspect(global_mrb, exc);
-    if (global_mrb->exc) {
+  int result_ref_id;
+  if (error) {
+    mrb_bool inspect_error = FALSE;
+    mrb_value msg = mrb_protect_error(mrb, sync_inspect_body, &result, &inspect_error);
+    if (inspect_error || !mrb_string_p(msg)) {
       fprintf(stderr, "Generic callback exception (failed to inspect exception)\n");
-      global_mrb->exc = NULL;
-    } else {
-      fprintf(stderr, "Generic callback exception: %s\n", RSTRING_PTR(exc_str));
     }
-    return -1;
+    else {
+      fprintf(stderr, "Generic callback exception: %s\n", RSTRING_PTR(msg));
+    }
+    result_ref_id = -1;
   }
+  else {
+    result_ref_id = ruby_value_to_js_ref(mrb, result);
+  }
+  if (mrb->exc) mrb->exc = NULL;
 
-  // Convert result to JavaScript ref_id
-  int result_ref_id = ruby_value_to_js_ref(global_mrb, result);
+  mrb_gc_arena_restore(mrb, ai);
   return result_ref_id;
 }
 
@@ -2151,8 +2288,12 @@ mrb_object__add_event_listener(mrb_state *mrb, mrb_value self)
   picorb_js_obj *obj = (picorb_js_obj *)DATA_PTR(self);
   mrb_int callback_id;
   char* event_type;
-  mrb_get_args(mrb, "iz", &callback_id, &event_type);
-  js_add_event_listener(obj->ref_id, (uintptr_t)callback_id, event_type);
+  mrb_bool sync, capture, once;
+  mrb_int passive;  /* -1: browser default, 0 / 1: explicit */
+  mrb_get_args(mrb, "izbbbi", &callback_id, &event_type,
+               &sync, &capture, &once, &passive);
+  js_add_event_listener(obj->ref_id, (uintptr_t)callback_id, event_type,
+                        sync ? 1 : 0, capture ? 1 : 0, once ? 1 : 0, (int)passive);
   return mrb_nil_value();
 }
 
@@ -2625,7 +2766,7 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(inspect), mrb_object_inspect, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_f), mrb_object_to_f, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(to_i), mrb_object_to_i, MRB_ARGS_NONE());
-  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_add_event_listener), mrb_object__add_event_listener, MRB_ARGS_REQ(2));
+  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_add_event_listener), mrb_object__add_event_listener, MRB_ARGS_REQ(6));
   mrb_define_class_method_id(mrb, class_JS_Object, MRB_SYM(_register_callback), mrb_object_s__register_callback, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_and_suspend), mrb_object__fetch_and_suspend, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_with_options_and_suspend), mrb_object__fetch_with_options_and_suspend, MRB_ARGS_REQ(3));

--- a/mrbgems/picoruby-wasm/test/js_generic_callback_test.rb
+++ b/mrbgems/picoruby-wasm/test/js_generic_callback_test.rb
@@ -1,0 +1,63 @@
+# Generic callbacks (register_callback, and blocks handed to a JS method) are
+# called synchronously from JavaScript and their return value goes back to JS.
+class JSGenericCallbackTest < Picotest::Test
+  def setup
+    JS.eval('globalThis.picorubyCallWith = function(value, fn) { return fn(value); }')
+    JS.eval('globalThis.picorubyCallWith2 = function(a, b, fn) { return fn(a, b); }')
+  end
+
+  def test_register_callback_returns_value_to_js
+    JS::Object.register_callback('picotestDouble') { |value| value.to_i * 2 }
+    assert_equal(42, JS.eval("globalThis.picorubyGenericCallbacks['picotestDouble'](21)"))
+  end
+
+  def test_block_passed_to_js_method_runs_inline
+    log = []
+    log << :before
+    result = JS.global.picorubyCallWith(21) do |value|
+      log << :handler
+      value.to_i + 1
+    end
+    log << :after
+    assert_equal(22, result)
+    assert_equal([:before, :handler, :after], log)
+  end
+
+  def test_block_receives_every_argument
+    assert_equal('3-4', JS.global.picorubyCallWith2(3, 4) { |a, b| "#{a.to_i}-#{b.to_i}" })
+  end
+
+  # Regression: the dispatch used to build a Proc from an irep it then freed,
+  # leaving a GC-managed Proc pointing at released memory.
+  def test_repeated_dispatch_survives_gc
+    JS::Object.register_callback('picotestCounted') { |value| value.to_i + 1 }
+    100.times do
+      JS.eval("globalThis.picorubyGenericCallbacks['picotestCounted'](1)")
+    end
+    GC.start
+    assert_equal(2, JS.eval("globalThis.picorubyGenericCallbacks['picotestCounted'](1)"))
+  end
+
+  def test_exception_in_callback_is_contained
+    JS::Object.register_callback('picotestRaises') { |_value| raise 'boom' }
+    assert_nil(JS.eval("globalThis.picorubyGenericCallbacks['picotestRaises'](1)"))
+    # await goes through mrb_suspend_task, which raises while scheduler_lock is
+    # held - so it succeeding proves the lock was released.
+    assert_equal(1, JS.eval('Promise.resolve(1)').await)
+  end
+
+  # No task to suspend on the JS stack: it has to raise, not corrupt the scheduler.
+  def test_await_inside_callback_raises
+    error = nil
+    JS::Object.register_callback('picotestAwaits') do |_value|
+      begin
+        JS.eval('Promise.resolve(1)').await
+      rescue => e
+        error = e.class
+      end
+      nil
+    end
+    JS.eval("globalThis.picorubyGenericCallbacks['picotestAwaits'](1)")
+    assert_equal(RuntimeError, error)
+  end
+end

--- a/mrbgems/picoruby-wasm/test/js_sync_event_test.rb
+++ b/mrbgems/picoruby-wasm/test/js_sync_event_test.rb
@@ -1,0 +1,167 @@
+# Node has EventTarget / Event as globals, so the synchronous dispatch path can
+# be exercised without a DOM. Capture *propagation* cannot: an EventTarget has
+# no tree, so only capture-aware removal is asserted here.
+class JSSyncEventTest < Picotest::Test
+  def new_target
+    JS.global[:EventTarget].new
+  end
+
+  def new_event(type, cancelable = false)
+    options = JS.global.create_object
+    options[:cancelable] = cancelable
+    JS.global[:Event].new(type, options)
+  end
+
+  def test_sync_handler_runs_on_the_dispatch_stack
+    target = new_target
+    log = []
+    id = target.addEventListener('sync-order', sync: true) { |_ev| log << :handler }
+    log << :before
+    target.dispatchEvent(new_event('sync-order'))
+    log << :after
+    assert_equal([:before, :handler, :after], log)
+    JS::Object.removeEventListener(id)
+  end
+
+  def test_async_handler_does_not_run_inline
+    target = new_target
+    log = []
+    id = target.addEventListener('async-order') { |_ev| log << :handler }
+    target.dispatchEvent(new_event('async-order'))
+    assert_equal([], log)
+    JS::Object.removeEventListener(id)
+  end
+
+  def test_sync_prevent_default_is_observed_by_dispatch_event
+    target = new_target
+    id = target.addEventListener('sync-cancel', sync: true) { |ev| ev.preventDefault }
+    event = new_event('sync-cancel', true)
+    assert_equal(false, target.dispatchEvent(event))
+    assert_equal(true, event[:defaultPrevented])
+    JS::Object.removeEventListener(id)
+  end
+
+  # The reason sync: true exists: an async handler calls preventDefault long
+  # after dispatch has finished, so it has no effect.
+  def test_async_prevent_default_is_too_late
+    target = new_target
+    id = target.addEventListener('async-cancel') { |ev| ev.preventDefault }
+    event = new_event('async-cancel', true)
+    assert_equal(true, target.dispatchEvent(event))
+    assert_equal(false, event[:defaultPrevented])
+    JS::Object.removeEventListener(id)
+  end
+
+  def test_block_receives_js_event
+    target = new_target
+    seen = nil
+    # JS::Object descends from BasicObject, so #is_a? (defined in C) is the
+    # way to ask - #class would be forwarded to JS as a property lookup.
+    id = target.addEventListener('sync-arg', sync: true) { |ev| seen = ev.is_a?(JS::Event) }
+    target.dispatchEvent(new_event('sync-arg'))
+    assert_equal(true, seen)
+    JS::Object.removeEventListener(id)
+  end
+
+  def test_nested_synchronous_dispatch
+    outer = new_target
+    inner = new_target
+    log = []
+    inner_id = inner.addEventListener('inner', sync: true) { |_ev| log << :inner }
+    outer_id = outer.addEventListener('outer', sync: true) do |_ev|
+      log << :outer_begin
+      inner.dispatchEvent(new_event('inner'))
+      log << :outer_end
+    end
+    outer.dispatchEvent(new_event('outer'))
+    assert_equal([:outer_begin, :inner, :outer_end], log)
+    JS::Object.removeEventListener(inner_id)
+    JS::Object.removeEventListener(outer_id)
+  end
+
+  def test_sync_once_fires_exactly_once
+    target = new_target
+    count = 0
+    target.addEventListener('sync-once', sync: true, once: true) { |_ev| count += 1 }
+    target.dispatchEvent(new_event('sync-once'))
+    target.dispatchEvent(new_event('sync-once'))
+    assert_equal(1, count)
+  end
+
+  def test_sync_once_clears_bookkeeping
+    target = new_target
+    id = target.addEventListener('sync-once-gc', sync: true, once: true) { |_ev| nil }
+    target.dispatchEvent(new_event('sync-once-gc'))
+    # The DOM dropped the listener, and so did the JS-side registry.
+    assert_equal(false, JS::Object.removeEventListener(id))
+  end
+
+  def test_passive_suppresses_prevent_default
+    target = new_target
+    id = target.addEventListener('sync-passive', sync: true, passive: true) do |ev|
+      ev.preventDefault
+    end
+    event = new_event('sync-passive', true)
+    assert_equal(true, target.dispatchEvent(event))
+    assert_equal(false, event[:defaultPrevented])
+    JS::Object.removeEventListener(id)
+  end
+
+  def test_capture_listener_is_removable
+    target = new_target
+    count = 0
+    id = target.addEventListener('sync-capture', sync: true, capture: true) { |_ev| count += 1 }
+    assert_equal(true, JS::Object.removeEventListener(id))
+    target.dispatchEvent(new_event('sync-capture'))
+    assert_equal(0, count)
+  end
+
+  # An exception must not escape into the JS dispatch frame, and the
+  # scheduler_lock taken around the dispatch must be released either way.
+  def test_exception_in_sync_handler_is_contained
+    target = new_target
+    id = target.addEventListener('sync-raise', sync: true) { |_ev| raise 'boom' }
+    target.dispatchEvent(new_event('sync-raise'))
+    # await goes through mrb_suspend_task, which raises while scheduler_lock is
+    # held - so it succeeding proves the lock was released.
+    assert_equal(1, JS.eval('Promise.resolve(1)').await)
+    JS::Object.removeEventListener(id)
+  end
+
+  # Spawning a task is allowed (it is only *suspending* that is not), so a sync
+  # handler can register an async listener - which then runs on the scheduler.
+  def test_async_listener_can_be_registered_from_sync_handler
+    outer = new_target
+    inner = new_target
+    log = []
+    outer_id = outer.addEventListener('register', sync: true) do |_ev|
+      inner.addEventListener('registered-later') { |_e| log << :async }
+      log << :sync
+    end
+    outer.dispatchEvent(new_event('register'))
+    assert_equal([:sync], log)
+
+    inner.dispatchEvent(new_event('registered-later'))
+    assert_equal([:sync], log)
+    sleep 0.05
+    assert_equal([:sync, :async], log)
+    JS::Object.removeEventListener(outer_id)
+  end
+
+  # Suspending is impossible on the JS dispatch stack; it has to raise rather
+  # than corrupt the scheduler.
+  def test_await_inside_sync_handler_raises
+    target = new_target
+    error = nil
+    id = target.addEventListener('sync-await', sync: true) do |_ev|
+      begin
+        JS.eval('Promise.resolve(1)').await
+      rescue => e
+        error = e.class
+      end
+    end
+    target.dispatchEvent(new_event('sync-await'))
+    assert_equal(RuntimeError, error)
+    JS::Object.removeEventListener(id)
+  end
+end

--- a/mrbgems/picoruby-wasm/test/js_sync_event_test.rb
+++ b/mrbgems/picoruby-wasm/test/js_sync_event_test.rb
@@ -12,6 +12,18 @@ class JSSyncEventTest < Picotest::Test
     JS.global[:Event].new(type, options)
   end
 
+  # Hand the scheduler a chance to run the consumer task, without an arbitrary
+  # wall-clock delay: awaiting an already-resolved Promise suspends this task
+  # until the host loop has pumped the scheduler again. Retrying until the
+  # block is satisfied keeps the test independent of how many steps that takes.
+  def wait_until(limit = 200, &block)
+    limit.times do
+      return true if block.call
+      JS.eval('Promise.resolve()').await
+    end
+    false
+  end
+
   def test_sync_handler_runs_on_the_dispatch_stack
     target = new_target
     log = []
@@ -29,6 +41,8 @@ class JSSyncEventTest < Picotest::Test
     id = target.addEventListener('async-order') { |_ev| log << :handler }
     target.dispatchEvent(new_event('async-order'))
     assert_equal([], log)
+    # ... but it does run, once the scheduler gets to the consumer task.
+    assert_equal(true, wait_until { log.include?(:handler) })
     JS::Object.removeEventListener(id)
   end
 
@@ -142,8 +156,7 @@ class JSSyncEventTest < Picotest::Test
     assert_equal([:sync], log)
 
     inner.dispatchEvent(new_event('registered-later'))
-    assert_equal([:sync], log)
-    sleep 0.05
+    assert_equal(true, wait_until { log.include?(:async) })
     assert_equal([:sync, :async], log)
     JS::Object.removeEventListener(outer_id)
   end


### PR DESCRIPTION
Event listeners have always run through a Task::Queue, so the Ruby block executes on a later scheduler tick - after the browser has finished dispatching the event. preventDefault and stopPropagation are therefore no-ops, transient user activation is gone, and event.currentTarget / composedPath() have already been invalidated. js_add_event_listener worked around part of this by hard-coding preventDefault() for submit events and for clicks on <a> tags.

addEventListener now takes sync:, plus the DOM options capture:, once: and passive:. A synchronous listener runs the block on the JS dispatch stack via call_ruby_callback_sync_event(): mrb_funcall under mrb_protect_error, with mrb->task.scheduler_lock held so that anything which would suspend (fetch, await, blocking Queue#pop) raises instead of corrupting the scheduler. Scheduling work for later - Task.new, setTimeout, registering an async listener - still works. The default path is unchanged, and the submit / <a> preventDefault hack now applies to asynchronous listeners only.

call_ruby_callback_sync_generic is rewritten onto the same mechanism. It used to snprintf a Ruby snippet, compile it with Prism on every invocation, and run it as a temporary task via
mrb_execute_proc_synchronously - a leftover from the mruby/c era, when there was no way to hand arguments to a Ruby proc from C. Besides the per-call compile, that had a real bug: mrb_proc_new increfs the irep, mrc_irep_free then released it regardless, leaving a GC-managed RProc pointing at freed memory for the sweeper to walk. Dropping the compile also removes js.c's dependency on the compiler headers and the $js_callback_args global.

Also:
- removeEventListener passes the capture flag, without which a listener registered with capture: true is not removed
- the event's picorubyRefs slot is released after a synchronous dispatch; its lifetime is bounded, unlike the queued path
- terminal.html's drag is made synchronous: separate listeners get separate queues, so mousemove and mouseup had no guaranteed order relative to each other
- ble_irb_demo.html's history navigation now actually suppresses the caret-moving default action

Node tests cover dispatch ordering, preventDefault (sync vs async), once, passive, capture-aware removal, nested dispatch, exception containment and the generic path including a post-GC regression test.