### PR TITLE
Improve BLE::UART

### DIFF
--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -341,8 +341,13 @@ class BLE
 
       when HCI_EVENT_DISCONNECTION_COMPLETE
         debug_puts "Disconnected, re-scanning"
-        @on_disconnect&.call if @connected
+        # Reset state before invoking the hook so that user code inside
+        # on_disconnect sees the same disconnected state as the
+        # peripheral path (e.g. write drops instead of being accepted
+        # and then discarded by the reset).
+        was_connected = @connected
         _central_reset
+        @on_disconnect&.call if was_connected
         start_scan
         @uart_central_state = :TC_W4_SCAN_RESULT
 

--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -40,6 +40,13 @@ class BLE
 
     USER_BLOCK_INTERVAL_MS = 20
 
+    # Caps for the internal buffers. Without them, a stalled link (or
+    # an application that writes while nobody is connected) would let
+    # a buffer grow until memory runs out. Oldest bytes are dropped
+    # first; fresh data is more valuable for telemetry-style traffic.
+    TX_BUFFER_LIMIT = 1024
+    RX_BUFFER_LIMIT = 1024
+
     def initialize(role: :peripheral,
                    name: "RubyUART",
                    service_uuid: NUS_SERVICE_UUID,
@@ -51,6 +58,8 @@ class BLE
       @rx_buffer = ""
       @tx_buffer = ""
       @connected = false
+      @on_connect = nil
+      @on_disconnect = nil
       @notify_chunk_size = DEFAULT_ATT_MTU - 3
 
       if role == :peripheral
@@ -171,13 +180,32 @@ class BLE
 
     # --- IO interface (shared between peripheral and central) ---
 
+    # Registers a block called when a central subscribes (peripheral
+    # role) or the link becomes ready (central role).
+    def on_connect(&block)
+      @on_connect = block
+    end
+
+    # Registers a block called when an established link is lost.
+    def on_disconnect(&block)
+      @on_disconnect = block
+    end
+
+    # Writes data to the peer. Returns the number of bytes accepted.
+    # While disconnected the data is dropped and 0 is returned; nothing
+    # would ever drain the buffer, so hoarding it only wastes memory
+    # and would burst stale data at the peer on the next connection.
     def write(data)
       str = data.to_s
+      return 0 unless @connected
       @tx_buffer << str
+      if TX_BUFFER_LIMIT < @tx_buffer.bytesize
+        @tx_buffer = @tx_buffer.byteslice(-TX_BUFFER_LIMIT, TX_BUFFER_LIMIT) || ""
+      end
       if peripheral?
         _request_send
       else
-        _flush_tx_central if @connected
+        _flush_tx_central
       end
       str.bytesize
     end
@@ -228,17 +256,23 @@ class BLE
         debug_puts "UART Peripheral up on: `#{Utils.bd_addr_to_str(gap_local_bd_addr)}`"
         _start_advertise
       when HCI_EVENT_DISCONNECTION_COMPLETE
+        was_connected = @connected
         @connected = false
         @notification_enabled = false
         @advertising_started = false
         @notify_chunk_size = DEFAULT_ATT_MTU - 3
+        # Anything still queued belongs to the lost connection; flushing
+        # it to the next central would only deliver stale data.
+        @tx_buffer = ""
         debug_puts "Disconnected, re-advertising"
+        @on_disconnect&.call if was_connected
         _start_advertise
       when ATT_EVENT_MTU_EXCHANGE_COMPLETE
         @connected = true
         mtu = Utils.little_endian_to_int16(event_packet.byteslice(4, 2))
         @notify_chunk_size = mtu - 3 if mtu && mtu >= DEFAULT_ATT_MTU
         debug_puts "Connected (MTU=#{mtu}, chunk=#{@notify_chunk_size})"
+        @on_connect&.call
       when ATT_EVENT_CAN_SEND_NOW
         _flush_tx
       end
@@ -246,7 +280,14 @@ class BLE
 
     def _drain_rx
       while (data = pop_write_value(@rx_handle))
-        @rx_buffer << data
+        _push_rx(data)
+      end
+    end
+
+    def _push_rx(data)
+      @rx_buffer << data
+      if RX_BUFFER_LIMIT < @rx_buffer.bytesize
+        @rx_buffer = @rx_buffer.byteslice(-RX_BUFFER_LIMIT, RX_BUFFER_LIMIT) || ""
       end
     end
 
@@ -296,6 +337,7 @@ class BLE
 
       when HCI_EVENT_DISCONNECTION_COMPLETE
         debug_puts "Disconnected, re-scanning"
+        @on_disconnect&.call if @connected
         _central_reset
         start_scan
         @uart_central_state = :TC_W4_SCAN_RESULT
@@ -328,7 +370,7 @@ class BLE
         return unless value_handle == @peer_tx_handle
         value_length = Utils.little_endian_to_int16(event_packet.byteslice(6, 2))
         value = event_packet.byteslice(8, value_length)
-        @rx_buffer << value if value
+        _push_rx(value) if value
       end
     end
 
@@ -389,12 +431,14 @@ class BLE
           @connected = true
           @uart_central_state = :TC_READY
           debug_puts "NUS central ready"
+          @on_connect&.call
         end
       end
     end
 
     def _central_reset
       @connected = false
+      @tx_buffer = ""
       @conn_handle = HCI_CON_HANDLE_INVALID
       @peer_rx_handle = nil
       @peer_tx_handle = nil

--- a/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-ble-uart/mrblib/ble_uart.rb
@@ -191,7 +191,9 @@ class BLE
       @on_disconnect = block
     end
 
-    # Writes data to the peer. Returns the number of bytes accepted.
+    # Writes data to the peer. Returns the number of bytes of this
+    # call that remain queued after the TX_BUFFER_LIMIT cap is applied
+    # (older queued bytes are discarded first when the cap trims).
     # While disconnected the data is dropped and 0 is returned; nothing
     # would ever drain the buffer, so hoarding it only wastes memory
     # and would burst stale data at the peer on the next connection.
@@ -199,7 +201,9 @@ class BLE
       str = data.to_s
       return 0 unless @connected
       @tx_buffer << str
+      accepted = str.bytesize
       if TX_BUFFER_LIMIT < @tx_buffer.bytesize
+        accepted = TX_BUFFER_LIMIT if TX_BUFFER_LIMIT < accepted
         @tx_buffer = @tx_buffer.byteslice(-TX_BUFFER_LIMIT, TX_BUFFER_LIMIT) || ""
       end
       if peripheral?
@@ -207,7 +211,7 @@ class BLE
       else
         _flush_tx_central
       end
-      str.bytesize
+      accepted
     end
 
     def puts(data = "")

--- a/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-ble-uart/sig/ble_uart.rbs
@@ -29,6 +29,9 @@ class BLE
 
     USER_BLOCK_INTERVAL_MS: Integer
 
+    TX_BUFFER_LIMIT: Integer
+    RX_BUFFER_LIMIT: Integer
+
     # peripheral-only state
     @adv_data: String
     @rx_handle: Integer
@@ -54,6 +57,8 @@ class BLE
     @connected: bool
     @notify_chunk_size: Integer
     @user_block: (^() -> void | nil)
+    @on_connect: (^() -> void | nil)
+    @on_disconnect: (^() -> void | nil)
 
     def initialize: (
       ?role: :peripheral | :central,
@@ -66,6 +71,8 @@ class BLE
     def heartbeat_callback: () -> void
     def packet_callback: (String event_packet) -> void
 
+    def on_connect: () ?{ () -> void } -> void
+    def on_disconnect: () ?{ () -> void } -> void
     def write: (untyped data) -> Integer
     def puts: (?untyped data) -> nil
     def read_nonblock: (?Integer nbytes) -> (String | nil)
@@ -82,6 +89,7 @@ class BLE
     private def _central_reset: () -> void
     private def _flush_tx_central: () -> void
     private def _drain_rx: () -> void
+    private def _push_rx: (String data) -> void
     private def _check_cccd: () -> void
     private def _request_send: () -> void
     private def _flush_tx: () -> void

--- a/mrbgems/picoruby-iir_filter/mrblib/iir_filter.rb
+++ b/mrbgems/picoruby-iir_filter/mrblib/iir_filter.rb
@@ -15,11 +15,9 @@ class IIRFilter
     if raw_value < (@filterd_value - FILTER_FEEDFORWARD) || (@filterd_value + FILTER_FEEDFORWARD) < raw_value
       # Pass the filter input as it is for fast changes in input
       @filterd_value = raw_value
-      puts "case 1 filterd_value: #{@filterd_value}"
     else
       # If not the first sample then based on filter coefficient, filter the input signal
       @filterd_value += (raw_value - @filterd_value) >> COEFF_SHIFT
-      puts "case 2 filterd_value: #{@filterd_value}"
     end
     # Compensate filter result for left shift of 8 and round off
     return (@filterd_value >> MAX_COEFF_SHIFT) + ((@filterd_value >> MAX_COEFF_SHIFT - 1) & 1)

--- a/mrbgems/picoruby-wasm/mrblib/ble_gatt.rb
+++ b/mrbgems/picoruby-wasm/mrblib/ble_gatt.rb
@@ -163,10 +163,14 @@ module JS
 
         # Register a notification callback.
         # The block receives binary String data on each notification.
+        # Returns a callback id that can be passed to
+        # JS::Object._close_event_queue to end the consumer, e.g. when
+        # re-registering after a reconnect.
         def on_change(&block)
           callback_id = block.object_id
           JS::Object._spawn_event_consumer(callback_id, block)
           JS::BLE._set_notify_handler(@js_char, callback_id)
+          callback_id
         end
 
         # Start receiving notifications.

--- a/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
@@ -12,39 +12,54 @@ module JS
 
       DEFAULT_TIMEOUT = nil
 
+      # Cap for the receive buffer. If the application stops reading,
+      # oldest bytes are dropped first instead of growing forever.
+      RX_BUFFER_LIMIT = 8192
+
       attr_reader :device
 
       # Connect to a BLE UART device.
+      # By default the browser chooser only lists devices advertising
+      # service_uuid; pass filter_by_service: false to list everything
+      # (some peripherals do not advertise the service UUID).
       def initialize(service_uuid: NUS_SERVICE_UUID,
                      tx_uuid: NUS_TX_CHAR_UUID,
                      rx_uuid: NUS_RX_CHAR_UUID,
-                     name: nil, name_prefix: nil)
+                     name: nil, name_prefix: nil,
+                     filter_by_service: true)
+        @service_uuid = service_uuid
+        @tx_uuid = tx_uuid
+        @rx_uuid = rx_uuid
+        @on_disconnect = nil
         @device = GATT.request_device(
           name: name,
           name_prefix: name_prefix,
+          services: filter_by_service ? [service_uuid] : nil,
           optional_services: [service_uuid]
         )
 
         @buffer = ""
-        @server = @device.connect # steep:ignore
-        @service = @server.service(service_uuid) # steep:ignore
-        @tx_char = @service.characteristic(tx_uuid) # steep:ignore
-
-        if tx_uuid == rx_uuid
-          @rx_char = @tx_char
-        else
-          @rx_char = @service.characteristic(rx_uuid) # steep:ignore
-        end
-
-        @rx_char.on_change do |data| # steep:ignore
-          @buffer << data
-        end
-        @rx_char.start_notify # steep:ignore
-
         @device.on_disconnected do # steep:ignore
           @connected = false
+          @on_disconnect&.call
         end
-        @connected = true
+        _connect
+      end
+
+      # Registers a block called when the connection is lost.
+      def on_disconnect(&block)
+        @on_disconnect = block
+      end
+
+      # Reconnect to the same device without showing the browser
+      # chooser again (the permission granted by the first chooser is
+      # remembered by Web Bluetooth). Use this to recover from a
+      # dropped link or after #close.
+      def reconnect
+        return self if connected?
+        @buffer = ""
+        _connect
+        self
       end
 
       # Write string data to the TX characteristic.
@@ -109,12 +124,40 @@ module JS
         @connected && @device.connected? # steep:ignore
       end
 
-      # Disconnect and clean up.
+      # Disconnect and clean up. The device reference is kept, so
+      # #reconnect can re-establish the link without a new chooser.
       def close
         @rx_char.stop_notify # steep:ignore
         @device.disconnect # steep:ignore
         @connected = false
         @buffer = ""
+      end
+
+      private
+
+      def _connect
+        @server = @device.connect # steep:ignore
+        @service = @server.service(@service_uuid) # steep:ignore
+        @tx_char = @service.characteristic(@tx_uuid) # steep:ignore
+
+        if @tx_uuid == @rx_uuid
+          @rx_char = @tx_char
+        else
+          @rx_char = @service.characteristic(@rx_uuid) # steep:ignore
+        end
+
+        @rx_char.on_change do |data| # steep:ignore
+          _push_rx(data)
+        end
+        @rx_char.start_notify # steep:ignore
+        @connected = true
+      end
+
+      def _push_rx(data)
+        @buffer << data
+        if RX_BUFFER_LIMIT < @buffer.bytesize
+          @buffer = @buffer.byteslice(-RX_BUFFER_LIMIT, RX_BUFFER_LIMIT) || ""
+        end
       end
     end
   end

--- a/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
@@ -31,6 +31,7 @@ module JS
         @tx_uuid = tx_uuid
         @rx_uuid = rx_uuid
         @on_disconnect = nil
+        @rx_callback_id = nil
         @device = GATT.request_device(
           name: name,
           name_prefix: name_prefix,
@@ -131,6 +132,7 @@ module JS
         @device.disconnect # steep:ignore
         @connected = false
         @buffer = ""
+        _close_rx_consumer
       end
 
       private
@@ -146,11 +148,24 @@ module JS
           @rx_char = @service.characteristic(@rx_uuid) # steep:ignore
         end
 
-        @rx_char.on_change do |data| # steep:ignore
+        # End the previous notification consumer before installing a
+        # new one; otherwise every reconnect would leak a consumer task.
+        # The JS-side listener uses replace semantics, so re-registering
+        # on the same characteristic cannot stack handlers either.
+        _close_rx_consumer
+        @rx_callback_id = @rx_char.on_change do |data| # steep:ignore
           _push_rx(data)
         end
         @rx_char.start_notify # steep:ignore
         @connected = true
+      end
+
+      def _close_rx_consumer
+        callback_id = @rx_callback_id
+        if callback_id
+          JS::Object._close_event_queue(callback_id)
+          @rx_callback_id = nil
+        end
       end
 
       def _push_rx(data)

--- a/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
+++ b/mrbgems/picoruby-wasm/mrblib/ble_uart.rb
@@ -30,6 +30,8 @@ module JS
         @service_uuid = service_uuid
         @tx_uuid = tx_uuid
         @rx_uuid = rx_uuid
+        @connected = false
+        @on_connect = nil
         @on_disconnect = nil
         @rx_callback_id = nil
         @device = GATT.request_device(
@@ -42,9 +44,20 @@ module JS
         @buffer = ""
         @device.on_disconnected do # steep:ignore
           @connected = false
+          # Also end the notification consumer here so an unexpected
+          # disconnect does not leave the task running until the next
+          # reconnect (which may never come).
+          _close_rx_consumer
           @on_disconnect&.call
         end
         _connect
+      end
+
+      # Registers a block called after the link is (re-)established.
+      # The initial connection happens inside #initialize, so in
+      # practice this fires on successful #reconnect.
+      def on_connect(&block)
+        @on_connect = block
       end
 
       # Registers a block called when the connection is lost.
@@ -158,6 +171,7 @@ module JS
         end
         @rx_char.start_notify # steep:ignore
         @connected = true
+        @on_connect&.call
       end
 
       def _close_rx_consumer

--- a/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
@@ -69,7 +69,7 @@ module JS
         def write: (String data, ?without_response: bool) -> void
 
         # Register a notification callback (data is binary String)
-        def on_change: () { (String data) -> void } -> void
+        def on_change: () { (String data) -> void } -> Integer
 
         # Start receiving notifications
         def start_notify: () -> void

--- a/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_gatt.rbs
@@ -16,7 +16,7 @@ module JS
       def self.request_device: (
         ?name: String,
         ?name_prefix: String,
-        ?services: ::Array[String],
+        ?services: ::Array[String]?,
         ?optional_services: ::Array[String]
       ) -> JS::BLE::GATT::Device?
 

--- a/mrbgems/picoruby-wasm/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_uart.rbs
@@ -18,6 +18,7 @@ module JS
       @buffer: String
       @connected: bool
       @on_disconnect: (^() -> void | nil)
+      @rx_callback_id: Integer?
 
       # Connect to a BLE UART device
       def initialize: (
@@ -64,6 +65,7 @@ module JS
       def close: () -> void
 
       private def _connect: () -> void
+      private def _close_rx_consumer: () -> void
       private def _push_rx: (String data) -> void
     end
   end

--- a/mrbgems/picoruby-wasm/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_uart.rbs
@@ -9,14 +9,31 @@ module JS
       # Default read timeout in seconds (nil = block forever)
       DEFAULT_TIMEOUT: Integer?
 
+      # Cap for the receive buffer (oldest bytes dropped first)
+      RX_BUFFER_LIMIT: Integer
+
+      @service_uuid: String
+      @tx_uuid: String
+      @rx_uuid: String
+      @buffer: String
+      @connected: bool
+      @on_disconnect: (^() -> void | nil)
+
       # Connect to a BLE UART device
       def initialize: (
         ?service_uuid: String,
         ?tx_uuid: String,
         ?rx_uuid: String,
         ?name: String,
-        ?name_prefix: String
+        ?name_prefix: String,
+        ?filter_by_service: bool
       ) -> void
+
+      # Registers a block called when the connection is lost
+      def on_disconnect: () ?{ () -> void } -> void
+
+      # Reconnect to the same device without a new browser chooser
+      def reconnect: () -> self
 
       # Write string data to the TX characteristic
       # Returns the number of bytes written
@@ -45,6 +62,9 @@ module JS
 
       # Disconnect and clean up
       def close: () -> void
+
+      private def _connect: () -> void
+      private def _push_rx: (String data) -> void
     end
   end
 end

--- a/mrbgems/picoruby-wasm/sig/ble_uart.rbs
+++ b/mrbgems/picoruby-wasm/sig/ble_uart.rbs
@@ -17,6 +17,7 @@ module JS
       @rx_uuid: String
       @buffer: String
       @connected: bool
+      @on_connect: (^() -> void | nil)
       @on_disconnect: (^() -> void | nil)
       @rx_callback_id: Integer?
 
@@ -29,6 +30,9 @@ module JS
         ?name_prefix: String,
         ?filter_by_service: bool
       ) -> void
+
+      # Registers a block called after the link is (re-)established
+      def on_connect: () ?{ () -> void } -> void
 
       # Registers a block called when the connection is lost
       def on_disconnect: () ?{ () -> void } -> void

--- a/mrbgems/picoruby-wasm/src/mruby/ble.c
+++ b/mrbgems/picoruby-wasm/src/mruby/ble.c
@@ -74,11 +74,17 @@ EM_JS(int, ble_create_uint8array, (const uint8_t *data, int length), {
   }
 });
 
-/* Set up characteristicvaluechanged listener with binary data extraction */
+/* Set up characteristicvaluechanged listener with binary data extraction.
+ * Replace semantics: registering again on the same characteristic removes
+ * the previous listener first, so reconnect flows cannot stack handlers
+ * and duplicate received data. */
 EM_JS(void, ble_set_notify_handler, (int char_ref_id, uintptr_t callback_id), {
   try {
     const char_obj = globalThis.picorubyRefs[char_ref_id];
-    char_obj.addEventListener('characteristicvaluechanged', (event) => {
+    if (char_obj.__picorbNotifyListener) {
+      char_obj.removeEventListener('characteristicvaluechanged', char_obj.__picorbNotifyListener);
+    }
+    const listener = (event) => {
       const dataview = event.target.value;
       const len = dataview.byteLength;
       const ptr = _malloc(len);
@@ -92,7 +98,9 @@ EM_JS(void, ble_set_notify_handler, (int char_ref_id, uintptr_t callback_id), {
         [callback_id, ptr, len]
       );
       _free(ptr);
-    });
+    };
+    char_obj.__picorbNotifyListener = listener;
+    char_obj.addEventListener('characteristicvaluechanged', listener);
   } catch(e) {
     console.error('ble_set_notify_handler failed:', e);
   }


### PR DESCRIPTION
This pull request introduces several improvements to the BLE UART implementations for both the embedded and WASM environments. The main changes focus on adding buffer size limits to prevent memory exhaustion, providing connection lifecycle hooks (such as `on_connect` and `on_disconnect`), and improving API ergonomics for reconnections and device filtering. Type signatures have been updated to reflect these new features.

**BLE UART buffer management and connection lifecycle enhancements:**

* Added buffer size limits (`TX_BUFFER_LIMIT` and `RX_BUFFER_LIMIT`) in `ble_uart.rb` for both transmit and receive buffers to prevent unbounded memory growth; oldest bytes are dropped when limits are exceeded. [[1]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R43-R49) [[2]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R259-R290) [[3]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6L331-R373) [[4]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbR15-R62) [[5]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbL112-R161)
* Introduced `on_connect` and `on_disconnect` hooks in the BLE UART classes, allowing users to register callbacks for connection and disconnection events. These hooks are invoked appropriately in both peripheral and central roles. [[1]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R61-R62) [[2]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R183-R208) [[3]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R259-R290) [[4]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R340) [[5]](diffhunk://#diff-d3bb08ad285171ca824440c24ba1d59409aa35b5e8d80de1c1acd68c211f93d6R434-R441) [[6]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbR15-R62) [[7]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbL112-R161)

**WASM BLE UART API improvements:**

* Added `reconnect` method to the WASM BLE UART class to allow reconnecting to a previously paired device without prompting the browser chooser again. [[1]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbR15-R62) [[2]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbL112-R161)
* Added `filter_by_service` option to the WASM BLE UART initializer, enabling device discovery with or without filtering by service UUID. [[1]](diffhunk://#diff-ecfe4a9869205d970832934cc83ae70e52570e0098dfb536dca6dd7458fe47bbR15-R62) [[2]](diffhunk://#diff-e889f6ee3958cf175871b8b820025e841808b5a0b623200ca01a5d6e7f4d003eL19-R19)

**Type signature updates:**

* Updated `.rbs` type signature files to reflect new buffer limits, connection hooks, new methods (`on_connect`, `on_disconnect`, `reconnect`), and updated constructor parameters. [[1]](diffhunk://#diff-4eab2252815ff3edda46defd1ce07019477a47ec75aed53b76d7f2eb748dd693R32-R34) [[2]](diffhunk://#diff-4eab2252815ff3edda46defd1ce07019477a47ec75aed53b76d7f2eb748dd693R60-R61) [[3]](diffhunk://#diff-4eab2252815ff3edda46defd1ce07019477a47ec75aed53b76d7f2eb748dd693R74-R75) [[4]](diffhunk://#diff-4eab2252815ff3edda46defd1ce07019477a47ec75aed53b76d7f2eb748dd693R92) [[5]](diffhunk://#diff-dc3776de13679fc05824b2c2a27179b25c43f98508848d2d9aa7b808f3aec21bR12-R37) [[6]](diffhunk://#diff-dc3776de13679fc05824b2c2a27179b25c43f98508848d2d9aa7b808f3aec21bR65-R67) [[7]](diffhunk://#diff-e889f6ee3958cf175871b8b820025e841808b5a0b623200ca01a5d6e7f4d003eL19-R19)

**Other improvements:**

* Removed debug `puts` statements from the IIR filter implementation to reduce console noise.