### PR TITLE
picomodem: multi-command sessions and capability check

### DIFF
--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -41,7 +41,10 @@ module PicoModem
 
   CHUNK_SIZE = 480
   TIMEOUT_MS = 5000
-  # Consecutive failed reads (timeout or bad frame) that end an idle session.
+  # Largest Cmd+Payload a valid frame can declare. A frame claiming more is
+  # rejected before read_exact allocates a read buffer for it.
+  MAX_FRAME_SIZE = 1024
+  # Consecutive recv failures (silence or a corrupt frame) before a session ends.
   SESSION_IDLE_LIMIT = 12
   PROTOCOL_VERSION = 1
   # Host -> device opcodes advertised by CMD_CAP.
@@ -83,37 +86,50 @@ module PicoModem
         idle = 0
         cmd = frame[0]
         payload = frame[1]
-        case cmd
-        when SESSION_OPEN
-          info = "session"
-          in_session = true
-          send_frame(io_out, DONE_ACK, [OK].pack("C"))
-        when SESSION_QUIT
-          info ||= "quit"
-          send_frame(io_out, DONE_ACK, [OK].pack("C"))
-          break
-        when CMD_CAP
-          info = "capability"
-          handle_capability(io_out)
-          break unless in_session
-        when FILE_READ
-          info = "read #{payload}"
-          handle_file_read(io_in, io_out, payload)
-          break unless in_session
-        when FILE_WRITE
-          path = 4 < payload.bytesize ? payload.byteslice(4, payload.bytesize - 4) : ""
-          info = "write #{path}"
-          handle_file_write(io_in, io_out, payload)
-          break unless in_session
-        when DFU_START
-          info = "dfu"
-          handle_dfu(io_in, io_out, payload)
-          break
-        when ABORT
-          info ||= "abort"
-          break
-        else
-          send_frame(io_out, ERROR, "Unknown command")
+        begin
+          case cmd
+          when SESSION_OPEN
+            info = "session"
+            in_session = true
+            send_frame(io_out, DONE_ACK, [OK].pack("C"))
+          when SESSION_QUIT
+            info ||= "quit"
+            send_frame(io_out, DONE_ACK, [OK].pack("C"))
+            break
+          when CMD_CAP
+            info = "capability"
+            handle_capability(io_out)
+            break unless in_session
+          when FILE_READ
+            info = "read #{payload}"
+            # Handlers return true when the host ABORTed, which ends the session.
+            break if handle_file_read(io_in, io_out, payload)
+            break unless in_session
+          when FILE_WRITE
+            path = 4 < payload.bytesize ? payload.byteslice(4, payload.bytesize - 4) : ""
+            info = "write #{path}"
+            break if handle_file_write(io_in, io_out, payload)
+            break unless in_session
+          when DFU_START
+            info = "dfu"
+            handle_dfu(io_in, io_out, payload)
+            break
+          when ABORT
+            info ||= "abort"
+            break
+          else
+            send_frame(io_out, ERROR, "Unknown command")
+            break unless in_session
+          end
+        rescue => e
+          # A per-command failure is recoverable: report it and, in a session,
+          # keep the loop running. A one-shot command ends as before.
+          info = "error: #{e.message}"
+          begin
+            send_frame(io_out, ERROR, e.message.to_s)
+          rescue
+            # best effort
+          end
           break unless in_session
         end
       end
@@ -162,6 +178,8 @@ module PicoModem
     return nil unless len_bytes
     # @type var length: Integer
     length = len_bytes.unpack("n")[0]
+    # Reject a bogus length before allocating a read buffer for it
+    return nil if length < 1 || MAX_FRAME_SIZE < length
     # Read cmd + payload + CRC16
     rest = read_exact(io, length + 2)
     return nil unless rest
@@ -212,11 +230,12 @@ module PicoModem
   # Handle FILE_READ: send file contents in chunks.
   # Reads the file in chunks to avoid loading the entire file into RAM.
   # CRC32 is computed incrementally across chunks.
+  # Returns true when the host ABORTed the transfer (the session should end).
   def self.handle_file_read(io_in, io_out, payload)
     path = payload.to_s
     unless File.exist?(path)
       send_frame(io_out, ERROR, "File not found: #{path}")
-      return
+      return false
     end
     total = File::Stat.new(path).size
     file_crc = 0
@@ -234,22 +253,25 @@ module PicoModem
         frame_payload << chunk
         send_frame(io_out, FILE_DATA, frame_payload)
         ack = recv_frame(io_in)
+        return true if ack && ack[0] == ABORT
         unless ack && ack[0] == CHUNK_ACK
           # No CHUNK_ACK: emit a terminal ERROR so a session sees a clean boundary.
           send_frame(io_out, ERROR, "FILE_READ aborted: missing CHUNK_ACK")
