### PR TITLE
feature: IRQ Event Bridge

### DIFF
--- a/build_config/femtoruby-test.rb
+++ b/build_config/femtoruby-test.rb
@@ -5,6 +5,7 @@ MRuby::Build.new do |conf|
   conf.cc.defines << "PICORB_PLATFORM_POSIX"
   conf.cc.defines << "PICORB_INT64"
   conf.cc.defines << "MRBC_TICK_UNIT=4"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=3"
   conf.cc.defines << "MRBC_USE_STRING_UTF8"
 

--- a/build_config/femtoruby.rb
+++ b/build_config/femtoruby.rb
@@ -5,6 +5,7 @@ MRuby::Build.new do |conf|
   conf.cc.defines << "PICORB_PLATFORM_POSIX"
   conf.cc.defines << "PICORB_INT64"
   conf.cc.defines << "MRBC_TICK_UNIT=4"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=3"
   conf.cc.defines << "MRBC_USE_STRING_UTF8"
 

--- a/build_config/r2p2-femtoruby-pico.rb
+++ b/build_config/r2p2-femtoruby-pico.rb
@@ -32,6 +32,7 @@ MRuby::CrossBuild.new("r2p2-femtoruby-pico") do |conf|
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "MRBC_USE_MATH=1"
   conf.cc.defines << "MRBC_TICK_UNIT=1"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=10"
   conf.cc.defines << "NO_CLOCK_GETTIME=1"
   conf.cc.defines << "MAX_SYMBOLS_COUNT=2000"

--- a/build_config/r2p2-femtoruby-pico2.rb
+++ b/build_config/r2p2-femtoruby-pico2.rb
@@ -41,6 +41,7 @@ MRuby::CrossBuild.new("r2p2-femtoruby-pico2") do |conf|
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "MRBC_USE_MATH=1"
   conf.cc.defines << "MRBC_TICK_UNIT=1"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=10"
   conf.cc.defines << "NO_CLOCK_GETTIME=1"
   conf.cc.defines << "MAX_SYMBOLS_COUNT=2000"

--- a/build_config/r2p2-femtoruby-pico2_w.rb
+++ b/build_config/r2p2-femtoruby-pico2_w.rb
@@ -41,6 +41,7 @@ MRuby::CrossBuild.new("r2p2-femtoruby-pico2_w") do |conf|
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "MRBC_USE_MATH=1"
   conf.cc.defines << "MRBC_TICK_UNIT=1"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=10"
   conf.cc.defines << "NO_CLOCK_GETTIME=1"
   conf.cc.defines << "MAX_SYMBOLS_COUNT=2000"

--- a/build_config/r2p2-femtoruby-pico_w.rb
+++ b/build_config/r2p2-femtoruby-pico_w.rb
@@ -32,6 +32,7 @@ MRuby::CrossBuild.new("r2p2-femtoruby-pico_w") do |conf|
   conf.cc.defines << "MRBC_CONVERT_CRLF=1"
   conf.cc.defines << "MRBC_USE_MATH=1"
   conf.cc.defines << "MRBC_TICK_UNIT=1"
+  conf.cc.defines << "MRBC_TASK_SCHEDULER_HOOK"  # picoruby-irq event bridge
   conf.cc.defines << "MRBC_TIMESLICE_TICK_COUNT=10"
   conf.cc.defines << "NO_CLOCK_GETTIME=1"
   conf.cc.defines << "MAX_SYMBOLS_COUNT=2000"

--- a/mrbgems/picoruby-irq/README.md
+++ b/mrbgems/picoruby-irq/README.md
@@ -104,23 +104,24 @@ ready source into one token in the queue you bound to it. A task blocked
 on that queue becomes runnable in the same scheduler iteration.
 
 ```ruby
-SRC = 0    # a source id; see below
-
 q = Task::Queue.new
-IRQ.bind(SRC, q)
+IRQ.bind(IRQ.gpio_source, q)
 
 Task.new do
   while source = q.pop
-    bits = IRQ.take(source)
-    next if bits == 0    # spurious token; note that 0 is truthy in Ruby
-    puts "event bits: #{bits}"
+    IRQ.take(source)   # required: this is what allows the next token
+    # One token can stand for any number of interrupts, so drain rather
+    # than assume it means exactly one event.
+    while 0 < IRQ.process
+    end
   end
 end
 ```
 
 Source ids are compile-time constants, never allocated and never reused.
-No peripheral publishes to the bridge yet -- GPIO is the first one being
-wired up -- so for now the only producer is `IRQ.simulate`.
+GPIO uses one source for the whole subsystem: the token only says "the
+GPIO event queue is worth looking at", and `IRQ.process` is still what
+dispatches events to their handlers.
 
 ### Contract
 
@@ -140,9 +141,11 @@ wired up -- so for now the only producer is `IRQ.simulate`.
 
 `IRQ.simulate(source, bits)` drives the bridge exactly as an interrupt
 handler would, for tests and for bringing a consumer up on a host build.
+Note that on a host build there are no GPIO interrupts to bind to.
 
-The bridge needs the task scheduler; on builds without it (mruby/c
-today) these methods are not defined.
+The bridge is available on both runtimes. A build configured without a
+task scheduler does not define these methods, and pays nothing for
+them.
 
 ## Constants
 

--- a/mrbgems/picoruby-irq/README.md
+++ b/mrbgems/picoruby-irq/README.md
@@ -91,6 +91,59 @@ processed_count = IRQ.process(10)  # Process up to 10 events
 puts "Processed #{processed_count} events"
 ```
 
+## Event bridge (ISR to task)
+
+`IRQ.process` above is polling: something has to keep asking. The event
+bridge is the other direction -- a task parks in `Task::Queue#pop` and
+the interrupt wakes it.
+
+An interrupt handler cannot enter the VM, so it only stages work: it ORs
+event bits into a *source* and marks that source ready. At every
+scheduler entry, before the ready queue is read, PicoRuby turns each
+ready source into one token in the queue you bound to it. A task blocked
+on that queue becomes runnable in the same scheduler iteration.
+
+```ruby
+SRC = 0    # a source id; see below
+
+q = Task::Queue.new
+IRQ.bind(SRC, q)
+
+Task.new do
+  while source = q.pop
+    bits = IRQ.take(source)
+    next if bits == 0    # spurious token; note that 0 is truthy in Ruby
+    puts "event bits: #{bits}"
+  end
+end
+```
+
+Source ids are compile-time constants, never allocated and never reused.
+No peripheral publishes to the bridge yet -- GPIO is the first one being
+wired up -- so for now the only producer is `IRQ.simulate`.
+
+### Contract
+
+1. **Tokens are edge-latched, coalesced notifications** -- one token per
+   "something happened since you last took the bits", not one per
+   interrupt. A burst of interrupts produces a single token whose bits
+   are ORed together, so the queue can never grow without bound.
+2. **Consumers must tolerate spurious tokens.** `IRQ.take` may return 0;
+   treat that as "nothing to do" rather than an error, and drain the
+   underlying peripheral until it reports empty rather than assuming one
+   token means exactly one event.
+3. **Late binding works, but coalesced.** Bits signalled while nothing
+   was bound are not lost: `IRQ.bind` re-asserts the source, and the
+   accumulated bits arrive on the next scheduler entry as one token.
+4. **Rebinding or unbinding a source with an undelivered token raises.**
+   Take the bits first. Rebinding the same queue is always a no-op.
+
+`IRQ.simulate(source, bits)` drives the bridge exactly as an interrupt
+handler would, for tests and for bringing a consumer up on a host build.
+
+The bridge needs the task scheduler; on builds without it (mruby/c
+today) these methods are not defined.
+
 ## Constants
 
 ### GPIO Event Types

--- a/mrbgems/picoruby-irq/example/irq_gpio.rb
+++ b/mrbgems/picoruby-irq/example/irq_gpio.rb
@@ -1,18 +1,57 @@
 require 'irq'
 
-button = GPIO.new(17, GPIO::IN|GPIO::PULL_UP)
+module IRQGPIOExample
+  def self.install_cleanup(button_irq, led, source)
+    @button_irq = button_irq
+    @led = led
+    @source = source
+    @previous_int_handler = Signal.trap(:INT) { IRQGPIOExample.cleanup }
+  end
 
-led = GPIO.new(16, GPIO::OUT)
-
-button.irq(GPIO::EDGE_FALL, debounce: 100, capture: {led: led}) do |button, event, cap|
-  puts "Button pressed, toggling LED"
-  cap[:led].write(cap[:led].high? ? 0 : 1)
+  def self.cleanup
+    @button_irq.unregister
+    @led.write(0)
+    IRQ.take(@source) # release a token that may still be outstanding
+    IRQ.unbind(@source)
+    @button_irq = nil
+    @led = nil
+    @source = nil
+    previous = @previous_int_handler
+    @previous_int_handler = nil
+    puts "Exiting..."
+    Signal.trap(:INT, previous || "DEFAULT")
+  end
 end
 
-# Main loop
+button = GPIO.new(17, GPIO::IN|GPIO::PULL_UP)
+led = GPIO.new(16, GPIO::OUT)
+
+# This sample is not suitable for reliable mechanical-switch input because it
+# does not debounce the switch. Contact bounce may cause the LED to flicker.
+# Debounce in hardware or confirm that the input is stable in software instead.
+led.write(button.low? ? 1 : 0)
+button_irq = button.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE, capture: {led: led}) do |button, _event, cap|
+  cap[:led].write(button.low? ? 1 : 0)
+end
+
+# Main loop. IRQ.bind arranges for a token to arrive whenever a GPIO
+# interrupt has queued something, and pop blocks until then, so there is
+# no polling interval to tune and nothing to wake up for while the
+# button is idle.
+q = Task::Queue.new
+source = IRQ.gpio_source
+IRQ.bind(source, q)
+IRQGPIOExample.install_cleanup(button_irq, led, source)
+
 loop do
-  IRQ.process
-  sleep_ms(10)
+  source = q.pop
+  # Taking the bits is required: it is what allows the next token.
+  IRQ.take(source)
+  # One token can stand for any number of interrupts, so keep
+  # dispatching until there is nothing left rather than assuming the
+  # token means exactly one event.
+  while 0 < IRQ.process
+  end
 end
 
 # Note:
@@ -25,8 +64,8 @@ end
 # write the code simply like below:
 # ```mruby
 # led = GPIO.new(16, GPIO::OUT)
-# button.irq(GPIO::EDGE_FALL, debounce: 100) do |button, event|
-#   puts "Button pressed, toggling LED"
-#   led.write(led.high? ? 0 : 1)
+# led.write(button.low? ? 1 : 0)
+# button.irq(GPIO::EDGE_FALL | GPIO::EDGE_RISE) do |button, _event|
+#   led.write(button.low? ? 1 : 0)
 # end
 # ```

--- a/mrbgems/picoruby-irq/example/irq_gpio.rb
+++ b/mrbgems/picoruby-irq/example/irq_gpio.rb
@@ -16,11 +16,12 @@ loop do
 end
 
 # Note:
-# For mruby/c's technical reasons, local variables outside
-# the irq block are not accessible from the callback.
-# `capture` is a way to pass local variables into the block.
+# On FemtoRuby (the mruby/c-based runtime), local variables outside
+# the irq block are not accessible from the callback, for technical
+# reasons of that VM. `capture` is a way to pass local variables into
+# the block.
 #
