### PR TITLE
Fix per-instance memory leaks in BLE._init

### DIFF
--- a/mrbgems/picoruby-ble/mrblib/ble.rb
+++ b/mrbgems/picoruby-ble/mrblib/ble.rb
@@ -79,6 +79,11 @@ class BLE
     @role = role
     @debug = false
     @event_queue = Task::Queue.new
+    # Value stores accessed from the C layer (BTstack callbacks).
+    # They live as instance variables so the GC can reclaim them
+    # together with this instance.
+    @write_values = {}
+    @read_values = {}
     unless CYW43.init
       puts "Failed to initialize CYW43"
       return # raising an exception here may cause a crash

--- a/mrbgems/picoruby-ble/ports/rp2040/ble.c
+++ b/mrbgems/picoruby-ble/ports/rp2040/ble.c
@@ -153,6 +153,9 @@ BLE_init(const uint8_t *profile_data, int ble_role)
       att_server_register_packet_handler(packet_handler);
       break;
     case BLE_ROLE_BROADCASTER:
+      /* Clear any ATT database left over from a previous peripheral
+       * init so BLE_init() never keeps a stale profile pointer. */
+      att_server_init(NULL, NULL, NULL);
       att_server_register_packet_handler(packet_handler);
       break;
     case BLE_ROLE_OBSERVER:

--- a/mrbgems/picoruby-ble/sig/ble.rbs
+++ b/mrbgems/picoruby-ble/sig/ble.rbs
@@ -68,6 +68,8 @@ class BLE
   @led_on: bool
   @ensure_proc: Proc
   @event_queue: Task::Queue
+  @write_values: Hash[Integer, Array[String]]
+  @read_values: Hash[Integer, String]
 
   type role_t = :central | :peripheral | :observer | :broadcaster
   attr_accessor debug: bool

--- a/mrbgems/picoruby-ble/src/ble.c
+++ b/mrbgems/picoruby-ble/src/ble.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <string.h>
 #include "picoruby.h"
 #include "../include/ble.h"
 #include "../include/ble_central.h"

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -158,12 +158,11 @@ mrb__init(mrb_state *mrb, mrb_value self)
     if (new_profile) mrb_free(mrb, new_profile);
     mrb_raise(mrb, E_RUNTIME_ERROR, "BLE init failed");
   }
-  if (new_profile) {
-    /* The previous profile is unreferenced once BLE_init() has
-     * installed the new one. */
-    if (profile_buf) mrb_free(mrb, profile_buf);
-    profile_buf = new_profile;
-  }
+  /* BLE_init() replaces the ATT database for every role (possibly
+   * with no database), so the previous profile is unreferenced now
+   * and must be released even when the new role has none. */
+  if (profile_buf) mrb_free(mrb, profile_buf);
+  profile_buf = new_profile;
 
   /* The value hashes are created in ble.rb as instance variables so
    * the GC keeps them alive through the pinned instance. */

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -5,10 +5,24 @@
 #include "mruby/array.h"
 #include "task.h"
 
+/*
+ * GC strategy: only the current BLE instance is pinned with
+ * mrb_gc_register (BTstack is a hardware singleton, so there is at
+ * most one). The event queue and the value hashes are instance
+ * variables of that instance, so they stay alive through it and get
+ * collected together with it when the next _init unpins it. The
+ * statics below are mere caches for the BTstack callbacks; they are
+ * always backed by the pinned instance, so they cannot dangle.
+ */
 static mrb_state *_mrb = NULL;
+static mrb_value registered_ble;
+static bool ble_registered = false;
 static mrb_value write_values;
 static mrb_value read_values;
 static mrb_value event_queue;
+/* C-heap copy of the GATT profile. BTstack keeps a raw pointer to it
+ * indefinitely, which is why it is not owned by a Ruby object. */
+static uint8_t *profile_buf = NULL;
 static uint8_t pending_event_count;
 
 #define BLE_MAX_PENDING_EVENTS 16