-          return
+          return false
         end
       end
     end
     send_frame(io_out, DONE_ACK, [OK, file_crc].pack("CN"))
+    false
   end
 
-  # Handle FILE_WRITE: receive file contents in chunks and stream them to flash
+  # Handle FILE_WRITE: receive file contents in chunks and stream them to flash.
+  # Returns true when the host ABORTed the transfer (the session should end).
   def self.handle_file_write(io_in, io_out, payload)
     # Payload: 4 bytes total size (big-endian) + path
     if payload.bytesize < 5
       send_frame(io_out, ERROR, "Invalid FILE_WRITE payload")
-      return
+      return false
     end
     # @type var total: Integer
     total = (payload.byteslice(0, 4) || '').unpack("N")[0]
@@ -296,10 +318,13 @@ module PicoModem
     if error_message
       File.unlink(path) if File.exist?(path)
       send_frame(io_out, ERROR, error_message.to_s)
+      false
     elsif aborted
       File.unlink(path) if File.exist?(path)
+      true
     else
       send_frame(io_out, DONE_ACK, [OK, file_crc].pack("CN"))
+      false
     end
   end
 

--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -15,12 +15,14 @@ require 'pack'
 module PicoModem
 
   # Command types (Host -> Device)
-  FILE_READ  = 0x01
-  FILE_WRITE = 0x02
-  DFU_START  = 0x03
-  CHUNK      = 0x04
-  DONE       = 0x0F
-  ABORT      = 0xFF
+  FILE_READ    = 0x01
+  FILE_WRITE   = 0x02
+  DFU_START    = 0x03
+  CHUNK        = 0x04
+  SESSION_QUIT = 0x0D
+  SESSION_OPEN = 0x0E
+  DONE         = 0x0F
+  ABORT        = 0xFF
 
   # Response types (Device -> Host) = request | 0x80
   FILE_DATA  = 0x81
@@ -37,39 +39,73 @@ module PicoModem
 
   CHUNK_SIZE = 480
   TIMEOUT_MS = 5000
+  # Consecutive failed reads (timeout or bad frame) that end an idle session.
+  SESSION_IDLE_LIMIT = 12
 
-  # Run a PicoModem session: read frames, dispatch commands, return to shell
+  # Run a PicoModem session from the shell: raw terminal, dispatch, then restore.
   def self.session(io_in, io_out)
     STDIN.raw!
     info = nil
     begin
+      info = run_session(io_in, io_out)
+    ensure
+      STDIN.cooked! # restore the terminal even if run_session raises
+    end
+    # Wait for browser to stop binary capture before printing
+    sleep_ms 200
+    puts "[PicoModem] #{info}"
+  end
+
+  # Read and dispatch frames. One command per call, or - after SESSION_OPEN - a
+  # loop until SESSION_QUIT/ABORT/idle timeout. Returns the shell status string.
+  def self.run_session(io_in, io_out)
+    info = nil
+    in_session = false
+    idle = 0
+    begin
       while true
         frame = recv_frame(io_in)
         unless frame
-          info = "timeout"
+          if in_session
+            idle += 1
+            next if idle < SESSION_IDLE_LIMIT
+            info = "session timeout"
+          else
+            info = "timeout"
+          end
           break
         end
+        idle = 0
         cmd = frame[0]
         payload = frame[1]
         case cmd
+        when SESSION_OPEN
+          info = "session"
+          in_session = true
+          send_frame(io_out, DONE_ACK, [OK].pack("C"))
+        when SESSION_QUIT
+          info ||= "quit"
+          send_frame(io_out, DONE_ACK, [OK].pack("C"))
+          break
         when FILE_READ
           info = "read #{payload}"
           handle_file_read(io_in, io_out, payload)
-          break
+          break unless in_session
         when FILE_WRITE
           path = 4 < payload.bytesize ? payload.byteslice(4, payload.bytesize - 4) : ""
           info = "write #{path}"
           handle_file_write(io_in, io_out, payload)
-          break
+          break unless in_session
         when DFU_START
           info = "dfu"
           handle_dfu(io_in, io_out, payload)
           break
         when ABORT
+          info ||= "abort"
           break
         else
           send_frame(io_out, ERROR, "Unknown command")
-          break
+          break unless in_session
         end
       end
     rescue => e
@@ -80,10 +116,7 @@ module PicoModem
         # best effort
       end
     end
-    STDIN.cooked!
-    # Wait for browser to stop binary capture before printing
-    sleep_ms 200
-    puts "[PicoModem] #{info}"
+    info
   end
 
   # Receive one PicoModem frame from io