-# If you can use mruby-based PicoRuby, you can
+# On PicoRuby (the mruby-based runtime) you can
 # write the code simply like below:
 # ```mruby
 # led = GPIO.new(16, GPIO::OUT)

--- a/mrbgems/picoruby-irq/include/irq.h
+++ b/mrbgems/picoruby-irq/include/irq.h
@@ -14,6 +14,49 @@ bool IRQ_unregister_gpio(int irq_id);
 bool IRQ_peek_event(int *irq_id, int *event_type);
 void IRQ_init(void);
 
+/*
+ * ISR-to-task event bridge
+ *
+ * An interrupt handler only stages work: it ORs event bits into a
+ * source's `pending` word and marks the source ready. A drain running
+ * in VM context later turns that into a token in a bound Task::Queue,
+ * waking a task blocked in `pop`. Handlers never touch the VM.
+ *
+ * Source ids are compile-time constants -- fixed, process-lifetime,
+ * never reused -- so no registration or generation counter is needed.
+ */
+#define IRQ_MAX_SOURCES 32
+
+enum {
+  IRQ_SRC_GPIO = 0,   /* shared by the whole GPIO subsystem */
+};
+
+/* ISR side. Invalid ids are a no-op. Order is load-bearing: the bits
+ * are published before the source is marked ready. */
+void IRQ_signal_from_isr(int id, uint32_t bits);
+
+/* VM side. A source stays ready until it has been dealt with, so a
+ * drain that is cut short (the push allocates, and allocation can
+ * raise) is simply retried at the next scheduler entry. */
+uint32_t IRQ_peek_ready(void);        /* the ready set, unchanged */
+void     IRQ_clear_ready(int id);     /* done with this source */
+bool     IRQ_any_pending(void);       /* cheap check for the scheduler hook */
+bool     IRQ_mark_enqueued(int id);   /* false if a token is already out */
+bool     IRQ_is_enqueued(int id);
+uint32_t IRQ_take_bits(int id);       /* claim bits, release the token */
+void     IRQ_mark_ready(int id);      /* re-assert after a late bind */
+uint32_t IRQ_peek_pending(int id);
+void     IRQ_reset(void);             /* drop all state; used at VM boundaries */
+
+/* Atomic primitives, provided by each port. Callable from ISR and task
+ * context alike, sequentially consistent: the ISR publishes payload
+ * (e.g. bytes in a driver ring) before the ready bit, and the consumer
+ * must observe them in that order. */
+uint32_t IRQ_hal_atomic_load_u32(const volatile uint32_t *p);
+uint32_t IRQ_hal_atomic_or_u32(volatile uint32_t *p, uint32_t bits);
+uint32_t IRQ_hal_atomic_and_u32(volatile uint32_t *p, uint32_t mask);
+uint32_t IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v);
+
 typedef enum picorb_gpio_irq_event_t {
   PICORB_GPIO_IRQ_EVENT_LEVEL_LOW  = 1,
   PICORB_GPIO_IRQ_EVENT_LEVEL_HIGH = 2,

--- a/mrbgems/picoruby-irq/include/irq.h
+++ b/mrbgems/picoruby-irq/include/irq.h
@@ -15,6 +15,20 @@ bool IRQ_peek_event(int *irq_id, int *event_type);
 void IRQ_init(void);
 
 /*
+ * The event bridge needs Task::Queue and a scheduler hook. Both VMs
+ * have them, but a build can be configured without: everything below --
+ * including the source table an ISR would publish to -- compiles out,
+ * so a build that has no consumer pays nothing.
+ */
+#if defined(PICORB_VM_MRUBY) && defined(MRB_USE_TASK_SCHEDULER)
+#define PICORB_IRQ_EVENT_BRIDGE 1
+#elif defined(PICORB_VM_MRUBYC) && defined(MRBC_TASK_SCHEDULER_HOOK)
+#define PICORB_IRQ_EVENT_BRIDGE 1
+#endif
+
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+
+/*
  * ISR-to-task event bridge
  *
  * An interrupt handler only stages work: it ORs event bits into a
@@ -25,7 +39,13 @@ void IRQ_init(void);
  * Source ids are compile-time constants -- fixed, process-lifetime,
  * never reused -- so no registration or generation counter is needed.
  */
-#define IRQ_MAX_SOURCES 32
+/* Every source costs a pending word plus a binding slot, permanently,
+ * on parts where RAM is the binding constraint -- a full 32 does not fit
+ * on pico2_w. Raise it from a build config when a build really has that
+ * many event producers; the bit arithmetic is written for up to 32. */
+#ifndef IRQ_MAX_SOURCES
+#define IRQ_MAX_SOURCES 8
+#endif
 
 enum {
   IRQ_SRC_GPIO = 0,   /* shared by the whole GPIO subsystem */
@@ -56,6 +76,8 @@ uint32_t IRQ_hal_atomic_load_u32(const volatile uint32_t *p);
 uint32_t IRQ_hal_atomic_or_u32(volatile uint32_t *p, uint32_t bits);
 uint32_t IRQ_hal_atomic_and_u32(volatile uint32_t *p, uint32_t mask);
 uint32_t IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v);
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */
 
 typedef enum picorb_gpio_irq_event_t {
   PICORB_GPIO_IRQ_EVENT_LEVEL_LOW  = 1,

--- a/mrbgems/picoruby-irq/mrbgem.rake
+++ b/mrbgems/picoruby-irq/mrbgem.rake
@@ -9,10 +9,8 @@ MRuby::Gem::Specification.new('picoruby-irq') do |spec|
   # hook. Without them the gem still builds; only the bridge
   # (IRQ.bind / IRQ.unbind / IRQ.take) compiles out. picoruby-machine
   # owns the single hook slot and hands out scheduler services.
-  unless build.platform?(:esp32)
-    spec.add_dependency 'mruby-task' if build.picoruby?
-    spec.add_dependency 'picoruby-machine'
-  end
+  spec.add_dependency 'mruby-task' if build.picoruby?
+  spec.add_dependency 'picoruby-machine'
 
   spec.cc.include_paths << "#{dir}/include"
 end

--- a/mrbgems/picoruby-irq/mrbgem.rake
+++ b/mrbgems/picoruby-irq/mrbgem.rake
@@ -6,11 +6,11 @@ MRuby::Gem::Specification.new('picoruby-irq') do |spec|
   spec.add_dependency 'picoruby-gpio'
 
   # The ISR-to-task event bridge needs Task::Queue and the scheduler
-  # hook. Without mruby-task the gem still builds; only the bridge
+  # hook. Without them the gem still builds; only the bridge
   # (IRQ.bind / IRQ.unbind / IRQ.take) compiles out. picoruby-machine
   # owns the single hook slot and hands out scheduler services.
-  if build.picoruby? && !build.platform?(:esp32)
-    spec.add_dependency 'mruby-task'
+  unless build.platform?(:esp32)
+    spec.add_dependency 'mruby-task' if build.picoruby?
     spec.add_dependency 'picoruby-machine'
   end
 

--- a/mrbgems/picoruby-irq/mrbgem.rake
+++ b/mrbgems/picoruby-irq/mrbgem.rake
@@ -4,4 +4,15 @@ MRuby::Gem::Specification.new('picoruby-irq') do |spec|
   spec.summary = 'IRQ module'
 
   spec.add_dependency 'picoruby-gpio'
+
+  # The ISR-to-task event bridge needs Task::Queue and the scheduler
+  # hook. Without mruby-task the gem still builds; only the bridge
+  # (IRQ.bind / IRQ.unbind / IRQ.take) compiles out. picoruby-machine
+  # owns the single hook slot and hands out scheduler services.
+  if build.picoruby? && !build.platform?(:esp32)
+    spec.add_dependency 'mruby-task'
+    spec.add_dependency 'picoruby-machine'
+  end
+
+  spec.cc.include_paths << "#{dir}/include"
 end

--- a/mrbgems/picoruby-irq/mrblib/irq.rb
+++ b/mrbgems/picoruby-irq/mrblib/irq.rb
@@ -29,11 +29,15 @@ module IRQ
       return id
     end
 
+    # Returns the number of events dispatched. The limit is checked
+    # before peek_event, not after: peek_event removes the event from
+    # the queue, so testing the limit afterwards threw one event away
+    # on every call that hit the limit.
     def process(max_count = MAX_PROCESS_COUNT)
       count = 0
-      while true
+      while count < max_count
         id, event_type = peek_event
-        break if id.nil? || max_count <= count
+        break if id.nil?
         if irq = HANDLER[id]
           irq.call(event_type)
           count += 1

--- a/mrbgems/picoruby-irq/ports/esp32/irq.c
+++ b/mrbgems/picoruby-irq/ports/esp32/irq.c
@@ -103,7 +103,14 @@ gpio_isr_handler(void* arg)
     .event_type = events
   };
 
-  xQueueSendFromISR(event_queue, &event, NULL);
+  if (xQueueSendFromISR(event_queue, &event, NULL) == pdTRUE) {
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+    /* Publish after the event is visible in the queue, so a task woken
+       by the token always finds it. A full queue does not signal: there
+       is nothing new to drain. */
+    IRQ_signal_from_isr(IRQ_SRC_GPIO, 1);
+#endif
+  }
 }
 
 int
@@ -237,6 +244,8 @@ IRQ_init(void)
   memset(irq_handlers, 0, sizeof(irq_handlers));
 }
 
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+
 /*
  * Atomic primitives for the event bridge. ESP-IDF supports the GCC
  * __atomic builtins on both Xtensa and RISC-V targets, so no critical
@@ -266,3 +275,5 @@ IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
 {
   return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST);
 }
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */

--- a/mrbgems/picoruby-irq/ports/esp32/irq.c
+++ b/mrbgems/picoruby-irq/ports/esp32/irq.c
@@ -236,3 +236,33 @@ IRQ_init(void)
 {
   memset(irq_handlers, 0, sizeof(irq_handlers));
 }
