### PR TITLE
Add picoruby-string-bitops gem for FemtoRuby

### DIFF
--- a/mrbgems/picoruby-string-bitops/README.md
+++ b/mrbgems/picoruby-string-bitops/README.md
@@ -1,0 +1,88 @@
+# picoruby-string-bitops
+
+Bit operations for `String` on FemtoRuby (mruby/c).
+
+This is the FemtoRuby port of CRuby [Feature #22118] "Introduce Basic
+Bit Operations into String".  On the mruby VM (PicoRuby/MicroRuby),
+the same API is provided by the `mruby-string-bitops` mgem bundled in
+`picoruby-mruby`; this gem intentionally supports only mruby/c and
+fails to compile for `PICORB_VM_MRUBY`.
+
+Strings are treated as byte buffers; all operations are independent of
+string encoding.
+
+## Methods
+
+### Single-bit operations
+
+- `String#bit_get(offset, lsb_first: true)` - returns `0` or `1`, or
+  `nil` when `offset` is beyond the end of the string
+- `String#bit_set?(offset, lsb_first: true)` - returns `true` or
+  `false`, or `nil` when `offset` is beyond the end of the string
+- `String#bit_set(offset, lsb_first: true)` - sets the bit to 1;
+  returns `self`
+- `String#bit_clear(offset, lsb_first: true)` - sets the bit to 0;
+  returns `self`
+- `String#bit_flip(offset, lsb_first: true)` - inverts the bit;
+  returns `self`
+
+`offset` is a zero-based bit offset.  By default, bits within each
+byte are numbered from least-significant to most-significant.  With
+`lsb_first: false`, byte order is unchanged but bits within each byte
+are numbered from most-significant to least-significant.
+
+`IndexError` is raised when `offset` is negative, or (for the mutating
+methods) when it is beyond the end of the string.
+
+### Whole-string operations
+
+- `String#bit_count` - number of set bits (population count)
+- `String#bitwise_not` / `String#bitwise_not!` - bitwise complement
+- `String#bitwise_and(other)` / `String#bitwise_and!(other)`
+- `String#bitwise_or(other)` / `String#bitwise_or!(other)`
+- `String#bitwise_xor(other)` / `String#bitwise_xor!(other)`
+
+The binary operations require both strings to have the same byte
+length, otherwise `ArgumentError` is raised.  The non-bang variants
+return a new string; the bang variants mutate `self` in place.
+
+## Example
+
+```ruby
+require "string-bitops"
+
+s = "\x00\x00"
+s.bit_set(3)          # => "\x08\x00"
+s.bit_set?(3)         # => true
+s.bit_count           # => 1
+
+"\xF0".bitwise_and("\xCC")  # => "\xC0"
+"\x0F".bitwise_or("\xF0")   # => "\xFF"
+"\xFF".bitwise_not          # => "\x00"
+```
+
+## Implementation notes
+
+The bulk kernels (`bit_count` and the `bitwise_*` family) process one
+machine word per iteration with 4x unrolling.  The word width follows
+the pointer width of the target, so 32-bit targets use 32-bit words
+and avoid emulated 64-bit arithmetic.  On GNU-compatible compilers,
+word-aligned buffers are accessed directly through a `may_alias` word
+pointer, which yields true word loads even on cores without unaligned
+access support (e.g. Cortex-M0+); unaligned buffers fall back to a
+`memcpy`-based word loop.
+
+## Differences from CRuby
+
+- Offsets must be `Integer` (up to `mrbc_int_t`); `to_int` conversion
+  and Bignum offsets are not supported (`TypeError`).
+- Binary operands must be real `String`s; `to_str` conversion is not
+  performed (`TypeError`).
+- mruby/c has no `freeze` or `Encoding`, so the corresponding CRuby
+  behaviors (`FrozenError`, BINARY result encoding) do not apply.
+- `bit_count` raises `RangeError` when the count does not fit in
+  `mrbc_int_t`; this is only reachable under `MRBC_INT16`.
+
+## License
+
+MIT

--- a/mrbgems/picoruby-string-bitops/mrbgem.rake
+++ b/mrbgems/picoruby-string-bitops/mrbgem.rake
@@ -1,0 +1,7 @@
+MRuby::Gem::Specification.new('picoruby-string-bitops') do |spec|
+  spec.license = 'MIT'
+  spec.author  = 'HASUMI Hitoshi'
+  spec.summary = 'Bit operations for String on FemtoRuby'
+
+  spec.add_conflict 'picoruby-mruby'
+end

--- a/mrbgems/picoruby-string-bitops/sig/string-bitops.rbs
+++ b/mrbgems/picoruby-string-bitops/sig/string-bitops.rbs
@@ -1,0 +1,16 @@
+class String
+  def bit_get: (Integer offset, ?lsb_first: bool) -> Integer?
+  def bit_set?: (Integer offset, ?lsb_first: bool) -> bool?
+  def bit_set: (Integer offset, ?lsb_first: bool) -> String
+  def bit_clear: (Integer offset, ?lsb_first: bool) -> String
+  def bit_flip: (Integer offset, ?lsb_first: bool) -> String
+  def bit_count: () -> Integer
+  def bitwise_not: () -> String
+  def bitwise_not!: () -> String
+  def bitwise_and: (String other) -> String
+  def bitwise_and!: (String other) -> String
+  def bitwise_or: (String other) -> String
+  def bitwise_or!: (String other) -> String
+  def bitwise_xor: (String other) -> String
+  def bitwise_xor!: (String other) -> String
+end

--- a/mrbgems/picoruby-string-bitops/src/mrubyc/string-bitops.c
+++ b/mrbgems/picoruby-string-bitops/src/mrubyc/string-bitops.c
@@ -1,0 +1,347 @@
+#include <mrubyc.h>
+
+/*
+ * mruby/c passes only positional arguments in argc; a keyword-argument
+ * Hash, when given, sits at v[argc + 1] (followed by the block slot,
+ * which is nil or a Proc, never a Hash).
+ */
+static mrbc_value *
+bitop_kwargs(mrbc_value v[], int argc)
+{
+  if (v[argc + 1].tt == MRBC_TT_HASH) {
+    return &v[argc + 1];
+  }
+  return NULL;
+}
+
+/*
+ * Scans the offset argument and the optional lsb_first keyword.
+ * Returns 1 on success, 0 after raising.
+ */
+static int
+bitop_scan_offset(mrbc_vm *vm, mrbc_value v[], int argc, mrbc_int_t *offset, int *lsb_first)
+{
+  mrbc_value *kwargs = bitop_kwargs(v, argc);
+
+  *lsb_first = 1;
+  if (kwargs) {
+    int pairs = kwargs->hash->n_stored / 2;
+    /* mrbc_hash_search_by_id returns a pointer to the key; the value
+       occupies the next slot. */
+    mrbc_value *key = mrbc_hash_search_by_id(kwargs, mrbc_str_to_symid("lsb_first"));
+    mrbc_value *val = key ? key + 1 : NULL;
+    if (val == NULL) {
+      if (pairs > 0) {
+        mrbc_raise(vm, MRBC_CLASS(ArgumentError), "unknown keyword");
+        return 0;
+      }
+    }
+    else if (pairs > 1) {
+      mrbc_raise(vm, MRBC_CLASS(ArgumentError), "unknown keyword");
+      return 0;
+    }
+    else if (val->tt == MRBC_TT_TRUE) {
+      /* default */
+    }
+    else if (val->tt == MRBC_TT_FALSE) {
+      *lsb_first = 0;
+    }
+    else {
+      mrbc_raise(vm, MRBC_CLASS(ArgumentError), "lsb_first must be true or false");
+      return 0;
+    }
+  }
+  if (argc != 1) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return 0;
+  }
+  if (v[1].tt != MRBC_TT_INTEGER) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "offset must be an Integer");
+    return 0;
+  }
+  *offset = v[1].i;
+  return 1;
+}
+
+static mrbc_int_t
+bitop_physical_index(mrbc_int_t logical, int lsb_first)
+{
+  if (lsb_first) return logical;
+  return (logical & ~(mrbc_int_t)7) | (7 - (logical & 7));
+}
+
+/* Returns 0 or 1, -1 when offset is beyond the end, -2 after raising. */
+static int
+bitop_get_bit(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  mrbc_int_t offset, physical;
+  int lsb_first;
+
+  if (!bitop_scan_offset(vm, v, argc, &offset, &lsb_first)) {
+    return -2;
+  }
+  if (offset < 0) {
+    mrbc_raise(vm, MRBC_CLASS(IndexError), "bit index out of range");
+    return -2;
+  }
+  /* Compare byte indexes to avoid overflowing size * 8.  The int64_t
+     width holds both operands even when mrbc_int_t is narrower than
+     MRBC_STRING_SIZE_T (e.g. MRBC_INT16). */
+  if ((int64_t)(offset / 8) >= (int64_t)v[0].string->size) {
+    return -1;
+  }
+  physical = bitop_physical_index(offset, lsb_first);
+  return (v[0].string->data[physical / 8] >> (physical % 8)) & 1;
+}
+
+static void
+c_string_bit_get(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  int bit = bitop_get_bit(vm, v, argc);
+  if (bit == -2) return;
+  if (bit < 0) {
+    SET_NIL_RETURN();
+  }
+  else {
+    SET_INT_RETURN(bit);
+  }
+}
+
+static void
+c_string_bit_set_p(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  int bit = bitop_get_bit(vm, v, argc);
+  if (bit == -2) return;
+  if (bit < 0) {
+    SET_NIL_RETURN();
+  }
+  else {
+    SET_BOOL_RETURN(bit);
+  }
+}
+
+enum bitop_mutation {
+  BITOP_MUT_SET,
+  BITOP_MUT_CLEAR,
+  BITOP_MUT_FLIP
+};
+
+/* Mutates self in place and leaves v[0] untouched, so self is returned. */
+static void
+bitop_mutate(mrbc_vm *vm, mrbc_value v[], int argc, enum bitop_mutation mutation)
+{
+  mrbc_int_t offset, physical;
+  int lsb_first;
+  uint8_t *ptr;
+  uint8_t mask;
+
+  if (!bitop_scan_offset(vm, v, argc, &offset, &lsb_first)) {
+    return;
+  }
+  if (offset < 0 || (int64_t)(offset / 8) >= (int64_t)v[0].string->size) {
+    mrbc_raise(vm, MRBC_CLASS(IndexError), "bit index out of range");
+    return;
+  }
+  physical = bitop_physical_index(offset, lsb_first);
+  ptr = v[0].string->data;
+  mask = (uint8_t)(1u << (physical % 8));
+  switch (mutation) {
+  case BITOP_MUT_SET:
+    ptr[physical / 8] |= mask;
+    break;
+  case BITOP_MUT_CLEAR:
+    ptr[physical / 8] &= (uint8_t)~mask;
+    break;
+  case BITOP_MUT_FLIP:
+    ptr[physical / 8] ^= mask;
+    break;
+  }
+}
+
+static void
+c_string_bit_set(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_mutate(vm, v, argc, BITOP_MUT_SET);
+}
+
+static void
+c_string_bit_clear(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_mutate(vm, v, argc, BITOP_MUT_CLEAR);
+}
+
+static void
+c_string_bit_flip(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_mutate(vm, v, argc, BITOP_MUT_FLIP);
+}
+
+/* Validates that no positional nor keyword argument was given. */
+static int
+bitop_check_no_args(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  if (argc != 0 || bitop_kwargs(v, argc) != NULL) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return 0;
+  }
+  return 1;
+}
+
+static void
+c_string_bit_count(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  uint32_t count;
+
+  if (!bitop_check_no_args(vm, v, argc)) {
+    return;
+  }
+  count = bitop_count_bits(v[0].string->data, (int)v[0].string->size);
+  /* The count fits in uint32_t, but not necessarily in mrbc_int_t:
+     under MRBC_INT16 a 4096-byte all-ones string already exceeds it.
+     Out-of-range conversion to a signed type is implementation-
+     defined, so compare against the mrbc_int_t maximum before
+     casting.  The comparison is done in uint64_t, which holds both
+     operands for every MRBC_INT configuration. */
+  if ((uint64_t)count > (uint64_t)((mrbc_uint_t)-1 >> 1)) {
+    mrbc_raise(vm, MRBC_CLASS(RangeError), "bit count exceeds Integer range");
+    return;
+  }
+  SET_INT_RETURN((mrbc_int_t)count);
+}
+
+static void
+c_string_bitwise_not(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  int len;
+  mrbc_value result;
+
+  if (!bitop_check_no_args(vm, v, argc)) {
+    return;
+  }
+  len = (int)v[0].string->size;
+  result = mrbc_string_new(vm, NULL, len);
+  bitop_not_kernel(result.string->data, v[0].string->data, len);
+  result.string->data[len] = '\0';
+  SET_RETURN(result);
+}
+
+static void
+c_string_bitwise_not_bang(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  uint8_t *ptr;
+
+  if (!bitop_check_no_args(vm, v, argc)) {
+    return;
+  }
+  ptr = v[0].string->data;
+  bitop_not_kernel(ptr, ptr, (int)v[0].string->size);
+  /* v[0] left untouched: returns self */
+}
+
+/* Validates the operand of a binary operation.  Returns 1 on success. */
+static int
+bitop_binary_operand(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  if (argc != 1 || bitop_kwargs(v, argc) != NULL) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return 0;
+  }
+  if (v[1].tt != MRBC_TT_STRING) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "operand must be a String");
+    return 0;
+  }
+  if (v[1].string->size != v[0].string->size) {
+    mrbc_raisef(vm, MRBC_CLASS(ArgumentError), "operands must have the same length (%d vs %d)",
+                (int)v[0].string->size, (int)v[1].string->size);
+    return 0;
+  }
+  return 1;
+}
+
+typedef void (*bitop_binary_kernel)(uint8_t*, const uint8_t*, const uint8_t*, int);
+
+static void
+bitop_binary(mrbc_vm *vm, mrbc_value v[], int argc, bitop_binary_kernel kernel)
+{
+  int len;
+  mrbc_value result;
+
+  if (!bitop_binary_operand(vm, v, argc)) {
+    return;
+  }
+  len = (int)v[0].string->size;
+  result = mrbc_string_new(vm, NULL, len);
+  kernel(result.string->data, v[0].string->data, v[1].string->data, len);
+  result.string->data[len] = '\0';
+  SET_RETURN(result);
+}
+
+static void
+bitop_binary_bang(mrbc_vm *vm, mrbc_value v[], int argc, bitop_binary_kernel kernel)
+{
+  uint8_t *ptr;
+
+  if (!bitop_binary_operand(vm, v, argc)) {
+    return;
+  }
+  ptr = v[0].string->data;
+  kernel(ptr, ptr, v[1].string->data, (int)v[0].string->size);
+  /* v[0] left untouched: returns self */
+}
+
+static void
+c_string_bitwise_and(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary(vm, v, argc, bitop_and_kernel);
+}
+
+static void
+c_string_bitwise_and_bang(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary_bang(vm, v, argc, bitop_and_kernel);
+}
+
+static void
+c_string_bitwise_or(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary(vm, v, argc, bitop_or_kernel);
+}
+
+static void
+c_string_bitwise_or_bang(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary_bang(vm, v, argc, bitop_or_kernel);
+}
+
+static void
+c_string_bitwise_xor(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary(vm, v, argc, bitop_xor_kernel);
+}
+
+static void
+c_string_bitwise_xor_bang(mrbc_vm *vm, mrbc_value v[], int argc)
+{
+  bitop_binary_bang(vm, v, argc, bitop_xor_kernel);
+}
+
+void
+mrbc_string_bitops_init(mrbc_vm *vm)
+{
+  mrbc_class *s = MRBC_CLASS(String);
+
+  mrbc_define_method(vm, s, "bit_get", c_string_bit_get);
+  mrbc_define_method(vm, s, "bit_set?", c_string_bit_set_p);
+  mrbc_define_method(vm, s, "bit_set", c_string_bit_set);
+  mrbc_define_method(vm, s, "bit_clear", c_string_bit_clear);
+  mrbc_define_method(vm, s, "bit_flip", c_string_bit_flip);
+  mrbc_define_method(vm, s, "bit_count", c_string_bit_count);
+  mrbc_define_method(vm, s, "bitwise_not", c_string_bitwise_not);
+  mrbc_define_method(vm, s, "bitwise_not!", c_string_bitwise_not_bang);
+  mrbc_define_method(vm, s, "bitwise_and", c_string_bitwise_and);
+  mrbc_define_method(vm, s, "bitwise_and!", c_string_bitwise_and_bang);
+  mrbc_define_method(vm, s, "bitwise_or", c_string_bitwise_or);
+  mrbc_define_method(vm, s, "bitwise_or!", c_string_bitwise_or_bang);
+  mrbc_define_method(vm, s, "bitwise_xor", c_string_bitwise_xor);
+  mrbc_define_method(vm, s, "bitwise_xor!", c_string_bitwise_xor_bang);
+}

