### PR TITLE
machine: keep the sleep upper bound out of a 32-bit constant pool

### DIFF
--- a/mrbgems/picoruby-machine/mrblib/machine.rb
+++ b/mrbgems/picoruby-machine/mrblib/machine.rb
@@ -58,8 +58,12 @@ module Machine
       unless ms.is_a?(Integer)
         raise ArgumentError, "ms: must be an Integer"
       end
-      # The C side takes uint32_t; reject instead of wrapping.
-      if ms < 1 || 4294967295 < ms
+      # The C side takes uint32_t and is the authority on the upper
+      # bound; it rejects instead of wrapping. No literal above
+      # INT32_MAX may appear here: a build whose Integer is 32-bit
+      # cannot load the irep that would hold it, and the failure takes
+      # down every class defined in this file.
+      if ms < 1
         raise ArgumentError, "ms: out of range (1..4294967295)"
       end
       _sleep_timer(deep, ms)

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -117,16 +117,18 @@ c_Machine__sleep_timer(mrbc_vm *vm, mrbc_value *v, int argc)
   mrbc_int_t ms = GET_INT_ARG(2);
   /* The mrblib wrapper checks the lower bound too; this is the
    * authority for a direct private call. The port takes uint32_t:
-   * reject rather than wrap. A 32-bit mrbc_int_t cannot hold a value
-   * out of range, so the upper bound only exists under MRBC_INT64. */
-  if (ms < 1
-#if defined(MRBC_INT64)
-      || 4294967295LL < (int64_t)ms
-#endif
-     ) {
+   * reject rather than wrap. */
+  if (ms < 1) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "ms out of range");
     return;
   }
+#if defined(MRBC_INT64)
+  /* A 32-bit mrbc_int_t cannot hold a value above the upper bound. */
+  if (4294967295LL < (int64_t)ms) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "ms out of range");
+    return;
+  }
+#endif
   if (machine_sleep_raised(vm, Machine_sleep_timer(deep, (uint32_t)ms))) return;
   SET_NIL_RETURN();
 }

--- a/mrbgems/picoruby-machine/src/mrubyc/machine.c
+++ b/mrbgems/picoruby-machine/src/mrubyc/machine.c
@@ -115,9 +115,15 @@ c_Machine__sleep_timer(mrbc_vm *vm, mrbc_value *v, int argc)
     return;
   }
   mrbc_int_t ms = GET_INT_ARG(2);
-  /* The port takes uint32_t: reject rather than wrap. mrbc_int_t is
-   * 64-bit here (PICORB_INT64). */
-  if (ms < 1 || 4294967295LL < (int64_t)ms) {
+  /* The mrblib wrapper checks the lower bound too; this is the
+   * authority for a direct private call. The port takes uint32_t:
+   * reject rather than wrap. A 32-bit mrbc_int_t cannot hold a value
+   * out of range, so the upper bound only exists under MRBC_INT64. */
+  if (ms < 1
+#if defined(MRBC_INT64)
+      || 4294967295LL < (int64_t)ms
+#endif
+     ) {
     mrbc_raise(vm, MRBC_CLASS(ArgumentError), "ms out of range");
     return;
   }


### PR DESCRIPTION
Machine.sleep checked ms against a 4294967295 literal in mrblib. The host mrbc stores any literal above INT32_MAX as an IREP_TT_INT64 pool entry, and mruby/c rejects such an irep at load time unless it was built with MRBC_INT64. On the mips-linux-gnu build -- the only mrubyc-VM config without PICORB_INT64 -- that aborted the mrblib load, and the runtime came up so incomplete that even `puts 1` raised NoMethodError.

The C bindings already own this bound and are the authority for a direct private call, so the wrapper only needs the lower bound. Guard the upper half of the mrubyc binding with MRBC_INT64 to match the mruby one: a 32-bit mrbc_int_t cannot hold an out-of-range value.

Behaviour is unchanged where Integer is 64-bit. picoruby-machine's own tests still pass, including the 4294967296 case, which the C side rejects.