+
+/*
+ * Atomic primitives for the event bridge. ESP-IDF supports the GCC
+ * __atomic builtins on both Xtensa and RISC-V targets, so no critical
+ * section (and no task/ISR variant split) is needed.
+ */
+
+uint32_t
+IRQ_hal_atomic_load_u32(const volatile uint32_t *p)
+{
+  return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_or_u32(volatile uint32_t *p, uint32_t bits)
+{
+  return __atomic_fetch_or(p, bits, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_and_u32(volatile uint32_t *p, uint32_t mask)
+{
+  return __atomic_fetch_and(p, mask, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
+{
+  return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST);
+}

--- a/mrbgems/picoruby-irq/ports/posix/irq.c
+++ b/mrbgems/picoruby-irq/ports/posix/irq.c
@@ -12,6 +12,8 @@
 
 #include "../../include/irq.h"
 
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+
 uint32_t
 IRQ_hal_atomic_load_u32(const volatile uint32_t *p)
 {
@@ -35,6 +37,8 @@ IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
 {
   return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST);
 }
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */
 
 int
 IRQ_register_gpio(int pin, int event_type, uint32_t debounce_ms)

--- a/mrbgems/picoruby-irq/ports/posix/irq.c
+++ b/mrbgems/picoruby-irq/ports/posix/irq.c
@@ -1,0 +1,63 @@
+/*
+ * POSIX port: host test target for the event bridge.
+ *
+ * There is no interrupt source here -- tests drive the bridge with
+ * IRQ.simulate, which runs in ordinary VM context -- so the GCC
+ * __atomic builtins are all this port needs. The GPIO entry points
+ * below exist so the gem links; GPIO interrupts are hardware-only.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../include/irq.h"
+
+uint32_t
+IRQ_hal_atomic_load_u32(const volatile uint32_t *p)
+{
+  return __atomic_load_n(p, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_or_u32(volatile uint32_t *p, uint32_t bits)
+{
+  return __atomic_fetch_or(p, bits, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_and_u32(volatile uint32_t *p, uint32_t mask)
+{
+  return __atomic_fetch_and(p, mask, __ATOMIC_SEQ_CST);
+}
+
+uint32_t
+IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
+{
+  return __atomic_exchange_n(p, v, __ATOMIC_SEQ_CST);
+}
+
+int
+IRQ_register_gpio(int pin, int event_type, uint32_t debounce_ms)
+{
+  (void)pin; (void)event_type; (void)debounce_ms;
+  return -1;
+}
+
+bool
+IRQ_unregister_gpio(int irq_id)
+{
+  (void)irq_id;
+  return false;
+}
+
+bool
+IRQ_peek_event(int *irq_id, int *event_type)
+{
+  (void)irq_id; (void)event_type;
+  return false;
+}
+
+void
+IRQ_init(void)
+{
+}

--- a/mrbgems/picoruby-irq/ports/rp2040/irq.c
+++ b/mrbgems/picoruby-irq/ports/rp2040/irq.c
@@ -4,6 +4,7 @@
 #include "hardware/gpio.h"
 #include "hardware/irq.h"
 #include "pico/time.h"
+#include "hardware/sync.h"
 
 #include "../../include/irq.h"
 
@@ -177,4 +178,57 @@ picorb_irq_gpio_resume(void)
           irq_handlers[i].event_mask, true, &gpio_irq_callback);
     }
   }
+}
+
+/*
+ * Atomic primitives for the event bridge.
+ *
+ * Cortex-M0+ has no LDREX/STREX, so C11 atomics would lower to
+ * libatomic calls; a short interrupt-save critical section is both
+ * cheaper and valid in ISR and task context alike. This masks
+ * interrupts on the CURRENT core only: producers (ISRs) and the VM
+ * are expected to live on core 0, as PicoRuby runs today.
+ */
+
+uint32_t
+IRQ_hal_atomic_load_u32(const volatile uint32_t *p)
+{
+  uint32_t v;
+  uint32_t state = save_and_disable_interrupts();
+  v = *p;
+  restore_interrupts(state);
+  return v;
+}
+
+uint32_t
+IRQ_hal_atomic_or_u32(volatile uint32_t *p, uint32_t bits)
+{
+  uint32_t old;
+  uint32_t state = save_and_disable_interrupts();
+  old = *p;
+  *p = old | bits;
+  restore_interrupts(state);
+  return old;
+}
+
+uint32_t
+IRQ_hal_atomic_and_u32(volatile uint32_t *p, uint32_t mask)
+{
+  uint32_t old;
+  uint32_t state = save_and_disable_interrupts();
+  old = *p;
+  *p = old & mask;
+  restore_interrupts(state);
+  return old;
+}
+
+uint32_t
+IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
+{
+  uint32_t old;
+  uint32_t state = save_and_disable_interrupts();
+  old = *p;
+  *p = v;
+  restore_interrupts(state);
+  return old;
 }

--- a/mrbgems/picoruby-irq/ports/rp2040/irq.c
+++ b/mrbgems/picoruby-irq/ports/rp2040/irq.c
@@ -58,6 +58,12 @@ gpio_irq_callback(uint gpio, uint32_t events)
         event_queue[queue_tail].irq_id = i + 1;  /* IRQ ID is 1-based */
         event_queue[queue_tail].event_type = events;
         queue_tail = next_tail;
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+        /* Publish after the event is visible in the queue, so a task
+           woken by the token always finds it. Dropped events (queue
+           full) do not signal: there is nothing new to drain. */
+        IRQ_signal_from_isr(IRQ_SRC_GPIO, 1);
+#endif
       }
       break;
     }
@@ -180,6 +186,8 @@ picorb_irq_gpio_resume(void)
   }
 }
 
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+
 /*
  * Atomic primitives for the event bridge.
  *
@@ -232,3 +240,5 @@ IRQ_hal_atomic_exchange_u32(volatile uint32_t *p, uint32_t v)
   restore_interrupts(state);
   return old;
 }
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */

--- a/mrbgems/picoruby-irq/sig/irq.rbs
+++ b/mrbgems/picoruby-irq/sig/irq.rbs
@@ -8,6 +8,7 @@ module IRQ
   type irq_source_t = Integer
 
   MAX_PROCESS_COUNT: Integer
+  MAX_SOURCES: Integer
   HANDLER: Hash[irq_id_t, IRQInstance]
 
   private def self.peek_event: () -> [(irq_id_t | nil), irq_event_type_t]
@@ -20,6 +21,7 @@ module IRQ
 
   # ISR-to-task event bridge. Defined in C, and only in builds that have
   # the task scheduler.
+  def self.gpio_source: () -> irq_source_t
   def self.bind: (irq_source_t source, Task::Queue queue) -> Task::Queue
   def self.unbind: (irq_source_t source) -> bool
   def self.take: (irq_source_t source) -> Integer

--- a/mrbgems/picoruby-irq/sig/irq.rbs
+++ b/mrbgems/picoruby-irq/sig/irq.rbs
@@ -3,6 +3,9 @@ module IRQ
   type irq_id_t = Integer
   type irq_event_type_t = Integer
   type irq_peri_t = GPIO
+  # Compile-time constant slot in the ISR-to-task event bridge; unrelated
+  # to irq_id_t, which is handed out by IRQ.register_gpio.
+  type irq_source_t = Integer
 
   MAX_PROCESS_COUNT: Integer
   HANDLER: Hash[irq_id_t, IRQInstance]
@@ -14,6 +17,13 @@ module IRQ
   private def self.register_gpio: (gpio_pin_t pin, irq_event_type_t event_type, Hash[Symbol, untyped] opts) -> irq_id_t
   private def self.unregister_gpio: (irq_id_t id) -> bool
   def irq: (irq_event_type_t event_type, **untyped opts) { (irq_peri_t peri, irq_event_type_t event_type, Object capture) -> void } -> void
+
+  # ISR-to-task event bridge. Defined in C, and only in builds that have
+  # the task scheduler.
+  def self.bind: (irq_source_t source, Task::Queue queue) -> Task::Queue
+  def self.unbind: (irq_source_t source) -> bool
+  def self.take: (irq_source_t source) -> Integer
+  def self.simulate: (irq_source_t source, Integer bits) -> nil
 
   class IRQInstance
     @id: irq_id_t

--- a/mrbgems/picoruby-irq/src/irq_source.c
+++ b/mrbgems/picoruby-irq/src/irq_source.c
@@ -10,13 +10,14 @@
 #include <stddef.h>
 #include "../include/irq.h"
 
-typedef struct {
-  volatile uint32_t pending;  /* event bits, OR-ed by the ISR */
-  bool enqueued;              /* a token is outstanding; VM context only */
-} irq_source_t;
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
 
-static irq_source_t sources_[IRQ_MAX_SOURCES];
+/* Parallel arrays rather than a struct: `enqueued` is one bit of state
+   and a bool field would cost four bytes per source after padding, on a
+   part where RAM is the binding constraint. */
+static volatile uint32_t pending_[IRQ_MAX_SOURCES];  /* OR-ed by the ISR */
 static volatile uint32_t ready_mask_;
+static uint32_t enqueued_mask_;   /* a token is out; VM context only */
 
 /* `1 << id` would be undefined at id 31 (signed shift overflow). */
 #define IRQ_BIT(id) (UINT32_C(1) << (id))
@@ -33,7 +34,7 @@ IRQ_signal_from_isr(int id, uint32_t bits)
   if (!valid_id(id)) return;
   /* Publish the bits before the ready flag: a consumer that sees the
      ready bit must also see everything the handler staged. */
-  IRQ_hal_atomic_or_u32(&sources_[id].pending, bits);
+  IRQ_hal_atomic_or_u32(&pending_[id], bits);
   IRQ_hal_atomic_or_u32(&ready_mask_, IRQ_BIT(id));
 }
 
@@ -64,15 +65,15 @@ IRQ_any_pending(void)
 bool
 IRQ_mark_enqueued(int id)
 {
-  if (!valid_id(id) || sources_[id].enqueued) return false;
-  sources_[id].enqueued = true;
+  if (!valid_id(id) || (enqueued_mask_ & IRQ_BIT(id))) return false;
+  enqueued_mask_ |= IRQ_BIT(id);
   return true;
 }
 
 bool
 IRQ_is_enqueued(int id)
 {
-  return valid_id(id) && sources_[id].enqueued;
+  return valid_id(id) && (enqueued_mask_ & IRQ_BIT(id)) != 0;
 }
 
 uint32_t
@@ -81,12 +82,12 @@ IRQ_take_bits(int id)
   uint32_t bits;
 
   if (!valid_id(id)) return 0;
-  bits = IRQ_hal_atomic_exchange_u32(&sources_[id].pending, 0);
+  bits = IRQ_hal_atomic_exchange_u32(&pending_[id], 0);
   /* Releasing the token after claiming the bits is enough: a signal
      that lands before the exchange is in `bits`, and one that lands
      after it re-asserts the ready bit itself. Worst case the consumer
      sees one spurious token, which the contract allows. */
-  sources_[id].enqueued = false;
+  enqueued_mask_ &= ~IRQ_BIT(id);
   return bits;
 }
 
@@ -101,7 +102,7 @@ uint32_t
 IRQ_peek_pending(int id)
 {
   if (!valid_id(id)) return 0;
-  return IRQ_hal_atomic_load_u32(&sources_[id].pending);
+  return IRQ_hal_atomic_load_u32(&pending_[id]);
 }
 
 void
@@ -112,8 +113,10 @@ IRQ_reset(void)
   /* Interrupts may still be firing, so clear atomically. Events racing
      a VM boundary are dropped by design. */
   for (i = 0; i < IRQ_MAX_SOURCES; i++) {
-    IRQ_hal_atomic_exchange_u32(&sources_[i].pending, 0);
-    sources_[i].enqueued = false;
+    IRQ_hal_atomic_exchange_u32(&pending_[i], 0);
   }
+  enqueued_mask_ = 0;
   IRQ_hal_atomic_exchange_u32(&ready_mask_, 0);
 }
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */

--- a/mrbgems/picoruby-irq/src/irq_source.c
+++ b/mrbgems/picoruby-irq/src/irq_source.c
@@ -1,0 +1,119 @@
+/*
+ * Source table for the ISR-to-task event bridge.
+ *
+ * VM-agnostic: this file only manipulates plain C state. Turning a
+ * ready source into a Task::Queue token is the VM glue's job (see
+ * src/mruby/irq.c), because that step allocates and must run in VM
+ * context.
+ */
+
+#include <stddef.h>
+#include "../include/irq.h"
+
+typedef struct {
+  volatile uint32_t pending;  /* event bits, OR-ed by the ISR */
+  bool enqueued;              /* a token is outstanding; VM context only */
+} irq_source_t;
+
+static irq_source_t sources_[IRQ_MAX_SOURCES];
+static volatile uint32_t ready_mask_;
+
+/* `1 << id` would be undefined at id 31 (signed shift overflow). */
+#define IRQ_BIT(id) (UINT32_C(1) << (id))
+
+static inline bool
+valid_id(int id)
+{
+  return 0 <= id && id < IRQ_MAX_SOURCES;
+}
+
+void
+IRQ_signal_from_isr(int id, uint32_t bits)
+{
+  if (!valid_id(id)) return;
+  /* Publish the bits before the ready flag: a consumer that sees the
+     ready bit must also see everything the handler staged. */
+  IRQ_hal_atomic_or_u32(&sources_[id].pending, bits);
+  IRQ_hal_atomic_or_u32(&ready_mask_, IRQ_BIT(id));
+}
+
+uint32_t
+IRQ_peek_ready(void)
+{
+  return IRQ_hal_atomic_load_u32(&ready_mask_);
+}
+
+void
+IRQ_clear_ready(int id)
+{
+  if (!valid_id(id)) return;
+  /* A signal that lands between the drain's read and this call is
+     dropped from the ready set, but never lost: either a token is
+     outstanding, in which case the bits it stands for are still in
+     `pending` and the consumer will take them, or nothing is bound, in
+     which case IRQ.bind re-asserts. */
+  IRQ_hal_atomic_and_u32(&ready_mask_, ~IRQ_BIT(id));
+}
+
+bool
+IRQ_any_pending(void)
+{
+  return IRQ_hal_atomic_load_u32(&ready_mask_) != 0;
+}
+
+bool
+IRQ_mark_enqueued(int id)
+{
+  if (!valid_id(id) || sources_[id].enqueued) return false;
+  sources_[id].enqueued = true;
+  return true;
+}
+
+bool
+IRQ_is_enqueued(int id)
+{
+  return valid_id(id) && sources_[id].enqueued;
+}
+
+uint32_t
+IRQ_take_bits(int id)
+{
+  uint32_t bits;
+
+  if (!valid_id(id)) return 0;
+  bits = IRQ_hal_atomic_exchange_u32(&sources_[id].pending, 0);
+  /* Releasing the token after claiming the bits is enough: a signal
+     that lands before the exchange is in `bits`, and one that lands
+     after it re-asserts the ready bit itself. Worst case the consumer
+     sees one spurious token, which the contract allows. */
+  sources_[id].enqueued = false;
+  return bits;
+}
+
+void
+IRQ_mark_ready(int id)
+{
+  if (!valid_id(id)) return;
+  IRQ_hal_atomic_or_u32(&ready_mask_, IRQ_BIT(id));
+}
+
+uint32_t
+IRQ_peek_pending(int id)
+{
+  if (!valid_id(id)) return 0;
+  return IRQ_hal_atomic_load_u32(&sources_[id].pending);
+}
+
+void
+IRQ_reset(void)
+{
+  int i;
+
+  /* Interrupts may still be firing, so clear atomically. Events racing
+     a VM boundary are dropped by design. */
+  for (i = 0; i < IRQ_MAX_SOURCES; i++) {
+    IRQ_hal_atomic_exchange_u32(&sources_[i].pending, 0);
+    sources_[i].enqueued = false;
+  }
+  IRQ_hal_atomic_exchange_u32(&ready_mask_, 0);
+}

--- a/mrbgems/picoruby-irq/src/mruby/irq.c
+++ b/mrbgems/picoruby-irq/src/mruby/irq.c
@@ -4,8 +4,16 @@
 #include <mruby/string.h>
 #include <mruby/hash.h>
 #include <mruby/array.h>
+#include <mruby/class.h>
 
 #include "../../include/irq.h"
+
+#if defined(MRB_USE_TASK_SCHEDULER)
+#include "task.h"
+/* Spelled out: picoruby-mruby/include/hal.h shadows this one on the
+   include path. */
+#include "../../../picoruby-machine/include/hal.h"
+#endif
 
 /*
  * IRQ.register_gpio(pin, event_type, opts)
@@ -69,6 +77,248 @@ mrb_s_peek_event(mrb_state *mrb, mrb_value self)
   return result;
 }
 
+#if defined(MRB_USE_TASK_SCHEDULER)
+
+/*
+ * ISR-to-task event bridge (VM side)
+ *
+ * The C core (src/irq_source.c) only latches bits. This is where a
+ * ready source becomes a token in a Task::Queue, which is why it runs
+ * in VM context: pushing allocates.
+ *
+ * Exactly one mrb_state owns the bridge, because the source table is a
+ * process-global that ISRs write to -- a second owner could not tell
+ * whose queue an event belongs to. The owner is claimed at gem init and
+ * released at gem final; other VMs get no bridge methods at all.
+ */
+
+static mrb_state *irq_owner_;
+static mrb_value irq_bindings_;   /* Array(IRQ_MAX_SOURCES) of queue-or-nil */
+
+static void
+irq_check_id(mrb_state *mrb, mrb_int id)
+{
+  if (id < 0 || IRQ_MAX_SOURCES <= id) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "IRQ source id out of range: %i", id);
+  }
+}
+
+static int
+irq_lowest_bit(uint32_t v)
+{
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_ctz(v);
+#else
+  int n = 0;
+  while ((v & UINT32_C(1)) == 0) {
+    v >>= 1;
+    n++;
+  }
+  return n;
+#endif
+}
+
+/*
+ * Scheduler hook: turn every ready source into at most one token.
+ *
+ * Runs in thread context at every scheduler entry, right before the
+ * ready-queue read, so a task woken here runs in the same iteration.
+ * Kept cheap: with no pending event this is one atomic exchange.
+ *
+ * A push can allocate, so it can raise, and the exception escapes into
+ * the scheduler. That is deliberate -- a silently dropped interrupt is
+ * worse than a visible failure -- but it must not cost the event. Hence
+ * a source is cleared from the ready set only after it has been dealt
+ * with, and the token is recorded only after the push actually
+ * happened: an interrupted drain retries that source at the next
+ * scheduler entry instead of leaving it claimed forever.
+ */
+static void
+irq_drain(mrb_state *mrb, void *ud)
+{
+  uint32_t ready;
+
+  (void)ud;
+  ready = IRQ_peek_ready();
+  while (ready) {
+    int id = irq_lowest_bit(ready);
+    ready &= ready - 1;
+
+    mrb_value queue = mrb_ary_entry(irq_bindings_, id);
+    if (mrb_nil_p(queue)) {
+      /* Nobody is listening yet. The bits stay latched; IRQ.bind
+         re-asserts the ready bit, so a late consumer still sees them. */
+      IRQ_clear_ready(id);
+      continue;
+    }
+    if (IRQ_is_enqueued(id)) {
+      /* A token is already outstanding; it covers these bits. */
+      IRQ_clear_ready(id);
+      continue;
+    }
+    switch (mrb_task_queue_push(mrb, queue, mrb_fixnum_value(id))) {
+      case MRB_TASK_QUEUE_PUSH_OK:
+        IRQ_mark_enqueued(id);
+        break;
+      case MRB_TASK_QUEUE_PUSH_CLOSED:
+      case MRB_TASK_QUEUE_PUSH_INVALID:
+        /* The consumer is gone. Drop the binding rather than retry at
+           every scheduler entry for the rest of the process. The bits
+           stay latched for whoever binds next. */
+        mrb_ary_set(mrb, irq_bindings_, id, mrb_nil_value());
+        break;
+    }
+    IRQ_clear_ready(id);
+  }
+}
+
+/*
+ * IRQ.bind(id, queue) -> queue
+ *
+ * Tokens are edge-latched and coalesced: the queue receives the source
+ * id once per "something happened since you last took the bits", not
+ * once per interrupt. Binding a source that already has pending bits
+ * delivers them on the next scheduler entry.
+ */
+static mrb_value
+mrb_s_bind(mrb_state *mrb, mrb_value self)
+{
+  mrb_int id;
+  mrb_value queue, current;
+  struct RClass *queue_class;
+
+  mrb_get_args(mrb, "io", &id, &queue);
+  irq_check_id(mrb, id);
+
+  queue_class = mrb_class_get_under_id(mrb, mrb_class_get_id(mrb, MRB_SYM(Task)), MRB_SYM(Queue));
+  if (!mrb_obj_is_kind_of(mrb, queue, queue_class)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "IRQ.bind expects a Task::Queue");
+  }
+
+  current = mrb_ary_entry(irq_bindings_, id);
+  if (mrb_obj_eq(mrb, current, queue)) {
+    return queue;  /* rebinding the same queue changes nothing */
+  }
+  if (IRQ_is_enqueued(id)) {
+    /* The outstanding token names this source, and the new consumer has
+       no way to know the old queue still holds it. Make the caller take
+       the bits first. */
+    mrb_raise(mrb, E_RUNTIME_ERROR, "IRQ source has an undelivered token");
+  }
+  mrb_ary_set(mrb, irq_bindings_, id, queue);
+  if (IRQ_peek_pending((int)id) != 0) {
+    IRQ_mark_ready((int)id);
+  }
+  return queue;
+}
+
+/*
+ * IRQ.unbind(id) -> true if a binding was removed
+ */
+static mrb_value
+mrb_s_unbind(mrb_state *mrb, mrb_value self)
+{
+  mrb_int id;
+
+  mrb_get_args(mrb, "i", &id);
+  irq_check_id(mrb, id);
+
+  if (mrb_nil_p(mrb_ary_entry(irq_bindings_, id))) {
+    return mrb_false_value();
+  }
+  if (IRQ_is_enqueued(id)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "IRQ source has an undelivered token");
+  }
+  mrb_ary_set(mrb, irq_bindings_, id, mrb_nil_value());
+  return mrb_true_value();
+}
+
+/*
+ * IRQ.take(id) -> event bits (0 is possible: tokens may be spurious)
+ */
+static mrb_value
+mrb_s_take(mrb_state *mrb, mrb_value self)
+{
+  mrb_int id;
+
+  mrb_get_args(mrb, "i", &id);
+  irq_check_id(mrb, id);
+  return mrb_fixnum_value((mrb_int)IRQ_take_bits((int)id));
+}
+
+/*
+ * IRQ.simulate(id, bits) -> nil
+ *
+ * Drives the bridge from VM context exactly as an interrupt handler
+ * would. For tests and for bringing up a consumer on a host build,
+ * where there is no interrupt to fire.
+ */
+static mrb_value
+mrb_s_simulate(mrb_state *mrb, mrb_value self)
+{
+  mrb_int id, bits;
+
+  mrb_get_args(mrb, "ii", &id, &bits);
+  irq_check_id(mrb, id);
+  IRQ_signal_from_isr((int)id, (uint32_t)bits);
+  return mrb_nil_value();
+}
+
+static void
+irq_bridge_init(mrb_state *mrb, struct RClass *module_IRQ)
+{
+  mrb_value bindings;
+  int i;
+
+  if (irq_owner_ != NULL) {
+    /* Nothing has been touched yet, so the first owner keeps working. */
+    mrb_raise(mrb, E_RUNTIME_ERROR, "IRQ event bridge is owned by another VM");
+  }
+
+  bindings = mrb_ary_new_capa(mrb, IRQ_MAX_SOURCES);
+  i = 0;
+  while (i < IRQ_MAX_SOURCES) {
+    mrb_ary_push(mrb, bindings, mrb_nil_value());
+    i++;
+  }
+  /* Rooted once for the lifetime of the gem. Registering per binding
+     would be wrong: mrb_gc_unregister removes ALL occurrences of an
+     object, so two bindings to one queue would unroot it too early. */
+  mrb_gc_register(mrb, bindings);
+
+  mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(bind), mrb_s_bind, MRB_ARGS_REQ(2));
+  mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(unbind), mrb_s_unbind, MRB_ARGS_REQ(1));
+  mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(take), mrb_s_take, MRB_ARGS_REQ(1));
+  mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(simulate), mrb_s_simulate, MRB_ARGS_REQ(2));
+
+  irq_bindings_ = bindings;
+  IRQ_reset();
+  /* Not mrb_task_set_scheduler_hook: the hook slot is shared with the
+     platform's own servicing (cyw43_arch poll on pico_w/pico2_w), and
+     setting it directly would silently disable whichever registered
+     first. See include/hal.h in picoruby-machine. */
+  picorb_scheduler_service_add(mrb, irq_drain, NULL);
+
+  /* Claim ownership only once nothing above can still raise. Otherwise
+     a failed init would leave the bridge owned by a VM that does not
+     exist, and every later mrb_open would be refused. */
+  irq_owner_ = mrb;
+}
+
+static void
+irq_bridge_final(mrb_state *mrb)
+{
+  if (irq_owner_ != mrb) return;
+
+  picorb_scheduler_service_remove(mrb, irq_drain, NULL);
+  IRQ_reset();
+  mrb_gc_unregister(mrb, irq_bindings_);
+  irq_bindings_ = mrb_nil_value();
+  irq_owner_ = NULL;
+}
+
+#endif /* MRB_USE_TASK_SCHEDULER */
+
 void
 mrb_picoruby_irq_gem_init(mrb_state *mrb)
 {
@@ -79,11 +329,17 @@ mrb_picoruby_irq_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(unregister_gpio), mrb_s_unregister_gpio, MRB_ARGS_REQ(1));
   mrb_define_class_method_id(mrb, module_IRQ, MRB_SYM(peek_event), mrb_s_peek_event, MRB_ARGS_NONE());
 