@@ -173,6 +206,8 @@ module PicoModem
         send_frame(io_out, FILE_DATA, frame_payload)
         ack = recv_frame(io_in)
         unless ack && ack[0] == CHUNK_ACK
+          # No CHUNK_ACK: emit a terminal ERROR so a session sees a clean boundary.
+          send_frame(io_out, ERROR, "FILE_READ aborted: missing CHUNK_ACK")
           return
         end
       end

--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -19,18 +19,20 @@ module PicoModem
   FILE_WRITE   = 0x02
   DFU_START    = 0x03
   CHUNK        = 0x04
+  CMD_CAP      = 0x0A
   SESSION_QUIT = 0x0D
   SESSION_OPEN = 0x0E
   DONE         = 0x0F
   ABORT        = 0xFF
 
   # Response types (Device -> Host) = request | 0x80
-  FILE_DATA  = 0x81
-  FILE_ACK   = 0x82
-  DFU_ACK    = 0x83
-  CHUNK_ACK  = 0x84
-  DONE_ACK   = 0x8F
-  ERROR      = 0xFE
+  FILE_DATA     = 0x81
+  FILE_ACK      = 0x82
+  DFU_ACK       = 0x83
+  CHUNK_ACK     = 0x84
+  CMD_CAP_FLAGS = 0x8A
+  DONE_ACK      = 0x8F
+  ERROR         = 0xFE
 
   # Status codes
   OK    = 0x00
@@ -41,6 +43,9 @@ module PicoModem
   TIMEOUT_MS = 5000
   # Consecutive failed reads (timeout or bad frame) that end an idle session.
   SESSION_IDLE_LIMIT = 12
+  PROTOCOL_VERSION = 1
+  # Host -> device opcodes advertised by CMD_CAP.
+  CAPABILITIES = [FILE_READ, FILE_WRITE, DFU_START, CMD_CAP, SESSION_QUIT, SESSION_OPEN]
 
   # Run a PicoModem session from the shell: raw terminal, dispatch, then restore.
   def self.session(io_in, io_out)
@@ -87,6 +92,10 @@ module PicoModem
           info ||= "quit"
           send_frame(io_out, DONE_ACK, [OK].pack("C"))
           break
+        when CMD_CAP
+          info = "capability"
+          handle_capability(io_out)
+          break unless in_session
         when FILE_READ
           info = "read #{payload}"
           handle_file_read(io_in, io_out, payload)
@@ -117,6 +126,22 @@ module PicoModem
       end
     end
     info
+  end
+
+  # Handle CMD_CAP: reply with the protocol version and a bitmap of the
+  # supported host -> device opcodes (bit n set means opcode n is supported).
+  def self.handle_capability(io_out)
+    max_byte = 0
+    CAPABILITIES.each do |op|
+      b = op >> 3
+      max_byte = b if max_byte < b
+    end
+    bitmap = Array.new(max_byte + 1, 0)
+    CAPABILITIES.each do |op|
+      bitmap[op >> 3] |= (1 << (op & 7))
+    end
+    payload = [PROTOCOL_VERSION, bitmap.size].pack("CC") + bitmap.pack("C*")
+    send_frame(io_out, CMD_CAP_FLAGS, payload)
   end
 
   # Receive one PicoModem frame from io

--- a/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-picomodem/mrblib/picomodem.rb
@@ -144,14 +144,18 @@ module PicoModem
     send_frame(io_out, CMD_CAP_FLAGS, payload)
   end
 
-  # Receive one PicoModem frame from io
-  # Returns [cmd, payload] or nil on timeout/error
+  # Receive one PicoModem frame from io, scanning to the next STX so line noise
+  # between frames is skipped instead of failing the read.
+  # Returns [cmd, payload] or nil on timeout/corrupt frame.
   def self.recv_frame(io)
-    # Read STX
-    stx = read_exact(io, 1)
-    return nil unless stx
-    unless stx.getbyte(0) == 0x02
-      return nil
+    skipped = 0
+    while true
+      stx = read_exact(io, 1)
+      return nil unless stx
+      break if stx.getbyte(0) == 0x02
+      skipped += 1
+      # Bound the scan so a junk flood without STX cannot block forever
+      return nil if CHUNK_SIZE < skipped
     end
     # Read length (2 bytes big-endian)
     len_bytes = read_exact(io, 2)

--- a/mrbgems/picoruby-picomodem/sig/picomodem.rbs
+++ b/mrbgems/picoruby-picomodem/sig/picomodem.rbs
@@ -3,6 +3,7 @@ module PicoModem
   FILE_WRITE: Integer
   DFU_START: Integer
   CHUNK: Integer
+  CMD_CAP: Integer
   SESSION_QUIT: Integer
   SESSION_OPEN: Integer
   DONE: Integer