--- a/mrbgems/picoruby-string-bitops/src/string-bitops.c
+++ b/mrbgems/picoruby-string-bitops/src/string-bitops.c
@@ -1,0 +1,260 @@
+/*
+** string-bitops.c - Basic bit operations for String
+**
+** Port of CRuby [Feature #22118] "Introduce Basic Bit Operations into
+** String" for FemtoRuby (mruby/c).  On the mruby VM, the same API is
+** provided by the mruby-string-bitops mgem inside picoruby-mruby.
+**
+** This file holds the VM-independent bulk kernels.  They process one
+** machine word at a time; the word type follows the pointer width, so
+** 32-bit targets use 32-bit words and avoid emulated 64-bit
+** arithmetic.
+*/
+
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+#if defined(UINTPTR_MAX) && UINTPTR_MAX > 0xFFFFFFFFul
+typedef uint64_t bitop_word;
+# define BITOP_WORD_SIZE 8
+#else
+typedef uint32_t bitop_word;
+# define BITOP_WORD_SIZE 4
+#endif
+#define BITOP_WORD_BITS (BITOP_WORD_SIZE * 8)
+
+#ifndef __has_builtin
+# define __has_builtin(x) 0
+#endif
+
+#if defined(__GNUC__) || __has_builtin(__builtin_popcount)
+static unsigned int
+bitop_popcount(bitop_word word)
+{
+#if BITOP_WORD_SIZE == 8
+  return (unsigned int)__builtin_popcountll((unsigned long long)word);
+#elif UINT_MAX >= 0xFFFFFFFFul
+  /* int holds a 32-bit word; avoids the 64-bit helper where long is 64-bit */
+  return (unsigned int)__builtin_popcount((unsigned int)word);
+#else
+  return (unsigned int)__builtin_popcountl((unsigned long)word);
+#endif
+}
+#else
+static unsigned int
+bitop_popcount(bitop_word word)
+{
+  /* Generic SWAR popcount; the constants adapt to the word width. */
+  const bitop_word m1 = (bitop_word)~(bitop_word)0 / 3;    /* 0x55... */
+  const bitop_word m2 = (bitop_word)~(bitop_word)0 / 5;    /* 0x33... */
+  const bitop_word m4 = (bitop_word)~(bitop_word)0 / 17;   /* 0x0f... */
+  const bitop_word h01 = (bitop_word)~(bitop_word)0 / 255; /* 0x01... */
+
+  word -= (word >> 1) & m1;
+  word = (word & m2) + ((word >> 2) & m2);
+  word = (word + (word >> 4)) & m4;
+  return (unsigned int)((word * h01) >> (BITOP_WORD_BITS - 8));
+}
+#endif
+
+/*
+ * memcpy-based word loops, safe for any alignment.  They are the
+ * whole bulk path on non-GNU compilers, and the unaligned fallback
+ * on GNU-compatible ones.  The trailing byte loop of each kernel
+ * only handles the tail.
+ */
+#define BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)               \
+  {                                                                          \
+    int aligned_end_ = (len) & ~(BITOP_WORD_SIZE - 1);                       \
+    for (; (off) < aligned_end_; (off) += BITOP_WORD_SIZE) {                 \
+      bitop_word w_;                                                         \
+      memcpy(&w_, (src) + (off), BITOP_WORD_SIZE);                           \
+      w_ = expr_word(w_);                                                    \
+      memcpy((dst) + (off), &w_, BITOP_WORD_SIZE);                           \
+    }                                                                        \
+  }
+
+#define BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)         \
+  {                                                                          \
+    int aligned_end_ = (len) & ~(BITOP_WORD_SIZE - 1);                       \
+    for (; (off) < aligned_end_; (off) += BITOP_WORD_SIZE) {                 \
+      bitop_word l_, r_;                                                     \
+      memcpy(&l_, (lhs) + (off), BITOP_WORD_SIZE);                           \
+      memcpy(&r_, (rhs) + (off), BITOP_WORD_SIZE);                           \
+      l_ = expr_word(l_, r_);                                                \
+      memcpy((dst) + (off), &l_, BITOP_WORD_SIZE);                           \
+    }                                                                        \
+  }
+
+/*
+ * On GNU-compatible compilers, word-aligned buffers are processed
+ * through a word pointer; the may_alias type keeps that free of
+ * strict-aliasing issues.  Targets without unaligned load support
+ * (e.g. Cortex-M0+) still get true word loads this way, which a bare
+ * memcpy cannot guarantee.  Unaligned buffers fall back to the memcpy
+ * word loops above.
+ */
+#if defined(__GNUC__)
+typedef bitop_word __attribute__((__may_alias__)) bitop_word_alias;
+# define BITOP_ALIGNED(ptrbits) (((ptrbits) & (BITOP_WORD_SIZE - 1)) == 0)
+
+#define BITOP_DEFINE_UNARY_KERNEL(name, expr_word, expr_byte)                \
+static void                                                                  \
+name(uint8_t *dst, const uint8_t *src, int len)                              \
+{                                                                            \
+  int off = 0;                                                               \
+  if (BITOP_ALIGNED((uintptr_t)dst | (uintptr_t)src)) {                      \
+    bitop_word_alias *dw = (bitop_word_alias*)dst;                           \
+    const bitop_word_alias *sw = (const bitop_word_alias*)src;               \
+    int words = len / BITOP_WORD_SIZE;                                       \
+    int i = 0;                                                               \
+    for (; i + 4 <= words; i += 4) {                                         \
+      bitop_word s0 = sw[i], s1 = sw[i+1], s2 = sw[i+2], s3 = sw[i+3];       \
+      dw[i]   = expr_word(s0);                                               \
+      dw[i+1] = expr_word(s1);                                               \
+      dw[i+2] = expr_word(s2);                                               \
+      dw[i+3] = expr_word(s3);                                               \
+    }                                                                        \
+    for (; i < words; i++) {                                                 \
+      dw[i] = expr_word(sw[i]);                                              \
+    }                                                                        \
+    off = words * BITOP_WORD_SIZE;                                           \
+  }                                                                          \
+  else                                                                       \
+    BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)                   \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(src[off]);                                          \
+  }                                                                          \
+}
+
+#define BITOP_DEFINE_BINARY_KERNEL(name, expr_word, expr_byte)               \
+static void                                                                  \
+name(uint8_t *dst, const uint8_t *lhs, const uint8_t *rhs, int len)          \
+{                                                                            \
+  int off = 0;                                                               \
+  if (BITOP_ALIGNED((uintptr_t)dst | (uintptr_t)lhs | (uintptr_t)rhs)) {     \
+    bitop_word_alias *dw = (bitop_word_alias*)dst;                           \
+    const bitop_word_alias *lw = (const bitop_word_alias*)lhs;               \
+    const bitop_word_alias *rw = (const bitop_word_alias*)rhs;               \
+    int words = len / BITOP_WORD_SIZE;                                       \
+    int i = 0;                                                               \
+    for (; i + 4 <= words; i += 4) {                                         \
+      bitop_word l0 = lw[i], l1 = lw[i+1], l2 = lw[i+2], l3 = lw[i+3];       \
+      bitop_word r0 = rw[i], r1 = rw[i+1], r2 = rw[i+2], r3 = rw[i+3];       \
+      dw[i]   = expr_word(l0, r0);                                           \
+      dw[i+1] = expr_word(l1, r1);                                           \
+      dw[i+2] = expr_word(l2, r2);                                           \
+      dw[i+3] = expr_word(l3, r3);                                           \
+    }                                                                        \
+    for (; i < words; i++) {                                                 \
+      dw[i] = expr_word(lw[i], rw[i]);                                       \
+    }                                                                        \
+    off = words * BITOP_WORD_SIZE;                                           \
+  }                                                                          \
+  else                                                                       \
+    BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)             \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(lhs[off], rhs[off]);                                \
+  }                                                                          \
+}
+
+#else /* generic compilers: memcpy word loops only */
+
+#define BITOP_DEFINE_UNARY_KERNEL(name, expr_word, expr_byte)                \
+static void                                                                  \
+name(uint8_t *dst, const uint8_t *src, int len)                              \
+{                                                                            \
+  int off = 0;                                                               \
+  BITOP_UNARY_MEMCPY_LOOP(dst, src, len, off, expr_word)                     \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(src[off]);                                          \
+  }                                                                          \
+}
+
+#define BITOP_DEFINE_BINARY_KERNEL(name, expr_word, expr_byte)               \
+static void                                                                  \
+name(uint8_t *dst, const uint8_t *lhs, const uint8_t *rhs, int len)          \
+{                                                                            \
+  int off = 0;                                                               \
+  BITOP_BINARY_MEMCPY_LOOP(dst, lhs, rhs, len, off, expr_word)               \
+  for (; off < len; off++) {                                                 \
+    dst[off] = expr_byte(lhs[off], rhs[off]);                                \
+  }                                                                          \
+}
+
+#endif
+
+#define BITOP_NOT_WORD(x)    (~(x))
+#define BITOP_NOT_BYTE(x)    ((uint8_t)~(x))
+#define BITOP_AND_WORD(x, y) ((x) & (y))
+#define BITOP_AND_BYTE(x, y) ((uint8_t)((x) & (y)))
+#define BITOP_OR_WORD(x, y)  ((x) | (y))
+#define BITOP_OR_BYTE(x, y)  ((uint8_t)((x) | (y)))
+#define BITOP_XOR_WORD(x, y) ((x) ^ (y))
+#define BITOP_XOR_BYTE(x, y) ((uint8_t)((x) ^ (y)))
+
+BITOP_DEFINE_UNARY_KERNEL(bitop_not_kernel, BITOP_NOT_WORD, BITOP_NOT_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_and_kernel, BITOP_AND_WORD, BITOP_AND_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_or_kernel, BITOP_OR_WORD, BITOP_OR_BYTE)
+BITOP_DEFINE_BINARY_KERNEL(bitop_xor_kernel, BITOP_XOR_WORD, BITOP_XOR_BYTE)
+
+/*
+ * The uint32_t count cannot overflow: it would need a 512MiB string,
+ * far beyond MRBC_STRING_SIZE_T.  Whether the count also fits in the
+ * VM integer type (it does not under MRBC_INT16) is checked by the
+ * caller when boxing the return value.
+ */
+static uint32_t
+bitop_count_bits(const uint8_t *ptr, int len)
+{
+  uint32_t count = 0;
+  int off = 0;
+
+#if defined(__GNUC__)
+  if (BITOP_ALIGNED((uintptr_t)ptr)) {
+    const bitop_word_alias *pw = (const bitop_word_alias*)ptr;
+    int words = len / BITOP_WORD_SIZE;
+    int i = 0;
+    for (; i + 4 <= words; i += 4) {
+      count += bitop_popcount(pw[i]);
+      count += bitop_popcount(pw[i+1]);
+      count += bitop_popcount(pw[i+2]);
+      count += bitop_popcount(pw[i+3]);
+    }
+    for (; i < words; i++) {
+      count += bitop_popcount(pw[i]);
+    }
+    off = words * BITOP_WORD_SIZE;
+  }
+  else
+#endif
+  {
+    int aligned_end = len & ~(BITOP_WORD_SIZE - 1);
+    for (; off < aligned_end; off += BITOP_WORD_SIZE) {
+      bitop_word w;
+      memcpy(&w, ptr + off, BITOP_WORD_SIZE);
+      count += bitop_popcount(w);
+    }
+  }
+  /* Pack the remaining bytes into one word and popcount it once. */
+  if (off < len) {
+    bitop_word w = 0;
+    unsigned int shift = 0;
+    for (; off < len; off++, shift += 8) {
+      w |= (bitop_word)ptr[off] << shift;
+    }
+    count += bitop_popcount(w);
+  }
+  return count;
+}
+
+#if defined(PICORB_VM_MRUBY)
+
+#error "picoruby-string-bitops does not support the mruby VM. Use mruby-string-bitops instead"
+
+#elif defined(PICORB_VM_MRUBYC)
+
+#include "mrubyc/string-bitops.c"
+
+#endif