+#if defined(MRB_USE_TASK_SCHEDULER)
+  irq_bridge_init(mrb, module_IRQ);
+#endif
+
   IRQ_init(); // Initialize the IRQ system
 }
 
 void
 mrb_picoruby_irq_gem_final(mrb_state *mrb)
 {
-  /* Cleanup if needed */
+#if defined(MRB_USE_TASK_SCHEDULER)
+  irq_bridge_final(mrb);
+#endif
 }

--- a/mrbgems/picoruby-irq/src/mruby/irq.c
+++ b/mrbgems/picoruby-irq/src/mruby/irq.c
@@ -89,7 +89,8 @@ mrb_s_peek_event(mrb_state *mrb, mrb_value self)
  * Exactly one mrb_state owns the bridge, because the source table is a
  * process-global that ISRs write to -- a second owner could not tell
  * whose queue an event belongs to. The owner is claimed at gem init and
- * released at gem final; other VMs get no bridge methods at all.
+ * released at gem final; a second VM attempting to initialize the bridge
+ * raises.
  */
 
 static mrb_state *irq_owner_;

--- a/mrbgems/picoruby-irq/src/mruby/irq.c
+++ b/mrbgems/picoruby-irq/src/mruby/irq.c
@@ -8,7 +8,7 @@
 
 #include "../../include/irq.h"
 
-#if defined(MRB_USE_TASK_SCHEDULER)
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
 #include "task.h"
 /* Spelled out: picoruby-mruby/include/hal.h shadows this one on the
    include path. */
@@ -77,7 +77,7 @@ mrb_s_peek_event(mrb_state *mrb, mrb_value self)
   return result;
 }
 
-#if defined(MRB_USE_TASK_SCHEDULER)
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
 
 /*
  * ISR-to-task event bridge (VM side)
@@ -123,7 +123,7 @@ irq_lowest_bit(uint32_t v)
  *
  * Runs in thread context at every scheduler entry, right before the
  * ready-queue read, so a task woken here runs in the same iteration.
- * Kept cheap: with no pending event this is one atomic exchange.
+ * Kept cheap: with no pending event this is one atomic load.
  *
  * A push can allocate, so it can raise, and the exception escapes into
  * the scheduler. That is deliberate -- a silently dropped interrupt is
@@ -264,6 +264,19 @@ mrb_s_simulate(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
+/*
+ * IRQ.gpio_source -> the source id shared by every GPIO interrupt
+ *
+ * One source for the whole subsystem, not one per pin: the token only
+ * says "the GPIO event queue is worth looking at", and IRQ.process is
+ * what sorts events out to their handlers.
+ */
+static mrb_value
+mrb_s_gpio_source(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(IRQ_SRC_GPIO);
+}
+
 static void
 irq_bridge_init(mrb_state *mrb, struct RClass *module_IRQ)
 {
@@ -290,6 +303,10 @@ irq_bridge_init(mrb_state *mrb, struct RClass *module_IRQ)
   mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(unbind), mrb_s_unbind, MRB_ARGS_REQ(1));
   mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(take), mrb_s_take, MRB_ARGS_REQ(1));
   mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(simulate), mrb_s_simulate, MRB_ARGS_REQ(2));
+  /* Not MRB_SYM(): "gpio_source" appears in no Ruby source, so it is
+     not in the generated presym table. */
+  mrb_define_module_function(mrb, module_IRQ, "gpio_source", mrb_s_gpio_source, MRB_ARGS_NONE());
+  mrb_define_const(mrb, module_IRQ, "MAX_SOURCES", mrb_fixnum_value(IRQ_MAX_SOURCES));
 
   irq_bindings_ = bindings;
   IRQ_reset();
@@ -317,7 +334,7 @@ irq_bridge_final(mrb_state *mrb)
   irq_owner_ = NULL;
 }
 
-#endif /* MRB_USE_TASK_SCHEDULER */
+#endif /* PICORB_IRQ_EVENT_BRIDGE */
 
 void
 mrb_picoruby_irq_gem_init(mrb_state *mrb)
@@ -329,7 +346,7 @@ mrb_picoruby_irq_gem_init(mrb_state *mrb)
   mrb_define_module_function_id(mrb, module_IRQ, MRB_SYM(unregister_gpio), mrb_s_unregister_gpio, MRB_ARGS_REQ(1));
   mrb_define_class_method_id(mrb, module_IRQ, MRB_SYM(peek_event), mrb_s_peek_event, MRB_ARGS_NONE());
 
-#if defined(MRB_USE_TASK_SCHEDULER)
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
   irq_bridge_init(mrb, module_IRQ);
 #endif
 
@@ -339,7 +356,7 @@ mrb_picoruby_irq_gem_init(mrb_state *mrb)
 void
 mrb_picoruby_irq_gem_final(mrb_state *mrb)
 {
-#if defined(MRB_USE_TASK_SCHEDULER)
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
   irq_bridge_final(mrb);
 #endif
 }

--- a/mrbgems/picoruby-irq/src/mrubyc/irq.c
+++ b/mrbgems/picoruby-irq/src/mrubyc/irq.c
@@ -1,6 +1,11 @@
 #include <mrubyc.h>
 #include "../../include/irq.h"
 
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+#include "c_task_queue.h"
+#include "../../../picoruby-machine/include/hal.h"
+#endif
+
 /*
  * IRQ.register_gpio(pin, event_type, opts)
  */