@@ -12,6 +13,7 @@ module PicoModem
   FILE_ACK: Integer
   DFU_ACK: Integer
   CHUNK_ACK: Integer
+  CMD_CAP_FLAGS: Integer
   DONE_ACK: Integer
   ERROR: Integer
 
@@ -22,9 +24,12 @@ module PicoModem
   CHUNK_SIZE: Integer
   TIMEOUT_MS: Integer
   SESSION_IDLE_LIMIT: Integer
+  PROTOCOL_VERSION: Integer
+  CAPABILITIES: Array[Integer]
 
   def self.session: (IO io_in, IO io_out) -> void
   def self.run_session: (IO io_in, IO io_out) -> String?
+  def self.handle_capability: (IO io_out) -> void
   def self.recv_frame: (IO io) -> [Integer, String]?
   def self.send_frame: (IO io, Integer cmd, ?String payload) -> void
   def self.read_exact: (IO io, Integer n) -> String?

--- a/mrbgems/picoruby-picomodem/sig/picomodem.rbs
+++ b/mrbgems/picoruby-picomodem/sig/picomodem.rbs
@@ -23,6 +23,7 @@ module PicoModem
 
   CHUNK_SIZE: Integer
   TIMEOUT_MS: Integer
+  MAX_FRAME_SIZE: Integer
   SESSION_IDLE_LIMIT: Integer
   PROTOCOL_VERSION: Integer
   CAPABILITIES: Array[Integer]
@@ -33,8 +34,8 @@ module PicoModem
   def self.recv_frame: (IO io) -> [Integer, String]?
   def self.send_frame: (IO io, Integer cmd, ?String payload) -> void
   def self.read_exact: (IO io, Integer n) -> String?
-  def self.handle_file_read: (IO io_in, IO io_out, String payload) -> void
-  def self.handle_file_write: (IO io_in, IO io_out, String payload) -> void
+  def self.handle_file_read: (IO io_in, IO io_out, String payload) -> bool
+  def self.handle_file_write: (IO io_in, IO io_out, String payload) -> bool
   def self.handle_dfu: (IO io_in, IO io_out, String payload) -> void
 end
 

--- a/mrbgems/picoruby-picomodem/sig/picomodem.rbs
+++ b/mrbgems/picoruby-picomodem/sig/picomodem.rbs
@@ -3,6 +3,8 @@ module PicoModem
   FILE_WRITE: Integer
   DFU_START: Integer
   CHUNK: Integer
+  SESSION_QUIT: Integer
+  SESSION_OPEN: Integer
   DONE: Integer
   ABORT: Integer
 
@@ -19,8 +21,10 @@ module PicoModem
 
   CHUNK_SIZE: Integer
   TIMEOUT_MS: Integer
+  SESSION_IDLE_LIMIT: Integer
 
   def self.session: (IO io_in, IO io_out) -> void
+  def self.run_session: (IO io_in, IO io_out) -> String?
   def self.recv_frame: (IO io) -> [Integer, String]?
   def self.send_frame: (IO io, Integer cmd, ?String payload) -> void
   def self.read_exact: (IO io, Integer n) -> String?

--- a/mrbgems/picoruby-picomodem/test/picomodem_test.rb
+++ b/mrbgems/picoruby-picomodem/test/picomodem_test.rb
@@ -61,6 +61,10 @@ class PicomodemSessionTest < Picotest::Test
     frames
   end
 
+  def supported?(bitmap, op)
+    (bitmap.getbyte(op >> 3) & (1 << (op & 7))) != 0
+  end
+
   # --- frame encode / parse ------------------------------------------------
 
   def test_recv_frame_roundtrip
@@ -172,5 +176,37 @@ class PicomodemSessionTest < Picotest::Test
     io = CaptureIO.new(build_frame(PicoModem::ABORT))
     info = PicoModem.run_session(io, io)
     assert_equal "abort", info
+  end
+
+  # --- capability check ----------------------------------------------------
+
+  # CMD_CAP replies with the version and a bitmap of the supported opcodes.
+  def test_capability_reports_supported_opcodes
+    io = CaptureIO.new(build_frame(PicoModem::CMD_CAP))
+    PicoModem.run_session(io, io)
+    frames = parse_frames(io.written)
+    assert_equal 1, frames.size
+    assert_equal PicoModem::CMD_CAP_FLAGS, frames[0][0]
+    payload = frames[0][1]
+    assert_equal PicoModem::PROTOCOL_VERSION, payload.getbyte(0)
+    bitmap = payload.byteslice(2, payload.getbyte(1))
+    assert_true supported?(bitmap, PicoModem::SESSION_OPEN)
+    assert_true supported?(bitmap, PicoModem::FILE_READ)
+    assert_false supported?(bitmap, PicoModem::DONE)
+  end
+
+  # A capability query works inside a session and does not end it.
+  def test_capability_in_session
+    io = CaptureIO.new(
+      build_frame(PicoModem::SESSION_OPEN) +
+      build_frame(PicoModem::CMD_CAP) +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    PicoModem.run_session(io, io)
+    frames = parse_frames(io.written)
+    assert_equal 3, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0]      # SESSION_OPEN ack
+    assert_equal PicoModem::CMD_CAP_FLAGS, frames[1][0] # capability response
+    assert_equal PicoModem::DONE_ACK, frames[2][0]      # SESSION_QUIT ack
   end
 end