@@ -108,18 +122,7 @@ mrb_push_read_value(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb__init(mrb_state *mrb, mrb_value self)
 {
-  _mrb = mrb;
-  event_queue = mrb_iv_get(mrb, self, MRB_IVSYM(event_queue));
-  mrb_gc_register(mrb, event_queue);
-  pending_event_count = 0;
-  write_values = mrb_hash_new(mrb);
-  mrb_gc_register(mrb, write_values);
-  read_values = mrb_hash_new(mrb);
-  mrb_gc_register(mrb, read_values);
-
   mrb_value profile;
-  mrb_value profile_copy = mrb_nil_value();
-  const uint8_t *profile_data = NULL;
   mrb_get_args(mrb, "o", &profile);
 
   if (!mrb_string_p(profile) && !mrb_nil_p(profile)) {
@@ -143,16 +146,52 @@ mrb__init(mrb_state *mrb, mrb_value self)
     default:
       mrb_raise(mrb, E_TYPE_ERROR, "BLE._init: wrong role type");
   }
+
+  uint8_t *new_profile = NULL;
+  size_t new_profile_len = 0;
   if (ble_role == BLE_ROLE_PERIPHERAL && mrb_string_p(profile)) {
-    profile_copy = mrb_str_dup(mrb, profile);
-    profile_data = (const uint8_t *)RSTRING_PTR(profile_copy);
+    new_profile_len = (size_t)RSTRING_LEN(profile);
+    new_profile = (uint8_t *)mrb_malloc(mrb, new_profile_len);
+    memcpy(new_profile, RSTRING_PTR(profile), new_profile_len);
   }
-  if (BLE_init(profile_data, ble_role) < 0) {
+  if (BLE_init(new_profile, ble_role) < 0) {
+    if (new_profile) mrb_free(mrb, new_profile);
     mrb_raise(mrb, E_RUNTIME_ERROR, "BLE init failed");
   }
-  if (!mrb_nil_p(profile_copy)) {
-    /* BTstack keeps profile_data by pointer after BLE_init(). */
-    mrb_gc_register(mrb, profile_copy);
+  if (new_profile) {
+    /* The previous profile is unreferenced once BLE_init() has
+     * installed the new one. */
+    if (profile_buf) mrb_free(mrb, profile_buf);
+    profile_buf = new_profile;
+  }
+
+  /* The value hashes are created in ble.rb as instance variables so
+   * the GC keeps them alive through the pinned instance. */
+  mrb_value new_write_values = mrb_iv_get(mrb, self, MRB_IVSYM(write_values));
+  mrb_value new_read_values = mrb_iv_get(mrb, self, MRB_IVSYM(read_values));
+  if (!mrb_hash_p(new_write_values) || !mrb_hash_p(new_read_values)) {
+    mrb_raise(mrb, E_TYPE_ERROR, "BLE._init: value hashes not initialized");
+  }
+
+  /* Pin the new instance before unpinning the previous one so the
+   * statics never point into an unpinned object graph. */
+  mrb_value prev_ble = registered_ble;
+  bool release_prev = ble_registered;
+  mrb_gc_register(mrb, self);
+  registered_ble = self;
+  ble_registered = true;
+
+  _mrb = mrb;
+  event_queue = mrb_iv_get(mrb, self, MRB_IVSYM(event_queue));
+  write_values = new_write_values;
+  read_values = new_read_values;
+  pending_event_count = 0;
+
+  /* The object identity check matters: mrb_gc_unregister removes ALL
+   * occurrences of an object, so unregistering self here would undo
+   * the pin above if _init ever ran twice on one instance. */
+  if (release_prev && !mrb_obj_eq(mrb, prev_ble, self)) {
+    mrb_gc_unregister(mrb, prev_ble);
   }
   return self;
 }
@@ -194,4 +233,10 @@ mrb_picoruby_ble_gem_init(mrb_state* mrb)
 void
 mrb_picoruby_ble_gem_final(mrb_state* mrb)
 {
+  if (profile_buf) {
+    mrb_free(mrb, profile_buf);
+    profile_buf = NULL;
+  }
+  ble_registered = false;
+  _mrb = NULL;
 }

--- a/mrbgems/picoruby-ble/src/mruby/ble.c
+++ b/mrbgems/picoruby-ble/src/mruby/ble.c
@@ -173,10 +173,17 @@ mrb__init(mrb_state *mrb, mrb_value self)
   }
 
   /* Pin the new instance before unpinning the previous one so the
-   * statics never point into an unpinned object graph. */
+   * statics never point into an unpinned object graph. The identity
+   * check keeps the pin count at exactly one even if _init runs
+   * twice on the same instance: registering again would stack a
+   * duplicate, and mrb_gc_unregister removes ALL occurrences, so
+   * unregistering self would undo the pin instead. */
   mrb_value prev_ble = registered_ble;
-  bool release_prev = ble_registered;
-  mrb_gc_register(mrb, self);
+  bool same_instance = ble_registered && mrb_obj_eq(mrb, prev_ble, self);
+  bool release_prev = ble_registered && !same_instance;
+  if (!same_instance) {
+    mrb_gc_register(mrb, self);
+  }
   registered_ble = self;
   ble_registered = true;
 
@@ -186,10 +193,7 @@ mrb__init(mrb_state *mrb, mrb_value self)
   read_values = new_read_values;
   pending_event_count = 0;
 
-  /* The object identity check matters: mrb_gc_unregister removes ALL
-   * occurrences of an object, so unregistering self here would undo
-   * the pin above if _init ever ran twice on one instance. */
-  if (release_prev && !mrb_obj_eq(mrb, prev_ble, self)) {
+  if (release_prev) {
     mrb_gc_unregister(mrb, prev_ble);
   }
   return self;

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -1,6 +1,9 @@
 static mrbc_value write_values = {.tt = MRBC_TT_NIL};
 static mrbc_value read_values = {.tt = MRBC_TT_NIL};
 static mrbc_value event_queue = {.tt = MRBC_TT_NIL};
+/* C-heap copy of the GATT profile. BTstack keeps a raw pointer to it
+ * indefinitely, which is why it is not owned by a Ruby object. */
+static uint8_t *profile_buf = NULL;
 static uint8_t pending_event_count;
 
 #define BLE_MAX_PENDING_EVENTS 16
@@ -113,14 +116,6 @@ c_push_read_value(mrbc_vm *vm, mrbc_value *v, int argc)
 static void
 c__init(mrbc_vm *vm, mrbc_value *v, int argc)
 {
-  if (event_queue.tt != MRBC_TT_NIL) mrbc_decref(&event_queue);
-  event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
-  pending_event_count = 0;
-  write_values = mrbc_hash_new(vm, 0);
-  read_values = mrbc_hash_new(vm, 0);
-
-  mrbc_value profile_copy = mrbc_nil_value();
-  const uint8_t *profile_data = NULL;
   if (GET_TT_ARG(1) != MRBC_TT_STRING && GET_TT_ARG(1) != MRBC_TT_NIL) {
     mrbc_raise(vm, MRBC_CLASS(TypeError), "BLE._init: wrong argument type");
     return;
@@ -139,19 +134,48 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     mrbc_raise(vm, MRBC_CLASS(TypeError), "BLE._init: wrong role type");
     return;
   }
+
+  uint8_t *new_profile = NULL;
   if (ble_role == BLE_ROLE_PERIPHERAL && GET_TT_ARG(1) == MRBC_TT_STRING) {
-    profile_copy = mrbc_string_dup(vm, &v[1]);
-    profile_data = (uint8_t *)mrbc_string_cstr(&profile_copy);
+    /* Copy the profile to the C heap. BTstack keeps a raw pointer to
+     * it, so a refcounted Ruby string is the wrong owner (the old
+     * code leaked one copy per BLE.new). */
+    int len = v[1].string->size;
+    new_profile = mrbc_raw_alloc(len + 1);
+    if (new_profile == NULL) {
+      mrbc_raise(vm, MRBC_CLASS(RuntimeError), "BLE._init: no memory");
+      return;
+    }
+    memcpy(new_profile, v[1].string->data, len);
+    new_profile[len] = 0;
   }
   Machine_tud_task();
-  if (BLE_init(profile_data, ble_role) < 0) {
-    if (profile_copy.tt == MRBC_TT_STRING) {
-      mrbc_decref(&profile_copy);
-    }
+  if (BLE_init(new_profile, ble_role) < 0) {
+    if (new_profile) mrbc_raw_free(new_profile);
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "BLE init failed");
     return;
   }
-  /* Keep profile_copy's initial reference count for BTstack's profile_data pointer. */
+  if (new_profile) {
+    /* The previous profile is unreferenced once BLE_init() has
+     * installed the new one. */
+    if (profile_buf) mrbc_raw_free(profile_buf);
+    profile_buf = new_profile;
+  }
+
+  /* Take references to the new instance's objects, then release the
+   * previous instance's ones (mrbc_instance_getiv increfs). The
+   * swap order keeps the statics valid at every point. */
+  mrbc_value prev_event_queue = event_queue;
+  mrbc_value prev_write_values = write_values;
+  mrbc_value prev_read_values = read_values;
+  event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
+  write_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("write_values"));
+  read_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("read_values"));
+  pending_event_count = 0;
+  mrbc_decref(&prev_event_queue);
+  mrbc_decref(&prev_write_values);
+  mrbc_decref(&prev_read_values);
+
   Machine_tud_task();
 }
 

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -164,12 +164,24 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
   /* Take references to the new instance's objects, then release the
    * previous instance's ones (mrbc_instance_getiv increfs). The
    * swap order keeps the statics valid at every point. */
+  mrbc_value new_event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
+  mrbc_value new_write_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("write_values"));
+  mrbc_value new_read_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("read_values"));
+  if (new_write_values.tt != MRBC_TT_HASH || new_read_values.tt != MRBC_TT_HASH) {
+    /* The value hashes are created in ble.rb; a wrong type here
+     * would crash the callbacks later. Release the getiv refs. */
+    mrbc_decref(&new_event_queue);
+    mrbc_decref(&new_write_values);
+    mrbc_decref(&new_read_values);
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "BLE._init: value hashes not initialized");
+    return;
+  }
   mrbc_value prev_event_queue = event_queue;
   mrbc_value prev_write_values = write_values;
   mrbc_value prev_read_values = read_values;
