### PR TITLE
docs: fix the build rake command

### DIFF
--- a/mrbgems/picoruby-wasm/README.md
+++ b/mrbgems/picoruby-wasm/README.md
@@ -40,10 +40,10 @@ See [docs/architecture.md](docs/architecture.md) for the full design including i
 
 ```bash
 # Debug build
-rake wasm:debug
+rake wasm:build_debug
 
 # Production build
-rake wasm:prod
+rake wasm:build_prod
 
 # Clean build artifacts
 rake wasm:clean
@@ -58,7 +58,7 @@ rake wasm:server
 Run the exception-handling test suite after any change to async/task/exception code:
 
 ```bash
-rake wasm:debug
+rake wasm:build_debug
 rake wasm:server
 # Open http://localhost:8080/www/test_index.html
 ```

--- a/mrbgems/picoruby-wasm/docs/architecture.md
+++ b/mrbgems/picoruby-wasm/docs/architecture.md
@@ -218,7 +218,7 @@ Two entry situations, both handled by the above:
 
 After any modification to task scheduling, async operations, or exception handling:
 
-1. Build: `rake wasm:clean && rake wasm:debug`
+1. Build: `rake wasm:clean && rake wasm:build_debug`
 2. Run test server: `rake wasm:server`
 3. Open: http://localhost:8080/test_index.html
 4. **Run ALL tests** and verify each one passes


### PR DESCRIPTION
I updated `rake wasm:debug` and `rake wasm:prod` in `mrbgems/picoruby-wasm/README.md` and `mrbgems/picoruby-wasm/docs/architecture.md` because they were out of sync with the current implementation.

I verified the current implementation in `tasks/picoruby/wasm.rake`.