--- a/mrbgems/picoruby-picomodem/test/picomodem_test.rb
+++ b/mrbgems/picoruby-picomodem/test/picomodem_test.rb
@@ -74,6 +74,15 @@ class PicomodemSessionTest < Picotest::Test
     assert_equal "app.rb", frame[1]
   end
 
+  # Line noise before a frame is skipped by scanning to the next STX.
+  def test_recv_frame_skips_leading_junk
+    junk = "\xFF\x00\x41\x7E"
+    io = CaptureIO.new(junk + build_frame(PicoModem::FILE_READ, "app.rb"))
+    frame = PicoModem.recv_frame(io)
+    assert_equal PicoModem::FILE_READ, frame[0]
+    assert_equal "app.rb", frame[1]
+  end
+
   def test_send_frame_roundtrip
     io = CaptureIO.new
     PicoModem.send_frame(io, PicoModem::DONE_ACK, [PicoModem::OK].pack("C"))
@@ -121,6 +130,22 @@ class PicomodemSessionTest < Picotest::Test
     frames = parse_frames(io.written)
     assert_equal 1, frames.size # only the SESSION_OPEN ack
     assert_equal PicoModem::DONE_ACK, frames[0][0]
+  end
+
+  # Noise between frames must not count toward SESSION_IDLE_LIMIT.
+  def test_session_survives_line_noise
+    junk = "\xFF" * (PicoModem::SESSION_IDLE_LIMIT + 4)
+    io = CaptureIO.new(
+      build_frame(PicoModem::SESSION_OPEN) +
+      junk +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    info = PicoModem.run_session(io, io)
+    assert_equal "session", info
+    frames = parse_frames(io.written)
+    assert_equal 2, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0] # SESSION_OPEN ack
+    assert_equal PicoModem::DONE_ACK, frames[1][0] # SESSION_QUIT ack, not a timeout
   end
 
   # Without a session, one unknown command gets ERROR and the loop returns.