-  event_queue = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("event_queue"));
-  write_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("write_values"));
-  read_values = mrbc_instance_getiv(&v[0], mrbc_str_to_symid("read_values"));
+  event_queue = new_event_queue;
+  write_values = new_write_values;
+  read_values = new_read_values;
   pending_event_count = 0;
   mrbc_decref(&prev_event_queue);
   mrbc_decref(&prev_write_values);

--- a/mrbgems/picoruby-ble/src/mrubyc/ble.c
+++ b/mrbgems/picoruby-ble/src/mrubyc/ble.c
@@ -155,12 +155,11 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     mrbc_raise(vm, MRBC_CLASS(RuntimeError), "BLE init failed");
     return;
   }
-  if (new_profile) {
-    /* The previous profile is unreferenced once BLE_init() has
-     * installed the new one. */
-    if (profile_buf) mrbc_raw_free(profile_buf);
-    profile_buf = new_profile;
-  }
+  /* BLE_init() replaces the ATT database for every role (possibly
+   * with no database), so the previous profile is unreferenced now
+   * and must be released even when the new role has none. */
+  if (profile_buf) mrbc_raw_free(profile_buf);
+  profile_buf = new_profile;
 
   /* Take references to the new instance's objects, then release the
    * previous instance's ones (mrbc_instance_getiv increfs). The


### PR DESCRIPTION
Every BLE.new leaked its event queue, both value hashes, and the GATT profile copy for the VM's lifetime, so repeatedly running and stopping a BLE script on R2P2 eventually ran out of memory.

- mruby: the four mrb_gc_register calls had no matching mrb_gc_unregister. Now only the current BLE instance is pinned and the previous one is unpinned on re-init; the value hashes became instance variables so they are reclaimed with the instance.
- mruby/c: write_values/read_values were overwritten without releasing the previous hashes, and the profile string kept its reference for BTstack. The statics now take instance variable references and release the previous ones on re-init.
- The GATT profile is copied to the C heap (BTstack keeps a raw pointer to it indefinitely), freed when the next BLE_init replaces it.