--- a/mrbgems/picoruby-string-bitops/test/string_bitops_test.rb
+++ b/mrbgems/picoruby-string-bitops/test/string_bitops_test.rb
@@ -1,0 +1,148 @@
+# Tests for picoruby-string-bitops (FemtoRuby / mruby/c)
+# Ported from CRuby [Feature #22118] test suite.
+
+class StringBitopsTest < Picotest::Test
+  def test_bit_get
+    s = "\xAA\x80"
+    assert_equal 0, s.bit_get(0)
+    assert_equal 1, s.bit_get(1)
+    assert_equal 1, s.bit_get(7)
+    assert_equal 1, s.bit_get(0, lsb_first: false)
+    assert_equal 0, s.bit_get(1, lsb_first: false)
+    assert_equal 1, s.bit_get(8, lsb_first: false)
+    assert_nil s.bit_get(16)
+    assert_raise(IndexError) { s.bit_get(-1) }
+    assert_raise(ArgumentError) { s.bit_get(0, lsb_first: nil) }
+    assert_raise(TypeError) { s.bit_get("1") }
+  end
+
+  def test_bit_set_p
+    s = "\xAA\x80"
+    assert_equal false, s.bit_set?(0)
+    assert_equal true, s.bit_set?(1)
+    assert_equal true, s.bit_set?(7)
+    assert_equal true, s.bit_set?(0, lsb_first: false)
+    assert_equal false, s.bit_set?(1, lsb_first: false)
+    assert_equal true, s.bit_set?(8, lsb_first: false)
+    assert_nil s.bit_set?(16)
+    assert_raise(IndexError) { s.bit_set?(-1) }
+    assert_raise(ArgumentError) { s.bit_set?(0, lsb_first: nil) }
+  end
+
+  def test_bit_set_clear_flip
+    s = "\x00"
+    assert_equal s.object_id, s.bit_set(1).object_id
+    assert_equal "\x02", s
+    assert_equal s.object_id, s.bit_clear(1).object_id
+    assert_equal "\x00", s
+    assert_equal s.object_id, s.bit_flip(1).object_id
+    assert_equal "\x02", s
+    s.bit_flip(1)
+    assert_equal "\x00", s
+
+    s.bit_set(1, lsb_first: false)
+    assert_equal "\x40", s
+    s.bit_clear(1, lsb_first: false)
+    assert_equal "\x00", s
+
+    s = "\x00\x00"
+    s.bit_set(8, lsb_first: false)
+    assert_equal "\x00\x80", s
+    s.bit_clear(8, lsb_first: false)
+    assert_equal "\x00\x00", s
+    s.bit_flip(8, lsb_first: false)
+    assert_equal "\x00\x80", s
+
+    assert_raise(IndexError) { "\x00".bit_set(8) }
+    assert_raise(IndexError) { "\x00".bit_set(-1) }
+    assert_raise(IndexError) { "\x00".bit_clear(8) }
+    assert_raise(IndexError) { "\x00".bit_clear(-1) }
+    assert_raise(IndexError) { "\x00".bit_flip(8) }
+    assert_raise(IndexError) { "\x00".bit_flip(-1) }
+    assert_raise(ArgumentError) { "\x00".bit_set(0, lsb_first: nil) }
+  end
+
+  def test_bit_count
+    assert_equal 0, "".bit_count
+    assert_equal 0, "\x00".bit_count
+    assert_equal 8, "\xFF".bit_count
+    assert_equal 8, "\xAA\xF0".bit_count
+    assert_raise(ArgumentError) { "\x00".bit_count(0) }
+    assert_raise(ArgumentError) { "\x00".bit_count(lsb_first: false) }
+  end
+
+  def test_bit_count_long_strings
+    # Exercise the word-at-a-time and unrolled paths.
+    assert_equal 0, ("\x00" * 100).bit_count
+    assert_equal 800, ("\xFF" * 100).bit_count
+    assert_equal 400, ("\xAA" * 100).bit_count
+    assert_equal 4 * 33, ("\x0F" * 33).bit_count
+    # Short strings exercise the unaligned and tail paths.
+    assert_equal 8 * 24, ("\xFF" * 24).bit_count
+    assert_equal 4 * 20, ("\x0F" * 20).bit_count
+  end
+
+  def test_bitwise_not
+    s = "\x00\xAA"
+    result = s.bitwise_not
+    assert_equal "\xFF\x55", result
+    assert_not_equal s.object_id, result.object_id
+    assert_equal "\x00\xAA", s
+
+    assert_equal s.object_id, s.bitwise_not!.object_id
+    assert_equal "\xFF\x55", s
+  end
+
+  def test_bitwise_and_or_xor
+    assert_equal "\xC0", "\xF0".bitwise_and("\xCC")
+    assert_equal "\xFC", "\xF0".bitwise_or("\x0C")
+    assert_equal "\x3C", "\xF0".bitwise_xor("\xCC")
+
+    s = "\xF0"
+    assert_equal s.object_id, s.bitwise_and!("\xCC").object_id
+    assert_equal "\xC0", s
+    assert_equal s.object_id, s.bitwise_or!("\x0C").object_id
+    assert_equal "\xCC", s
+    assert_equal s.object_id, s.bitwise_xor!("\xFF").object_id
+    assert_equal "\x33", s
+
+    # Length mismatch: other longer, shorter, and empty.
+    assert_raise(ArgumentError) { "\xF0".bitwise_and("\x00\x00") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_and("") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_or("\x00\x00") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_or("") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_xor("\x00\x00") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_xor("") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_and!("") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_or!("") }
+    assert_raise(ArgumentError) { "\xF0".bitwise_xor!("") }
+    assert_raise(ArgumentError) { "\x00\x00".bitwise_or!("\x00") }
+    assert_raise(TypeError) { "\x00".bitwise_or(nil) }
+    assert_raise(TypeError) { "\x00".bitwise_or(0) }
+  end
+
+  def test_bitwise_long_strings
+    a = "\xAA" * 41
+    b = "\x0F" * 41
+    assert_equal "\x0A" * 41, a.bitwise_and(b)
+    assert_equal "\xAF" * 41, a.bitwise_or(b)
+    assert_equal "\xA5" * 41, a.bitwise_xor(b)
+    assert_equal "\x55" * 41, a.bitwise_not
+    assert_equal "\x00" * 41, a.bitwise_xor(a)
+
+    c = a.dup
+    c.bitwise_xor!(b)
+    c.bitwise_xor!(b)
+    assert_equal a, c
+
+    # 20-byte strings exercise short-buffer word loops and the tail.
+    e = "\xAA" * 20
+    f = "\x0F" * 20
+    assert_equal "\x0A" * 20, e.bitwise_and(f)
+    assert_equal "\xAF" * 20, e.bitwise_or(f)
+    assert_equal "\xA5" * 20, e.bitwise_xor(f)
+    assert_equal "\x55" * 20, e.bitwise_not
+    e.bitwise_xor!(f)
+    assert_equal "\xA5" * 20, e
+  end
+end


### PR DESCRIPTION
Port String bit operations from CRuby Feature #22118 (https://bugs.ruby-lang.org/issues/22118) to the mruby/c VM: bit_get, bit_set?, bit_set, bit_clear, bit_flip, bit_count, and bitwise_not/and/or/xor with their bang variants.  On the mruby VM the same API comes from the mruby-string-bitops mgem in picoruby-mruby; this gem intentionally supports mruby/c only.

The port minds mruby/c specifics: keyword arguments are read from the Hash at v[argc + 1], integer widths follow mrbc_int_t including the MRBC_INT16 configuration, and the bulk kernels use pointer-width words with true word loads on aligned buffers.  See the gem's README.md for details and the intentional differences from CRuby.