@@ -87,6 +92,232 @@ c_peek_event(mrbc_vm *vm, mrbc_value *v, int argc)
   SET_RETURN(result);
 }
 
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+
+/*
+ * ISR-to-task event bridge (VM side)
+ *
+ * Mirror of src/mruby/irq.c; see that file and include/irq.h for the
+ * design. The differences are mruby/c's: the bindings are held as
+ * reference-counted values rather than rooted in a GC-visible array,
+ * and the scheduler hook is process-global, so there is no owner VM to
+ * track.
+ */
+
+static mrbc_value irq_bindings_[IRQ_MAX_SOURCES];
+
+static int
+irq_check_id(mrbc_vm *vm, mrbc_value *v, mrbc_int_t id)
+{
+  if (id < 0 || IRQ_MAX_SOURCES <= id) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "IRQ source id out of range");
+    return 0;
+  }
+  return 1;
+}
+
+static int
+irq_lowest_bit(uint32_t v)
+{
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_ctz(v);
+#else
+  int n = 0;
+  while ((v & UINT32_C(1)) == 0) {
+    v >>= 1;
+    n++;
+  }
+  return n;
+#endif
+}
+
+static void
+irq_unbind_source(int id)
+{
+  mrbc_decref(&irq_bindings_[id]);
+  irq_bindings_[id] = mrbc_nil_value();
+}
+
+/*
+ * Scheduler hook: turn every ready source into at most one token.
+ *
+ * A source leaves the ready set only after it has been dealt with, and
+ * the token is recorded only once the push happened, so an allocation
+ * failure inside the push cannot leave a source claimed forever.
+ */
+static void
+irq_drain(void *ud)
+{
+  uint32_t ready;
+
+  (void)ud;
+  ready = IRQ_peek_ready();
+  while (ready) {
+    int id = irq_lowest_bit(ready);
+    ready &= ready - 1;
+
+    if (mrbc_type(irq_bindings_[id]) == MRBC_TT_NIL) {
+      /* Nobody is listening yet. The bits stay latched; IRQ.bind
+         re-asserts the ready bit, so a late consumer still sees them. */
+      IRQ_clear_ready(id);
+      continue;
+    }
+    if (IRQ_is_enqueued(id)) {
+      /* A token is already outstanding; it covers these bits. */
+      IRQ_clear_ready(id);
+      continue;
+    }
+    mrbc_value token = mrbc_integer_value(id);
+    switch (mrbc_task_queue_push(&irq_bindings_[id], &token)) {
+      case MRBC_TASK_QUEUE_PUSH_OK:
+      case MRBC_TASK_QUEUE_PUSH_OK_WOKE:
+        IRQ_mark_enqueued(id);
+        break;
+      case MRBC_TASK_QUEUE_PUSH_CLOSED:
+      case MRBC_TASK_QUEUE_PUSH_INVALID:
+        /* The consumer is gone. Drop the binding rather than retry at
+           every scheduler entry for the rest of the process. The bits
+           stay latched for whoever binds next. */
+        irq_unbind_source(id);
+        break;
+    }
+    IRQ_clear_ready(id);
+  }
+}
+
+/*
+ * IRQ.bind(id, queue) -> queue
+ */
+static void
+c_bind(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 2 || v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "IRQ.bind(source, queue)");
+    return;
+  }
+  mrbc_int_t id = v[1].i;
+  if (!irq_check_id(vm, v, id)) return;
+
+  if (!mrbc_obj_is_kind_of(&v[2], MRBC_CLASS(Task_Queue))) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "IRQ.bind expects a Task::Queue");
+    return;
+  }
+  if (mrbc_type(irq_bindings_[id]) == MRBC_TT_OBJECT &&
+      irq_bindings_[id].instance == v[2].instance) {
+    /* rebinding the same queue changes nothing */
+    mrbc_incref(&v[2]);   /* the reference handed back to the caller */
+    SET_RETURN(v[2]);
+    return;
+  }
+  if (IRQ_is_enqueued(id)) {
+    /* The outstanding token names this source, and the new consumer has
+       no way to know the old queue still holds it. */
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "IRQ source has an undelivered token");
+    return;
+  }
+  mrbc_decref(&irq_bindings_[id]);
+  mrbc_incref(&v[2]);   /* the reference the table keeps */
+  irq_bindings_[id] = v[2];
+  if (IRQ_peek_pending((int)id) != 0) {
+    IRQ_mark_ready((int)id);
+  }
+  mrbc_incref(&v[2]);   /* the reference handed back to the caller */
+  SET_RETURN(v[2]);
+}
+
+/*
+ * IRQ.unbind(id) -> true if a binding was removed
+ */
+static void
+c_unbind(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1 || v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "IRQ.unbind(source)");
+    return;
+  }
+  mrbc_int_t id = v[1].i;
+  if (!irq_check_id(vm, v, id)) return;
+
+  if (mrbc_type(irq_bindings_[id]) == MRBC_TT_NIL) {
+    SET_FALSE_RETURN();
+    return;
+  }
+  if (IRQ_is_enqueued(id)) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "IRQ source has an undelivered token");
+    return;
+  }
+  irq_unbind_source((int)id);
+  SET_TRUE_RETURN();
+}
+
+/*
+ * IRQ.take(id) -> event bits (0 is possible: tokens may be spurious)
+ */
+static void
+c_take(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 1 || v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "IRQ.take(source)");
+    return;
+  }
+  mrbc_int_t id = v[1].i;
+  if (!irq_check_id(vm, v, id)) return;
+
+  SET_INT_RETURN((mrbc_int_t)IRQ_take_bits((int)id));
+}
+
+/*
+ * IRQ.simulate(id, bits) -> nil
+ */
+static void
+c_simulate(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (argc != 2 || v[1].tt != MRBC_TT_INTEGER || v[2].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "IRQ.simulate(source, bits)");
+    return;
+  }
+  mrbc_int_t id = v[1].i;
+  if (!irq_check_id(vm, v, id)) return;
+
+  IRQ_signal_from_isr((int)id, (uint32_t)v[2].i);
+  SET_NIL_RETURN();
+}
+
+/*
+ * IRQ.gpio_source -> the source id shared by every GPIO interrupt
+ */
+static void
+c_gpio_source(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  SET_INT_RETURN(IRQ_SRC_GPIO);
+}
+
+static void
+irq_bridge_init(mrbc_vm *vm, mrbc_class *module_IRQ)
+{
+  int i = 0;
+
+  while (i < IRQ_MAX_SOURCES) {
+    irq_bindings_[i] = mrbc_nil_value();
+    i++;
+  }
+  IRQ_reset();
+
+  mrbc_define_method(vm, module_IRQ, "bind", c_bind);
+  mrbc_define_method(vm, module_IRQ, "unbind", c_unbind);
+  mrbc_define_method(vm, module_IRQ, "take", c_take);
+  mrbc_define_method(vm, module_IRQ, "simulate", c_simulate);
+  mrbc_define_method(vm, module_IRQ, "gpio_source", c_gpio_source);
+  mrbc_set_class_const(module_IRQ, mrbc_str_to_symid("MAX_SOURCES"),
+                       &mrbc_integer_value(IRQ_MAX_SOURCES));
+
+  /* Not mrbc_task_set_scheduler_hook: the hook slot is shared with the
+     platform's own servicing. See include/hal.h in picoruby-machine. */
+  picorb_scheduler_service_add(irq_drain, NULL);
+}
+
+#endif /* PICORB_IRQ_EVENT_BRIDGE */
+
 #define SET_MODULE_CONST(mod, cst) \
   mrbc_set_const(mod, mrbc_str_to_symid(#cst), &mrbc_integer_value(cst))
 
@@ -97,8 +328,12 @@ mrbc_irq_init(mrbc_vm *vm)
 
   /* Define module methods */
   mrbc_define_method(vm, module_IRQ, "register_gpio", c_register_gpio);
-  mrbc_define_method(vm, module_IRQ, "unregister_gpio", c_unregister_gpio);  
+  mrbc_define_method(vm, module_IRQ, "unregister_gpio", c_unregister_gpio);
   mrbc_define_method(vm, module_IRQ, "peek_event", c_peek_event);
+
+#if defined(PICORB_IRQ_EVENT_BRIDGE)
+  irq_bridge_init(vm, module_IRQ);
+#endif
 
   /* Initialize the IRQ system */
   IRQ_init();

--- a/mrbgems/picoruby-irq/test/irq_bridge_test.rb
+++ b/mrbgems/picoruby-irq/test/irq_bridge_test.rb
@@ -1,91 +1,95 @@
 class IRQBridgeTest < Picotest::Test
-  # Source 31 belongs to no driver, so these tests never collide with a
-  # real peripheral. It also exercises the top bit of the ready mask,
-  # where a signed `1 << id` would be undefined behaviour.
-  SRC = 31
+  # The last slot belongs to no driver, so these tests never collide
+  # with a real peripheral. A method rather than a constant: the class
+  # body is evaluated before IRQ is reachable from this scope.
+  def spare_source
+    IRQ::MAX_SOURCES - 1
+  end
 
   def setup
     @q = Task::Queue.new
     # A previous test may have left bits or a token behind; take clears
     # both, which is also what makes the following unbind legal.
-    IRQ.take(SRC)
-    IRQ.unbind(SRC)
-    IRQ.bind(SRC, @q)
+    IRQ.take(spare_source)
+    IRQ.unbind(spare_source)
+    IRQ.bind(spare_source, @q)
   end
 
   def teardown
-    IRQ.take(SRC)
-    IRQ.unbind(SRC)
+    IRQ.take(spare_source)
+    IRQ.unbind(spare_source)
   end
 
   def test_signal_delivers_one_token_carrying_the_ored_bits
     i = 0
     while i < 3
-      IRQ.simulate(SRC, 1 << i)
+      IRQ.simulate(spare_source, 1 << i)
       i += 1
     end
     Task.pass
     assert_equal 1, @q.size
-    assert_equal SRC, @q.pop
-    assert_equal 7, IRQ.take(SRC)
+    assert_equal spare_source, @q.pop
+    assert_equal 7, IRQ.take(spare_source)
   end
 
   def test_no_second_token_while_one_is_outstanding
-    IRQ.simulate(SRC, 1)
+    IRQ.simulate(spare_source, 1)
     Task.pass
-    IRQ.simulate(SRC, 2)
+    IRQ.simulate(spare_source, 2)
     Task.pass
     assert_equal 1, @q.size
   end
 
   def test_a_new_token_follows_a_take
-    IRQ.simulate(SRC, 1)
+    IRQ.simulate(spare_source, 1)
     Task.pass
-    assert_equal SRC, @q.pop
-    assert_equal 1, IRQ.take(SRC)
+    assert_equal spare_source, @q.pop
+    assert_equal 1, IRQ.take(spare_source)
 
-    IRQ.simulate(SRC, 2)
+    IRQ.simulate(spare_source, 2)
     Task.pass
-    assert_equal SRC, @q.pop
-    assert_equal 2, IRQ.take(SRC)
+    assert_equal spare_source, @q.pop
+    assert_equal 2, IRQ.take(spare_source)
   end
 
   def test_take_on_a_spurious_token_returns_zero
-    IRQ.simulate(SRC, 4)
+    IRQ.simulate(spare_source, 4)
     Task.pass
     @q.pop
-    assert_equal 4, IRQ.take(SRC)
-    assert_equal 0, IRQ.take(SRC)
+    assert_equal 4, IRQ.take(spare_source)
+    assert_equal 0, IRQ.take(spare_source)
   end
 
   def test_bits_signalled_before_bind_are_delivered_after_bind
-    IRQ.unbind(SRC)
-    IRQ.simulate(SRC, 2)
+    IRQ.unbind(spare_source)
+    IRQ.simulate(spare_source, 2)
     Task.pass
     assert_equal 0, @q.size
 
-    IRQ.bind(SRC, @q)
+    IRQ.bind(spare_source, @q)
     Task.pass
-    assert_equal SRC, @q.pop
-    assert_equal 2, IRQ.take(SRC)
+    assert_equal spare_source, @q.pop
+    assert_equal 2, IRQ.take(spare_source)
   end
 
   def test_unbind_reports_whether_a_binding_was_removed
-    assert_true IRQ.unbind(SRC)
-    assert_false IRQ.unbind(SRC)
+    assert_true IRQ.unbind(spare_source)
+    assert_false IRQ.unbind(spare_source)
   end
 
   def test_rebinding_the_same_queue_is_a_no_op_even_with_a_token_out
-    IRQ.simulate(SRC, 1)
+    IRQ.simulate(spare_source, 1)
     Task.pass
-    assert_true IRQ.bind(SRC, @q).equal?(@q)
+    # object_id, not equal?: FemtoRuby has no equal?, and its == treats
+    # two objects of the same class as equal.
+    assert_equal @q.object_id, IRQ.bind(spare_source, @q).object_id
   end
 
   def test_rebind_or_unbind_with_an_undelivered_token_raises
-    IRQ.simulate(SRC, 1)
+    IRQ.simulate(spare_source, 1)
     Task.pass
-    assert_raise(RuntimeError) { IRQ.unbind(SRC) }
-    assert_raise(RuntimeError) { IRQ.bind(SRC, Task::Queue.new) }
+    assert_raise(RuntimeError) { IRQ.unbind(spare_source) }
+    assert_raise(RuntimeError) { IRQ.bind(spare_source, Task::Queue.new) }
   end
 
   # A push that cannot be delivered must not leave the source claimed:
@@ -93,34 +97,64 @@ class IRQBridgeTest < Picotest::Test
   # interrupt would be swallowed.
   def test_a_source_survives_a_queue_that_went_away
     @q.close
-    IRQ.simulate(SRC, 1)
+    IRQ.simulate(spare_source, 1)
     Task.pass
-    assert_false IRQ.unbind(SRC)   # the dead binding was dropped
+    assert_false IRQ.unbind(spare_source)   # the dead binding was dropped
 
     q = Task::Queue.new
-    IRQ.bind(SRC, q)
-    IRQ.simulate(SRC, 2)
+    IRQ.bind(spare_source, q)
+    IRQ.simulate(spare_source, 2)
     Task.pass
-    assert_equal SRC, q.pop
-    assert_equal 3, IRQ.take(SRC)
+    assert_equal spare_source, q.pop
+    assert_equal 3, IRQ.take(spare_source)
+  end
+
+  # GPIO shares one source for the whole subsystem, and it must be a
+  # real slot -- binding it is how a task waits for button presses.
+  def test_gpio_source_is_a_bindable_source
+    src = IRQ.gpio_source
+    assert_true 0 <= src
+    assert_true src < IRQ::MAX_SOURCES
+    assert_not_equal spare_source, src
+
+    q = Task::Queue.new
+    IRQ.bind(src, q)
+    IRQ.simulate(src, 1)
+    Task.pass
+    assert_equal src, q.pop
+    assert_equal 1, IRQ.take(src)
+    IRQ.unbind(src)
   end
 
   def test_bind_rejects_anything_that_is_not_a_task_queue
-    assert_raise(TypeError) { IRQ.bind(SRC, []) }
+    assert_raise(TypeError) { IRQ.bind(spare_source, []) }
   end
 
   def test_out_of_range_source_ids_raise
-    assert_raise(ArgumentError) { IRQ.bind(32, @q) }
+    over = IRQ::MAX_SOURCES
+    assert_raise(ArgumentError) { IRQ.bind(over, @q) }
     assert_raise(ArgumentError) { IRQ.bind(-1, @q) }
-    assert_raise(ArgumentError) { IRQ.unbind(32) }
-    assert_raise(ArgumentError) { IRQ.take(32) }
+    assert_raise(ArgumentError) { IRQ.unbind(over) }
+    assert_raise(ArgumentError) { IRQ.take(over) }
     assert_raise(ArgumentError) { IRQ.take(-1) }
-    assert_raise(ArgumentError) { IRQ.simulate(32, 1) }
+    assert_raise(ArgumentError) { IRQ.simulate(over, 1) }
   end
 
-  # The hypothesis the whole bridge exists for: an event raised outside
-  # the task can wake a task parked in Task::Queue#pop.
+  # The hypothesis the whole bridge exists for, in the form both
+  # runtimes can express: the signal happens before anything drains it,
+  # pop parks this task, and the drain that runs on the scheduler's way
+  # to idle is what wakes it again.
+  def test_a_parked_pop_is_woken_by_the_drain
+    IRQ.simulate(spare_source, 8)
+    assert_equal spare_source, @q.pop
+    assert_equal 8, IRQ.take(spare_source)
+  end
+
+  # The same thing with a second task doing the waiting, which is how a
+  # driver would really use it. PicoRuby only: FemtoRuby cannot spawn a
+  # task from a block (Task.create takes compiled bytecode).
   def test_a_task_blocked_in_pop_wakes_on_signal
+    skip "FemtoRuby cannot spawn a task from a block" if femtoruby?
     q = @q
     seen = nil
     Task.new do
@@ -138,13 +172,13 @@ class IRQBridgeTest < Picotest::Test
     assert_equal 1, q.num_waiting
     assert_nil seen
 
-    IRQ.simulate(SRC, 8)
+    IRQ.simulate(spare_source, 8)
     i = 0
     while i < 10
       break unless seen.nil?
       sleep_ms 1
       i += 1
     end
-    assert_equal [SRC, 8], seen
+    assert_equal [spare_source, 8], seen
   end
 end

--- a/mrbgems/picoruby-irq/test/irq_bridge_test.rb
+++ b/mrbgems/picoruby-irq/test/irq_bridge_test.rb
@@ -1,0 +1,150 @@
+class IRQBridgeTest < Picotest::Test
+  # Source 31 belongs to no driver, so these tests never collide with a
+  # real peripheral. It also exercises the top bit of the ready mask,
+  # where a signed `1 << id` would be undefined behaviour.
+  SRC = 31
+
+  def setup
+    @q = Task::Queue.new
+    # A previous test may have left bits or a token behind; take clears
+    # both, which is also what makes the following unbind legal.
+    IRQ.take(SRC)
+    IRQ.unbind(SRC)
+    IRQ.bind(SRC, @q)
+  end
+
+  def teardown
+    IRQ.take(SRC)
+    IRQ.unbind(SRC)
+  end
+
+  def test_signal_delivers_one_token_carrying_the_ored_bits
+    i = 0
+    while i < 3
+      IRQ.simulate(SRC, 1 << i)
+      i += 1
+    end
+    Task.pass
+    assert_equal 1, @q.size
+    assert_equal SRC, @q.pop
+    assert_equal 7, IRQ.take(SRC)
+  end
+
+  def test_no_second_token_while_one_is_outstanding
+    IRQ.simulate(SRC, 1)
+    Task.pass
+    IRQ.simulate(SRC, 2)
+    Task.pass
+    assert_equal 1, @q.size
+  end
+
+  def test_a_new_token_follows_a_take
+    IRQ.simulate(SRC, 1)
+    Task.pass
+    assert_equal SRC, @q.pop
+    assert_equal 1, IRQ.take(SRC)
+
+    IRQ.simulate(SRC, 2)
+    Task.pass
+    assert_equal SRC, @q.pop
+    assert_equal 2, IRQ.take(SRC)
+  end
+
+  def test_take_on_a_spurious_token_returns_zero
+    IRQ.simulate(SRC, 4)
+    Task.pass
+    @q.pop
+    assert_equal 4, IRQ.take(SRC)
+    assert_equal 0, IRQ.take(SRC)
+  end
+
+  def test_bits_signalled_before_bind_are_delivered_after_bind
+    IRQ.unbind(SRC)
+    IRQ.simulate(SRC, 2)
+    Task.pass
+    assert_equal 0, @q.size
+
+    IRQ.bind(SRC, @q)
+    Task.pass
+    assert_equal SRC, @q.pop
+    assert_equal 2, IRQ.take(SRC)
+  end
+
+  def test_unbind_reports_whether_a_binding_was_removed
+    assert_true IRQ.unbind(SRC)
+    assert_false IRQ.unbind(SRC)
+  end
+
+  def test_rebinding_the_same_queue_is_a_no_op_even_with_a_token_out
+    IRQ.simulate(SRC, 1)
+    Task.pass
+    assert_true IRQ.bind(SRC, @q).equal?(@q)
+  end
+
+  def test_rebind_or_unbind_with_an_undelivered_token_raises
+    IRQ.simulate(SRC, 1)
+    Task.pass
+    assert_raise(RuntimeError) { IRQ.unbind(SRC) }
+    assert_raise(RuntimeError) { IRQ.bind(SRC, Task::Queue.new) }
+  end
+
+  # A push that cannot be delivered must not leave the source claimed:
+  # no token exists, so nothing will ever release it and every later
+  # interrupt would be swallowed.
+  def test_a_source_survives_a_queue_that_went_away
+    @q.close
+    IRQ.simulate(SRC, 1)
+    Task.pass
+    assert_false IRQ.unbind(SRC)   # the dead binding was dropped
+
+    q = Task::Queue.new
+    IRQ.bind(SRC, q)
+    IRQ.simulate(SRC, 2)
+    Task.pass
+    assert_equal SRC, q.pop
+    assert_equal 3, IRQ.take(SRC)
+  end
+
+  def test_bind_rejects_anything_that_is_not_a_task_queue
+    assert_raise(TypeError) { IRQ.bind(SRC, []) }
+  end
+
+  def test_out_of_range_source_ids_raise
+    assert_raise(ArgumentError) { IRQ.bind(32, @q) }
+    assert_raise(ArgumentError) { IRQ.bind(-1, @q) }
+    assert_raise(ArgumentError) { IRQ.unbind(32) }
+    assert_raise(ArgumentError) { IRQ.take(32) }
+    assert_raise(ArgumentError) { IRQ.take(-1) }
+    assert_raise(ArgumentError) { IRQ.simulate(32, 1) }
+  end
+
+  # The hypothesis the whole bridge exists for: an event raised outside
+  # the task can wake a task parked in Task::Queue#pop.
+  def test_a_task_blocked_in_pop_wakes_on_signal
+    q = @q
+    seen = nil
+    Task.new do
+      id = q.pop
+      seen = [id, IRQ.take(id)]
+    end
+
+    # Let the task reach pop and block there.
+    i = 0
+    while i < 10
+      break if 0 < q.num_waiting
+      sleep_ms 1
+      i += 1
+    end
+    assert_equal 1, q.num_waiting
+    assert_nil seen
+
+    IRQ.simulate(SRC, 8)
+    i = 0
+    while i < 10
+      break unless seen.nil?
+      sleep_ms 1
+      i += 1
+    end
+    assert_equal [SRC, 8], seen
+  end
+end

--- a/mrbgems/picoruby-machine/include/hal.h
+++ b/mrbgems/picoruby-machine/include/hal.h
@@ -68,6 +68,16 @@ void picorb_scheduler_service_remove(mrb_state *mrb, void (*fn)(mrb_state *mrb, 
 void picorb_tick();
 void picorb_hal_init(void);
 void picorb_hal_idle_cpu(void);
+
+#if defined(MRBC_TASK_SCHEDULER_HOOK)
+/* Same contract as the mruby side above. mruby/c's hook is process-
+ * global rather than per-VM, so there is no owner to track and the
+ * callback takes no VM argument. */
+#define PICORB_SCHEDULER_SERVICE_MAX 4
+void picorb_scheduler_service_add(void (*fn)(void *ud), void *ud);
+void picorb_scheduler_service_remove(void (*fn)(void *ud), void *ud);
+#endif
+
 #ifndef picorb_SCHEDULER_EXIT
 #define picorb_SCHEDULER_EXIT 1
 #endif

--- a/mrbgems/picoruby-machine/include/hal.h
+++ b/mrbgems/picoruby-machine/include/hal.h
@@ -37,6 +37,33 @@ extern "C" {
 void picorb_tick(mrb_state *mrb);
 void picorb_hal_init(mrb_state *mrb);
 void picorb_hal_idle_cpu(mrb_state *mrb);
+
+#if defined(MRB_USE_TASK_SCHEDULER)
+/*
+ * Scheduler services
+ *
+ * mruby's scheduler hook is a single slot per mrb_state and setting it
+ * replaces whatever was there -- upstream leaves composition to the
+ * embedder on purpose. PicoRuby has more than one thing to service at a
+ * scheduler entry (the cyw43_arch poll pump, the IRQ event bridge), so
+ * the slot belongs to the dispatcher below and gems register here
+ * instead of calling mrb_task_set_scheduler_hook themselves.
+ *
+ * Same rules as the hook itself: runs in thread context before the
+ * ready-queue read, must be cheap, must never sleep or re-enter the
+ * scheduler. Registration order carries no meaning -- services must be
+ * independent. Registering the same fn/ud twice is a no-op.
+ *
+ * The table belongs to one mrb_state at a time, matching the slot it
+ * feeds. Registering from a different VM discards the previous VM's
+ * entries, so a service that outlives an mrb_close (one registered from
+ * a HAL init, say) is re-registered rather than duplicated.
+ */
+#define PICORB_SCHEDULER_SERVICE_MAX 4
+void picorb_scheduler_service_add(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud);
+void picorb_scheduler_service_remove(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud);
+#endif
+
 #elif defined(PICORB_VM_MRUBYC)
 void picorb_tick();
 void picorb_hal_init(void);

--- a/mrbgems/picoruby-machine/ports/rp2040/machine.c
+++ b/mrbgems/picoruby-machine/ports/rp2040/machine.c
@@ -308,7 +308,7 @@ picorb_hal_init(void)
 #if defined(PICORB_VM_MRUBY)
   mrb_ = (mrb_state *)mrb;
 #if defined(PICO_CYW43_ARCH_POLL)
-  mrb_task_set_scheduler_hook(mrb, rp2_scheduler_service, NULL);
+  picorb_scheduler_service_add(mrb, rp2_scheduler_service, NULL);
 #endif
 #endif
   RingBuffer_init(stdin_rb, PICORB_STDIN_BUFFER_SIZE);

--- a/mrbgems/picoruby-machine/src/scheduler_service.c
+++ b/mrbgems/picoruby-machine/src/scheduler_service.c
@@ -1,5 +1,5 @@
 /*
- * Multiplexer for mruby's single scheduler-hook slot.
+ * Multiplexer for the single scheduler-hook slot each VM provides.
  *
  * See the contract in include/hal.h. The table is plain static state
  * written only at gem init/final time and read only from the VM thread,
@@ -85,4 +85,70 @@ picorb_scheduler_service_remove(mrb_state *mrb, void (*fn)(mrb_state *mrb, void 
   }
 }
 
-#endif /* PICORB_VM_MRUBY && MRB_USE_TASK_SCHEDULER */
+#elif defined(PICORB_VM_MRUBYC) && defined(MRBC_TASK_SCHEDULER_HOOK)
+
+#include <mrubyc.h>
+
+typedef struct {
+  void (*fn)(void *ud);
+  void *ud;
+} scheduler_service_t;
+
+static scheduler_service_t services_[PICORB_SCHEDULER_SERVICE_MAX];
+static int service_count_;
+
+static void
+scheduler_dispatch(void *ud)
+{
+  int i = 0;
+
+  (void)ud;
+  while (i < service_count_) {
+    services_[i].fn(services_[i].ud);
+    i++;
+  }
+}
+
+void
+picorb_scheduler_service_add(void (*fn)(void *ud), void *ud)
+{
+  int i = 0;
+
+  if (fn == NULL) return;
+  while (i < service_count_) {
+    if (services_[i].fn == fn && services_[i].ud == ud) return;
+    i++;
+  }
+  if (PICORB_SCHEDULER_SERVICE_MAX <= service_count_) {
+    /* No VM context to raise into here, and a dropped service would be
+       a silent hang later. */
+    mrbc_printf("[FATAL] too many scheduler services\n");
+    return;
+  }
+  services_[service_count_].fn = fn;
+  services_[service_count_].ud = ud;
+  service_count_++;
+  mrbc_task_set_scheduler_hook(scheduler_dispatch, NULL);
+}
+
+void
+picorb_scheduler_service_remove(void (*fn)(void *ud), void *ud)
+{
+  int i = 0;
+
+  while (i < service_count_) {
+    if (services_[i].fn == fn && services_[i].ud == ud) {
+      /* Services are independent, so filling the hole with the last
+         entry is fine and keeps removal O(1). */
+      service_count_--;
+      services_[i] = services_[service_count_];
+      break;
+    }
+    i++;
+  }
+  if (service_count_ == 0) {
+    mrbc_task_set_scheduler_hook(NULL, NULL);
+  }
+}
+
+#endif /* scheduler hook available */

--- a/mrbgems/picoruby-machine/src/scheduler_service.c
+++ b/mrbgems/picoruby-machine/src/scheduler_service.c
@@ -1,0 +1,88 @@
+/*
+ * Multiplexer for mruby's single scheduler-hook slot.
+ *
+ * See the contract in include/hal.h. The table is plain static state
+ * written only at gem init/final time and read only from the VM thread,
+ * so it needs no locking.
+ */
+
+#include "../include/hal.h"
+
+#if defined(PICORB_VM_MRUBY) && defined(MRB_USE_TASK_SCHEDULER)
+
+#include <mruby.h>
+#include "task.h"
+
+typedef struct {
+  void (*fn)(mrb_state *mrb, void *ud);
+  void *ud;
+} scheduler_service_t;
+
+static scheduler_service_t services_[PICORB_SCHEDULER_SERVICE_MAX];
+static int service_count_;
+/* The table is process-global but the hook slot it feeds belongs to one
+   mrb_state, so the table has to belong to that same VM. PicoRuby runs
+   one VM at a time; when a different one shows up the previous one is
+   gone, and whatever it registered goes with it. */
+static mrb_state *owner_;
+
+static void
+scheduler_dispatch(mrb_state *mrb, void *ud)
+{
+  int i = 0;
+
+  (void)ud;
+  while (i < service_count_) {
+    services_[i].fn(mrb, services_[i].ud);
+    i++;
+  }
+}
+
+void
+picorb_scheduler_service_add(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud)
+{
+  int i = 0;
+
+  if (fn == NULL) return;
+  if (owner_ != mrb) {
+    /* A new VM: drop entries left over from the previous one rather
+       than call into whatever they closed over. */
+    service_count_ = 0;
+    owner_ = mrb;
+  }
+  while (i < service_count_) {
+    if (services_[i].fn == fn && services_[i].ud == ud) return;
+    i++;
+  }
+  if (PICORB_SCHEDULER_SERVICE_MAX <= service_count_) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "too many scheduler services");
+  }
+  services_[service_count_].fn = fn;
+  services_[service_count_].ud = ud;
+  service_count_++;
+  mrb_task_set_scheduler_hook(mrb, scheduler_dispatch, NULL);
+}
+
+void
+picorb_scheduler_service_remove(mrb_state *mrb, void (*fn)(mrb_state *mrb, void *ud), void *ud)
+{
+  int i = 0;
+
+  if (owner_ != mrb) return;
+  while (i < service_count_) {
+    if (services_[i].fn == fn && services_[i].ud == ud) {
+      /* Services are independent, so filling the hole with the last
+         entry is fine and keeps removal O(1). */
+      service_count_--;
+      services_[i] = services_[service_count_];
+      break;
+    }
+    i++;
+  }
+  if (service_count_ == 0) {
+    mrb_task_set_scheduler_hook(mrb, NULL, NULL);
+    owner_ = NULL;
+  }
+}
+
+#endif /* PICORB_VM_MRUBY && MRB_USE_TASK_SCHEDULER */

--- a/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
+++ b/mrbgems/picoruby-r2p2/cmake/CMakeLists.txt
@@ -250,6 +250,10 @@ if(PICORB_VM_MRUBY)
 elseif(PICORB_VM_MRUBYC)
   add_compile_definitions(PICORB_VM_MRUBYC=1)
   add_compile_definitions(MRBC_ALLOC_LIBC=1)
+  # Must match the build_config: ports compiled here share headers with
+  # the gem sources compiled by rake, and the IRQ event bridge is
+  # conditioned on this.
+  add_compile_definitions(MRBC_TASK_SCHEDULER_HOOK=1)
   target_include_directories(${PROJECT_NAME} PRIVATE
     ${PICORUBY_ROOT}/mrbgems/picoruby-mrubyc/lib/mrubyc/src
   )


### PR DESCRIPTION
This pull request introduces an ISR-to-task event bridge to the `picoruby-irq` gem, enabling interrupt handlers to wake tasks via `Task::Queue` without polling. The bridge is conditionally compiled in builds with a task scheduler and includes atomic primitives for safe cross-context signaling. Documentation and examples are updated to demonstrate the new event bridge, and support is added across all platforms (ESP32, RP2040, POSIX). The most important changes are grouped below.

**Event Bridge Feature:**

* Added the ISR-to-task event bridge, allowing interrupts to stage events for tasks blocked on `Task::Queue`, with new API methods (`IRQ.bind`, `IRQ.unbind`, `IRQ.take`, `IRQ.simulate`, and `IRQ.gpio_source`). This is only compiled in when the task scheduler is present. (`mrbgems/picoruby-irq/include/irq.h` [[1]](diffhunk://#diff-a5e4cc8dc336bcab79528527d7296c9f77f331383feec8d5f6efa67180bdd444R17-R81) `mrbgems/picoruby-irq/sig/irq.rbs` [[2]](diffhunk://#diff-8793237c0389d636b9255f8512c05e19c818e171d0b2afad72988a1ccd132cffR6-R11) [[3]](diffhunk://#diff-8793237c0389d636b9255f8512c05e19c818e171d0b2afad72988a1ccd132cffR22-R29)
* Updated build configs to define `MRBC_TASK_SCHEDULER_HOOK` where appropriate, ensuring the event bridge is enabled for compatible builds. (`build_config/femtoruby-test.rb` [[1]](diffhunk://#diff-5d2b13018aa9faeaf71a1b6a6759836867e03f913a18538243517287cfff85d7R8) `build_config/femtoruby.rb` [[2]](diffhunk://#diff-a7004d399e7e32423bdbf0f81a916b822aef39b0e0d3c19188e2a41883eff4ddR8) `build_config/r2p2-femtoruby-pico.rb` [[3]](diffhunk://#diff-0d7a1b503e696783a41845def023a29e92108b552c87f42e79fabcf524cb5ca3R35) `build_config/r2p2-femtoruby-pico2.rb` [[4]](diffhunk://#diff-09cd8112c90c7ff01bf6b59b17c2b8f1c765447c43f661529d600403536880eaR44) `build_config/r2p2-femtoruby-pico_w.rb` [[5]](diffhunk://#diff-6d9af4f692e3129d8153b7fab89dc1c021e8c2bccc295a5de9cfbac58ed64f04R35) `build_config/r2p2-femtoruby-pico2_w.rb` [[6]](diffhunk://#diff-1884bcd48cbd5e789665ffa03693459298bd6b6473275c1cfbe4f8baa9340547R44)
* Updated gem dependencies and configuration to require the scheduler and queue where needed, and to include the event bridge only when supported. (`mrbgems/picoruby-irq/mrbgem.rake` [mrbgems/picoruby-irq/mrbgem.rakeR7-R17](diffhunk://#diff-dc78fb25b7181afb4d9398da1268eebb1a9fc157b88d8c6dce296ceae1da96e0R7-R17))

**Platform Support:**

* Implemented atomic primitives for the event bridge on all platforms: ESP32 (using GCC builtins), RP2040 (using interrupt masking), and POSIX (for host testing). (`mrbgems/picoruby-irq/ports/esp32/irq.c` [[1]](diffhunk://#diff-0925280b7b6b0e0615047907315f8b846fa8041d9d3a0d02b55227558ad4289dR246-R279) `mrbgems/picoruby-irq/ports/rp2040/irq.c` [[2]](diffhunk://#diff-50c73cdb83b6212e5e50c04378727ee76eff45ba64252af9f490e1d42d1b69d9R188-R244) `mrbgems/picoruby-irq/ports/posix/irq.c` [[3]](diffhunk://#diff-c15c4b8893a02e954e29a5cd345a6a9d32388c7c350e93c070e830b24feb7a7eR1-R67)
* Modified GPIO interrupt handlers to signal the event bridge after queueing new events, ensuring tasks are woken only when there is work to do. (`mrbgems/picoruby-irq/ports/esp32/irq.c` [[1]](diffhunk://#diff-0925280b7b6b0e0615047907315f8b846fa8041d9d3a0d02b55227558ad4289dL106-R113) `mrbgems/picoruby-irq/ports/rp2040/irq.c` [[2]](diffhunk://#diff-50c73cdb83b6212e5e50c04378727ee76eff45ba64252af9f490e1d42d1b69d9R61-R66)

**Documentation and Examples:**

* Added comprehensive documentation for the event bridge, including its contract and usage patterns, in the README. (`mrbgems/picoruby-irq/README.md` [mrbgems/picoruby-irq/README.mdR94-R149](diffhunk://#diff-29ed617c4f8c245402bf53effe5797c85b92e566972ae9fe1b823a20d3097788R94-R149))
* Updated the main example to use the event bridge, demonstrating how to bind a queue to GPIO events and process them efficiently without polling. (`mrbgems/picoruby-irq/example/irq_gpio.rb` [mrbgems/picoruby-irq/example/irq_gpio.rbL3-R69](diffhunk://#diff-9cb5d51f31add2ad80885ff2208d442620b6d35d2614bebf79db2d2c270ba8ebL3-R69))

**Other Improvements:**

* Improved the implementation of `IRQ.process` to avoid dropping events when a limit is reached. (`mrbgems/picoruby-irq/mrblib/irq.rb` [mrbgems/picoruby-irq/mrblib/irq.rbR32-R40](diffhunk://#diff-f02f015cdc12faf78fa95f6d8e9321c23784683c2a6c0ecdda5772124d5c1f4bR32-R40))

These changes collectively make interrupt-driven event processing more robust, efficient, and easier to use in task-based PicoRuby applications.