--- a/mrbgems/picoruby-picomodem/test/picomodem_test.rb
+++ b/mrbgems/picoruby-picomodem/test/picomodem_test.rb
@@ -1,0 +1,176 @@
+# Tests for PicoModem multi-command sessions (issue #425). Each case ends with
+# SESSION_QUIT/ABORT or a one-shot command so recv_frame never blocks on EOF.
+
+# In-memory IO. read_nonblock replays a preloaded buffer, write captures output.
+class CaptureIO
+  def initialize(input = "")
+    @input = input.dup
+    @pos = 0
+    @written = ""
+  end
+
+  def written
+    @written
+  end
+
+  def feed(bytes)
+    @input << bytes
+    self
+  end
+
+  def read(n)
+    return nil if @input.bytesize <= @pos
+    chunk = @input.byteslice(@pos, n)
+    @pos += (chunk ? chunk.bytesize : 0)
+    chunk
+  end
+
+  def read_nonblock(n)
+    read(n)
+  end
+
+  def write(s)
+    str = s.to_s
+    @written << str
+    str.bytesize
+  end
+end
+
+class PicomodemSessionTest < Picotest::Test
+  description "PicoModem multi-command sessions"
+
+  # --- helpers -------------------------------------------------------------
+
+  def build_frame(cmd, payload = "")
+    body = [cmd].pack("C") + payload
+    [0x02, body.bytesize].pack("Cn") + body + [CRC.crc16(body)].pack("n")
+  end
+
+  def parse_frames(bytes)
+    frames = []
+    pos = 0
+    while pos < bytes.bytesize
+      break unless bytes.getbyte(pos) == 0x02
+      len = bytes.byteslice(pos + 1, 2).unpack("n")[0]
+      body = bytes.byteslice(pos + 3, len)
+      cmd = body.getbyte(0)
+      payload = len > 1 ? (body.byteslice(1, len - 1) || "") : ""
+      frames << [cmd, payload]
+      pos += 3 + len + 2
+    end
+    frames
+  end
+
+  # --- frame encode / parse ------------------------------------------------
+
+  def test_recv_frame_roundtrip
+    io = CaptureIO.new(build_frame(PicoModem::FILE_READ, "app.rb"))
+    frame = PicoModem.recv_frame(io)
+    assert_equal PicoModem::FILE_READ, frame[0]
+    assert_equal "app.rb", frame[1]
+  end
+
+  def test_send_frame_roundtrip
+    io = CaptureIO.new
+    PicoModem.send_frame(io, PicoModem::DONE_ACK, [PicoModem::OK].pack("C"))
+    frames = parse_frames(io.written)
+    assert_equal 1, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0]
+    assert_equal PicoModem::OK, frames[0][1].getbyte(0)
+  end
+
+  # --- session dispatch loop -----------------------------------------------
+
+  # SESSION_OPEN is acknowledged and SESSION_QUIT ends the session gracefully.
+  def test_session_open_and_quit
+    io = CaptureIO.new(build_frame(PicoModem::SESSION_OPEN) + build_frame(PicoModem::SESSION_QUIT))
+    info = PicoModem.run_session(io, io)
+    assert_equal "session", info
+    frames = parse_frames(io.written)
+    assert_equal 2, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0] # SESSION_OPEN ack
+    assert_equal PicoModem::OK, frames[0][1].getbyte(0)
+    assert_equal PicoModem::DONE_ACK, frames[1][0] # SESSION_QUIT ack
+  end
+
+  # A recoverable per-command error (unknown command) keeps the session open.
+  def test_unknown_command_continues_session
+    io = CaptureIO.new(
+      build_frame(PicoModem::SESSION_OPEN) +
+      build_frame(0x7F) +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    info = PicoModem.run_session(io, io)
+    assert_equal "session", info
+    frames = parse_frames(io.written)
+    assert_equal 3, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0] # SESSION_OPEN ack
+    assert_equal PicoModem::ERROR, frames[1][0]    # unknown command
+    assert_equal PicoModem::DONE_ACK, frames[2][0] # SESSION_QUIT ack (session survived)
+  end
+
+  # ABORT ends the session immediately, with no DONE ack.
+  def test_abort_ends_session
+    io = CaptureIO.new(build_frame(PicoModem::SESSION_OPEN) + build_frame(PicoModem::ABORT))
+    info = PicoModem.run_session(io, io)
+    assert_equal "session", info
+    frames = parse_frames(io.written)
+    assert_equal 1, frames.size # only the SESSION_OPEN ack
+    assert_equal PicoModem::DONE_ACK, frames[0][0]
+  end
+
+  # Without a session, one unknown command gets ERROR and the loop returns.
+  def test_single_command_mode_stops_after_one
+    io = CaptureIO.new(build_frame(0x7F) + build_frame(PicoModem::SESSION_OPEN))
+    PicoModem.run_session(io, io)
+    frames = parse_frames(io.written)
+    assert_equal 1, frames.size # ERROR only. The trailing SESSION_OPEN is never read
+    assert_equal PicoModem::ERROR, frames[0][0]
+  end
+
+  # A session dispatches many commands in one loop. Missing files make each
+  # FILE_READ answer ERROR, proving the loop keeps running until QUIT.
+  def test_session_dispatches_multiple_commands
+    stub(File).exist? { false }
+    io = CaptureIO.new(
+      build_frame(PicoModem::SESSION_OPEN) +
+      build_frame(PicoModem::FILE_READ, "a.rb") +
+      build_frame(PicoModem::FILE_READ, "b.rb") +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    PicoModem.run_session(io, io)
+    frames = parse_frames(io.written)
+    assert_equal 4, frames.size
+    assert_equal PicoModem::DONE_ACK, frames[0][0] # SESSION_OPEN ack
+    assert_equal PicoModem::ERROR, frames[1][0]    # FILE_READ a.rb (missing)
+    assert_equal PicoModem::ERROR, frames[2][0]    # FILE_READ b.rb (missing)
+    assert_equal PicoModem::DONE_ACK, frames[3][0] # SESSION_QUIT ack
+  end
+
+  # Outside a session a handled command still breaks after one.
+  def test_single_command_breaks_after_handler
+    stub(File).exist? { false }
+    io = CaptureIO.new(
+      build_frame(PicoModem::FILE_READ, "a.rb") +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    PicoModem.run_session(io, io)
+    frames = parse_frames(io.written)
+    assert_equal 1, frames.size # ERROR only. Trailing SESSION_QUIT is never read
+    assert_equal PicoModem::ERROR, frames[0][0]
+  end
+
+  # A stray SESSION_QUIT before any SESSION_OPEN still yields a non-empty status.
+  def test_quit_without_open_reports_status
+    io = CaptureIO.new(build_frame(PicoModem::SESSION_QUIT))
+    info = PicoModem.run_session(io, io)
+    assert_equal "quit", info
+  end
+
+  # A one-shot ABORT reports a status instead of nil.
+  def test_abort_without_session_reports_status
+    io = CaptureIO.new(build_frame(PicoModem::ABORT))
+    info = PicoModem.run_session(io, io)
+    assert_equal "abort", info
+  end
+end

--- a/mrbgems/picoruby-picomodem/test/picomodem_test.rb
+++ b/mrbgems/picoruby-picomodem/test/picomodem_test.rb
@@ -46,6 +46,13 @@ class PicomodemSessionTest < Picotest::Test
     [0x02, body.bytesize].pack("Cn") + body + [CRC.crc16(body)].pack("n")
   end
 
+  # A well-framed frame whose CRC is wrong, so recv_frame consumes it fully and
+  # returns nil instantly (no timeout wait).
+  def bad_crc_frame(cmd)
+    good = build_frame(cmd)
+    good.byteslice(0, good.bytesize - 1) + [good.getbyte(good.bytesize - 1) ^ 0xFF].pack("C")
+  end
+
   def parse_frames(bytes)
     frames = []
     pos = 0
@@ -90,6 +97,32 @@ class PicomodemSessionTest < Picotest::Test
     assert_equal 1, frames.size
     assert_equal PicoModem::DONE_ACK, frames[0][0]
     assert_equal PicoModem::OK, frames[0][1].getbyte(0)
+  end
+
+  # send_frame output (its own CRC) must decode back through recv_frame.
+  def test_send_frame_recv_frame_roundtrip
+    out = CaptureIO.new
+    PicoModem.send_frame(out, PicoModem::CMD_CAP_FLAGS, "\x01\x02")
+    frame = PicoModem.recv_frame(CaptureIO.new(out.written))
+    assert_equal PicoModem::CMD_CAP_FLAGS, frame[0]
+    assert_equal "\x01\x02", frame[1]
+  end
+
+  # The STX scan is bounded: a frame is found after CHUNK_SIZE junk bytes, but
+  # one more junk byte makes recv_frame give up with nil.
+  def test_recv_frame_bounds_junk_scan
+    frame = build_frame(PicoModem::CMD_CAP)
+    at_bound = CaptureIO.new(("\xFF" * PicoModem::CHUNK_SIZE) + frame)
+    assert_not_nil PicoModem.recv_frame(at_bound)
+    over_bound = CaptureIO.new(("\xFF" * (PicoModem::CHUNK_SIZE + 1)) + frame)
+    assert_nil PicoModem.recv_frame(over_bound)
+  end
+
+  # A bogus oversized length is rejected instead of allocating a huge read.
+  def test_recv_frame_rejects_oversized_length
+    big = PicoModem::MAX_FRAME_SIZE + 1
+    io = CaptureIO.new([0x02, big].pack("Cn") + "\x00")
+    assert_nil PicoModem.recv_frame(io)
   end
 
   # --- session dispatch loop -----------------------------------------------
@@ -146,6 +179,31 @@ class PicomodemSessionTest < Picotest::Test
     assert_equal 2, frames.size
     assert_equal PicoModem::DONE_ACK, frames[0][0] # SESSION_OPEN ack
     assert_equal PicoModem::DONE_ACK, frames[1][0] # SESSION_QUIT ack, not a timeout
+  end
+
+  # SESSION_IDLE_LIMIT consecutive recv failures end the session. A corrupt frame
+  # is an instant nil, so this needs no real waiting.
+  def test_session_ends_after_idle_limit
+    bad = bad_crc_frame(PicoModem::CMD_CAP)
+    io = CaptureIO.new(build_frame(PicoModem::SESSION_OPEN) + bad * PicoModem::SESSION_IDLE_LIMIT)
+    info = PicoModem.run_session(io, io)
+    assert_equal "session timeout", info
+  end
+
+  # A valid frame resets the idle counter: more than SESSION_IDLE_LIMIT total
+  # failures survive as long as a good frame lands before any run of 12.
+  def test_valid_frame_resets_idle
+    bad = bad_crc_frame(PicoModem::CMD_CAP)
+    n = PicoModem::SESSION_IDLE_LIMIT - 1
+    io = CaptureIO.new(
+      build_frame(PicoModem::SESSION_OPEN) +
+      bad * n +
+      build_frame(PicoModem::CMD_CAP) +
+      bad * n +
+      build_frame(PicoModem::SESSION_QUIT)
+    )
+    info = PicoModem.run_session(io, io)
+    assert_equal "capability", info
   end
 
   # Without a session, one unknown command gets ERROR and the loop returns.
@@ -215,8 +273,15 @@ class PicomodemSessionTest < Picotest::Test
     payload = frames[0][1]
     assert_equal PicoModem::PROTOCOL_VERSION, payload.getbyte(0)
     bitmap = payload.byteslice(2, payload.getbyte(1))
-    assert_true supported?(bitmap, PicoModem::SESSION_OPEN)
+    # Every advertised opcode is set...
     assert_true supported?(bitmap, PicoModem::FILE_READ)
+    assert_true supported?(bitmap, PicoModem::FILE_WRITE)
+    assert_true supported?(bitmap, PicoModem::DFU_START)
+    assert_true supported?(bitmap, PicoModem::CMD_CAP)
+    assert_true supported?(bitmap, PicoModem::SESSION_QUIT)
+    assert_true supported?(bitmap, PicoModem::SESSION_OPEN)
+    # ...and non-advertised opcodes are clear.
+    assert_false supported?(bitmap, PicoModem::CHUNK)
     assert_false supported?(bitmap, PicoModem::DONE)
   end
 

--- a/mrbgems/picoruby-wasm/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-wasm/mrblib/picomodem.rb
@@ -1,11 +1,13 @@
 module PicoModem
   # Command types (Host -> Device)
-  FILE_READ  = 0x01
-  FILE_WRITE = 0x02
-  DFU_START  = 0x03
-  CHUNK      = 0x04
-  DONE       = 0x0F
-  ABORT      = 0xFF
+  FILE_READ    = 0x01
+  FILE_WRITE   = 0x02
+  DFU_START    = 0x03
+  CHUNK        = 0x04
+  SESSION_QUIT = 0x0D
+  SESSION_OPEN = 0x0E
+  DONE         = 0x0F
+  ABORT        = 0xFF
 
   # Response types (Device -> Host) = request | 0x80
   FILE_DATA  = 0x81

--- a/mrbgems/picoruby-wasm/mrblib/picomodem.rb
+++ b/mrbgems/picoruby-wasm/mrblib/picomodem.rb
@@ -4,18 +4,20 @@ module PicoModem
   FILE_WRITE   = 0x02
   DFU_START    = 0x03
   CHUNK        = 0x04
+  CMD_CAP      = 0x0A
   SESSION_QUIT = 0x0D
   SESSION_OPEN = 0x0E
   DONE         = 0x0F
   ABORT        = 0xFF
 
   # Response types (Device -> Host) = request | 0x80
-  FILE_DATA  = 0x81
-  FILE_ACK   = 0x82
-  DFU_ACK    = 0x83
-  CHUNK_ACK  = 0x84
-  DONE_ACK   = 0x8F
-  ERROR      = 0xFE
+  FILE_DATA     = 0x81
+  FILE_ACK      = 0x82
+  DFU_ACK       = 0x83
+  CHUNK_ACK     = 0x84
+  CMD_CAP_FLAGS = 0x8A
+  DONE_ACK      = 0x8F
+  ERROR         = 0xFE
 
   # Status codes
   OK    = 0x00


### PR DESCRIPTION
`PicoModem.session` handles one command per `Ctrl-B` session and then returns to the shell, so a host operating the device filesystem pays a fixed ~200ms round-trip on every command.
This PR adds multi-command sessions and a capability check from #425. It is a first minimal step toward the filesystem commands in #425.

## Multi-command sessions

Multi-command sessions provide these behaviours:

- `SESSION_OPEN` (0x0E) enters the loop, acked with `DONE_ACK`.
- `SESSION_QUIT` (0x0D) ends it gracefully, acked with `DONE_ACK`, then the
  device returns to the shell.
- `ABORT` (0xFF) also ends the session, even mid-transfer.
- A recoverable per-command error returns `ERROR` and the loop keeps running.
- The idle timeout is extended while a session is open.

Outside a session nothing changes. The dispatch loop is extracted into `run_session` so it can run without a terminal. Every command emits exactly one terminal frame (`DONE_ACK` or `ERROR`).

## Capability check

A device may be running an older firmware, so a host needs to know what it supports before using new commands. `CMD_CAP` (0x0A) replies with `CMD_CAP_FLAGS` (0x8A), which includes a protocol version and a bitmap of the supported host->device opcodes.

## Frame reading

Previously, unexpected non-STX bytes caused `recv_frame` to return `nil`, triggering session timeouts in milliseconds instead of the intended 60s. To fix this, `recv_frame` now skips to the next STX. Because this makes the following length untrusted, frames exceeding `MAX_FRAME_SIZE` are rejected to prevent oversized reads.

## Testing

New `test/picomodem_test.rb` exercises `run_session` with an in-memory IO.

## Tasks

- [x] Multi-command sessions (`SESSION_OPEN` / `SESSION_QUIT`)
- [x] Capability check (`CMD_CAP` / `CMD_CAP_FLAGS`)
- [ ] Verify on real hardware
