### PR TITLE
Allow Time.new to accept a float for the sec argument

### DIFF
--- a/mrbgems/picoruby-time/src/mruby/time.c
+++ b/mrbgems/picoruby-time/src/mruby/time.c
@@ -186,6 +186,7 @@ mrb_s_local(mrb_state *mrb, mrb_value klass)
   int usec = 0;
   if (5 < argc) {
     double sec;
+    if (sec < 0 || 60 < sec) mrb_raise(mrb, E_ARGUMENT_ERROR, "sec out of range");
     if (mrb_float_p(argv[5])) {
       sec = mrb_float(argv[5]);
       if (sec != sec) mrb_raise(mrb, E_FLOATDOMAIN_ERROR, "NaN");
@@ -193,7 +194,6 @@ mrb_s_local(mrb_state *mrb, mrb_value klass)
     } else {
       sec = (double)Integer(argv[5]);
     }
-    if (sec < 0 || 60 < sec) mrb_raise(mrb, E_ARGUMENT_ERROR, "sec out of range");
     tm.tm_sec = (int)sec;
   } else {
     tm.tm_sec = 0;

--- a/mrbgems/picoruby-time/src/mruby/time.c
+++ b/mrbgems/picoruby-time/src/mruby/time.c
@@ -188,6 +188,7 @@ mrb_s_local(mrb_state *mrb, mrb_value klass)
     double sec;
     if (mrb_float_p(argv[5])) {
       sec = mrb_float(argv[5]);
+      if (sec != sec) mrb_raise(mrb, E_FLOATDOMAIN_ERROR, "NaN");
       usec = (sec - (int)sec) * USEC;
     } else {
       sec = (double)Integer(argv[5]);

--- a/mrbgems/picoruby-time/src/mruby/time.c
+++ b/mrbgems/picoruby-time/src/mruby/time.c
@@ -183,15 +183,25 @@ mrb_s_local(mrb_state *mrb, mrb_value klass)
     tm.tm_min = 0;
   }
 
+  int usec = 0;
   if (5 < argc) {
-    int sec = Integer(argv[5]);
+    double sec;
+    if (mrb_float_p(argv[5])) {
+      sec = mrb_float(argv[5]);
+      usec = (sec - (int)sec) * USEC;
+    } else {
+      sec = (double)Integer(argv[5]);
+    }
     if (sec < 0 || 60 < sec) mrb_raise(mrb, E_ARGUMENT_ERROR, "sec out of range");
-    tm.tm_sec = sec;
+    tm.tm_sec = (int)sec;
   } else {
     tm.tm_sec = 0;
   }
+  mrb_value time = new_from_tm(mrb, klass, &tm);
+  PICORB_TIME *data = (PICORB_TIME *)DATA_PTR(time);
+  data->unixtime_us += usec;
 
-  return new_from_tm(mrb, klass, &tm);
+  return time;
 }
 
 static mrb_value

--- a/mrbgems/picoruby-time/src/mrubyc/time.c
+++ b/mrbgems/picoruby-time/src/mrubyc/time.c
@@ -139,14 +139,20 @@ c_local(struct VM *vm, mrbc_value v[], int argc)
   if (5 < argc) {
     double sec;
     mrbc_value value = GET_ARG(6);
+    if (sec < 0 || 60 < sec) {
+      mrbc_raise(vm, MRBC_CLASS(ArgumentError), "sec out of range");
+      return
+    }
     if (value.tt == MRBC_TT_FLOAT) {
       sec = value.d;
-      if (sec != sec) mrbc_raise(vm, MRBC_CLASS(RangeError), "NaN");
+      if (sec != sec) {
+        mrbc_raise(vm, MRBC_CLASS(RangeError), "NaN");
+        return;
+      }
       usec = (sec - (int)sec) * USEC;
     } else {
       sec = (mrbc_float_t)Integer(value);
     }
-    if (sec < 0 || 60 < sec) mrbc_raise(vm, MRBC_CLASS(ArgumentError), "sec out of range");
     tm.tm_sec = (int)sec;
   } else tm.tm_sec = 0;
   mrbc_value time = new_from_tm(vm, v, &tm);

--- a/mrbgems/picoruby-time/src/mrubyc/time.c
+++ b/mrbgems/picoruby-time/src/mrubyc/time.c
@@ -141,6 +141,7 @@ c_local(struct VM *vm, mrbc_value v[], int argc)
     mrbc_value value = GET_ARG(6);
     if (value.tt == MRBC_TT_FLOAT) {
       sec = value.d;
+      if (sec != sec) mrbc_raise(vm, MRBC_CLASS(RangeError), "NaN");
       usec = (sec - (int)sec) * USEC;
     } else {
       sec = (mrbc_float_t)Integer(value);

--- a/mrbgems/picoruby-time/src/mrubyc/time.c
+++ b/mrbgems/picoruby-time/src/mrubyc/time.c
@@ -135,12 +135,23 @@ c_local(struct VM *vm, mrbc_value v[], int argc)
     if (min < 0 || 59 < min) mrbc_raise(vm, MRBC_CLASS(ArgumentError), "min out of range");
     tm.tm_min = min;
   } else tm.tm_min = 0;
+  int usec = 0;
   if (5 < argc) {
-    int sec = Integer(GET_ARG(6));
+    double sec;
+    mrbc_value value = GET_ARG(6);
+    if (value.tt == MRBC_TT_FLOAT) {
+      sec = value.d;
+      usec = (sec - (int)sec) * USEC;
+    } else {
+      sec = (mrbc_float_t)Integer(value);
+    }
     if (sec < 0 || 60 < sec) mrbc_raise(vm, MRBC_CLASS(ArgumentError), "sec out of range");
-    tm.tm_sec = sec;
+    tm.tm_sec = (int)sec;
   } else tm.tm_sec = 0;
-  SET_RETURN(new_from_tm(vm, v, &tm));
+  mrbc_value time = new_from_tm(vm, v, &tm);
+  PICORB_TIME *data = (PICORB_TIME *)time.instance->data;
+  data->unixtime_us += usec;
+  SET_RETURN(time);
 }
 
 static void


### PR DESCRIPTION
Time.new previously accepted only Integer values for its sixth (sec) argument. It now also accepts Float values.

before:
```ruby
p Time.new(2026,8,5,12,34,56.124)
#=> in new: invalid value for Integer() (ArgumentError)
```

after:
```ruby
p Time.new(2026,8,5,12,34,56.124)
#=> 2026-08-05 12:34:56.124000 +0900
```