### PR TITLE
Add DHCP-backed CYW43 access point mode

### DIFF
--- a/mrbgems/picoruby-cyw43/README.md
+++ b/mrbgems/picoruby-cyw43/README.md
@@ -35,6 +35,24 @@ CYW43.disconnect
 CYW43.disable_sta_mode
 ```
 
+### Access Point Mode
+
+```ruby
+require "cyw43"
+
+CYW43.init("JP")
+CYW43.enable_ap_mode("PicoRuby-AP", "12345678")
+
+puts "AP started"
+puts "AP active?: #{CYW43.ap_active?}"
+puts "AP SSID: #{CYW43.ap_ssid}"
+puts "AP IP: #{CYW43.ap_ipv4_address}"
+puts "AP netmask: #{CYW43.ap_ipv4_netmask}"
+```
+
+The access point uses Pico SDK's default `192.168.4.0/24` network. A minimal
+DHCP server assigns addresses from `192.168.4.2` through `192.168.4.5`.
+
 ## API
 
 ### CYW43 Module Methods
@@ -43,12 +61,18 @@ CYW43.disable_sta_mode
 - `CYW43.initialized?()` - Check if initialized
 - `CYW43.enable_sta_mode()` - Enable station mode
 - `CYW43.disable_sta_mode()` - Disable station mode
+- `CYW43.enable_ap_mode(ssid, password, auth = CYW43::Auth::WPA2_AES_PSK)` - Enable access point mode
+- `CYW43.disable_ap_mode()` - Disable access point mode
 - `CYW43.connect_timeout(ssid, password, auth, timeout_ms)` - Connect to WiFi with timeout
 - `CYW43.disconnect()` - Disconnect from WiFi
 - `CYW43.link_connected?(print_status = false)` - Check connection status
 - `CYW43.tcpip_link_status()` - Get link status code
 - `CYW43.tcpip_link_status_name()` - Get link status name
 - `CYW43.dhcp_supplied?()` - Check if DHCP supplied IP
+- `CYW43.ap_active?()` - Check whether AP mode is currently enabled
+- `CYW43.ap_ssid()` - Get the active AP SSID
+- `CYW43.ap_ipv4_address()` - Get AP-side IPv4 address
+- `CYW43.ap_ipv4_netmask()` - Get AP-side IPv4 netmask
 
 ### Authentication Types
 
@@ -80,3 +104,6 @@ CYW43.disable_sta_mode
 - Specific to Raspberry Pi Pico W and similar boards
 - Country code affects allowed WiFi channels
 - Timeout is in milliseconds
+- `enable_ap_mode` starts a minimal DHCP-backed AP on the default `192.168.4.0/24` network
+- PicoRuby exposes AP-side active/SSID state and AP-side IPv4 information, but not custom AP IP configuration or DHCP control yet
+- See `mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb` for the minimal AP sample

--- a/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
+++ b/mrbgems/picoruby-cyw43/example/pico_w_ap_mode.rb
@@ -1,0 +1,23 @@
+require "cyw43"
+
+# Minimal AP mode example for Pico W / Pico 2 W.
+
+CYW43.init("JP")
+unless CYW43.enable_ap_mode("PicoRuby-AP", "12345678")
+  raise "failed to enable AP mode"
+end
+
+puts "AP started"
+puts "AP active?: #{CYW43.ap_active?}"
+puts "AP SSID: #{CYW43.ap_ssid || 'unknown'}"
+puts "AP IP: #{CYW43.ap_ipv4_address || 'unassigned'}"
+puts "AP netmask: #{CYW43.ap_ipv4_netmask || 'unassigned'}"
+
+led = CYW43::GPIO.new(CYW43::GPIO::LED_PIN)
+
+loop do
+  led.write(1)
+  sleep 0.5
+  led.write(0)
+  sleep 0.5
+end

--- a/mrbgems/picoruby-cyw43/include/cyw43.h
+++ b/mrbgems/picoruby-cyw43/include/cyw43.h
@@ -14,10 +14,15 @@ void CYW43_arch_deinit(void);
 #ifdef USE_WIFI
 void CYW43_arch_enable_sta_mode(void);
 void CYW43_arch_disable_sta_mode(void);
+bool CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth);
+void CYW43_arch_disable_ap_mode(void);
 int CYW43_wifi_connect_with_dhcp(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms);
 int CYW43_wifi_disconnect(void);
 int CYW43_tcpip_link_status(void);
 bool CYW43_dhcp_supplied(void);
+bool CYW43_ap_active(void);
+const char *CYW43_ap_ssid(char *buf, size_t buflen);
+int CYW43_CONST_auth_wpa2_aes_psk(void);
 int CYW43_CONST_link_down(void);
 int CYW43_CONST_link_join(void);
 int CYW43_CONST_link_noip(void);
@@ -30,6 +35,8 @@ extern void lwip_end(void);
 const char *CYW43_ipv4_address(char *buf, size_t buflen);
 const char *CYW43_ipv4_netmask(char *buf, size_t buflen);
 const char *CYW43_ipv4_gateway(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_address(char *buf, size_t buflen);
+const char *CYW43_ap_ipv4_netmask(char *buf, size_t buflen);
 #endif
 void CYW43_GPIO_write(uint8_t, uint8_t);
 uint8_t CYW43_GPIO_read(uint8_t pin);
@@ -39,4 +46,3 @@ uint8_t CYW43_GPIO_read(uint8_t pin);
 #endif
 
 #endif /* CYW43_DEFINED_H_ */
-

--- a/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.c
@@ -1,0 +1,473 @@
+/*
+ * Minimal DHCP server for PicoRuby CYW43 AP mode.
+ *
+ * Adapted from TinyUSB's networking helpers.
+ * Copyright (c) 2015 Sergey Fetisov <fsenok@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "../../include/cyw43.h"
+#include "ap_dhcp_server.h"
+
+#include "pico/cyw43_arch.h"
+#include "pico/time.h"
+#include "lwip/pbuf.h"
+#include "lwip/udp.h"
+#include "lwip/netif.h"
+#include "lwip/ip_addr.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define AP_DHCP_SERVER_PORT 67
+#define AP_DHCP_CLIENT_PORT 68
+#define AP_DHCP_MAX_LEASES 4
+#define AP_DHCP_FIRST_HOST 2
+#define AP_DHCP_OFFER_HOLD_SEC 60
+#define AP_DHCP_LEASE_TIME_SEC (24 * 60 * 60)
+
+enum ap_dhcp_message_type {
+  AP_DHCP_DISCOVER = 1,
+  AP_DHCP_OFFER = 2,
+  AP_DHCP_REQUEST = 3,
+  AP_DHCP_ACK = 5,
+  AP_DHCP_RELEASE = 7,
+};
+
+enum ap_dhcp_option {
+  AP_DHCP_OPT_PAD = 0,
+  AP_DHCP_OPT_SUBNET_MASK = 1,
+  AP_DHCP_OPT_ROUTER = 3,
+  AP_DHCP_OPT_IP_ADDRESS = 50,
+  AP_DHCP_OPT_LEASE_TIME = 51,
+  AP_DHCP_OPT_MESSAGE_TYPE = 53,
+  AP_DHCP_OPT_SERVER_ID = 54,
+  AP_DHCP_OPT_END = 255,
+};
+
+typedef struct {
+  uint8_t mac[6];
+  ip4_addr_t addr;
+  uint32_t lease_sec;
+  uint64_t expires_at_ms;
+} ap_dhcp_lease_t;
+
+typedef struct {
+  uint8_t op;
+  uint8_t htype;
+  uint8_t hlen;
+  uint8_t hops;
+  uint32_t xid;
+  uint16_t secs;
+  uint16_t flags;
+  uint8_t ciaddr[4];
+  uint8_t yiaddr[4];
+  uint8_t siaddr[4];
+  uint8_t giaddr[4];
+  uint8_t chaddr[16];
+  uint8_t legacy[192];
+  uint8_t magic[4];
+  uint8_t options[275];
+} ap_dhcp_packet_t;
+
+static struct udp_pcb *s_dhcp_pcb = NULL;
+static ap_dhcp_lease_t s_leases[AP_DHCP_MAX_LEASES];
+static ip4_addr_t s_router;
+
+static const uint8_t s_magic_cookie[4] = {0x63, 0x82, 0x53, 0x63};
+
+static uint64_t
+ap_dhcp_now_ms(void)
+{
+  return to_us_since_boot(get_absolute_time()) / 1000;
+}
+
+static void
+ap_dhcp_set_ip(uint8_t *dest, ip4_addr_t addr)
+{
+  memcpy(dest, &addr.addr, sizeof(addr.addr));
+}
+
+static ip4_addr_t
+ap_dhcp_get_ip(const uint8_t *src)
+{
+  ip4_addr_t addr;
+  memcpy(&addr.addr, src, sizeof(addr.addr));
+  return addr;
+}
+
+static void
+ap_dhcp_release_lease(ap_dhcp_lease_t *lease)
+{
+  memset(lease->mac, 0, sizeof(lease->mac));
+  lease->expires_at_ms = 0;
+}
+
+static bool
+ap_dhcp_lease_vacant(ap_dhcp_lease_t *lease)
+{
+  static const uint8_t zero_mac[6] = {0};
+
+  if (memcmp(lease->mac, zero_mac, sizeof(zero_mac)) == 0) {
+    return true;
+  }
+  if (lease->expires_at_ms <= ap_dhcp_now_ms()) {
+    ap_dhcp_release_lease(lease);
+    return true;
+  }
+  return false;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_lease_by_mac(const uint8_t *mac)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (ap_dhcp_lease_vacant(&s_leases[i])) {
+      continue;
+    }
+    if (memcmp(s_leases[i].mac, mac, 6) == 0) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_lease_by_ip(ip4_addr_t ip)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (s_leases[i].addr.addr == ip.addr) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static ap_dhcp_lease_t *
+ap_dhcp_find_vacant_lease(void)
+{
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    if (ap_dhcp_lease_vacant(&s_leases[i])) {
+      return &s_leases[i];
+    }
+  }
+  return NULL;
+}
+
+static uint8_t *
+ap_dhcp_find_option(uint8_t *options, size_t options_len, uint8_t code)
+{
+  size_t i = 0;
+
+  while (i < options_len) {
+    uint8_t opt = options[i];
+    if (opt == AP_DHCP_OPT_END) {
+      break;
+    }
+    if (opt == AP_DHCP_OPT_PAD) {
+      i++;
+      continue;
+    }
+    if (i + 1 >= options_len) {
+      break;
+    }
+
+    uint8_t opt_len = options[i + 1];
+    if (i + 2 + opt_len > options_len) {
+      break;
+    }
+    if (opt == code) {
+      return &options[i];
+    }
+    i += 2 + opt_len;
+  }
+
+  return NULL;
+}
+
+static size_t
+ap_dhcp_fill_options(
+  uint8_t *dest,
+  uint8_t msg_type,
+  uint32_t lease_sec,
+  ip4_addr_t server_id,
+  ip4_addr_t router,
+  ip4_addr_t subnet_mask
+)
+{
+  uint8_t *ptr = dest;
+
+  *ptr++ = AP_DHCP_OPT_MESSAGE_TYPE;
+  *ptr++ = 1;
+  *ptr++ = msg_type;
+
+  *ptr++ = AP_DHCP_OPT_SERVER_ID;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, server_id);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_LEASE_TIME;
+  *ptr++ = 4;
+  *ptr++ = (lease_sec >> 24) & 0xff;
+  *ptr++ = (lease_sec >> 16) & 0xff;
+  *ptr++ = (lease_sec >> 8) & 0xff;
+  *ptr++ = lease_sec & 0xff;
+
+  *ptr++ = AP_DHCP_OPT_SUBNET_MASK;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, subnet_mask);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_ROUTER;
+  *ptr++ = 4;
+  ap_dhcp_set_ip(ptr, router);
+  ptr += 4;
+
+  *ptr++ = AP_DHCP_OPT_END;
+
+  return (size_t)(ptr - dest);
+}
+
+static err_t
+ap_dhcp_send_reply(
+  struct udp_pcb *pcb,
+  struct netif *ap_netif,
+  ap_dhcp_packet_t *packet,
+  uint8_t msg_type,
+  ap_dhcp_lease_t *lease
+)
+{
+  size_t options_len;
+  size_t payload_len;
+  struct pbuf *pbuf;
+
+  packet->op = 2; /* BOOTREPLY */
+  packet->secs = 0;
+  packet->flags = 0;
+  memset(packet->ciaddr, 0, sizeof(packet->ciaddr));
+  ap_dhcp_set_ip(packet->yiaddr, lease->addr);
+  ap_dhcp_set_ip(packet->siaddr, *netif_ip4_addr(ap_netif));
+  memcpy(packet->magic, s_magic_cookie, sizeof(s_magic_cookie));
+  memset(packet->options, 0, sizeof(packet->options));
+
+  options_len = ap_dhcp_fill_options(
+    packet->options,
+    msg_type,
+    lease->lease_sec,
+    *netif_ip4_addr(ap_netif),
+    s_router,
+    *netif_ip4_netmask(ap_netif)
+  );
+
+  payload_len = offsetof(ap_dhcp_packet_t, options) + options_len;
+  pbuf = pbuf_alloc(PBUF_TRANSPORT, payload_len, PBUF_RAM);
+  if (!pbuf) {
+    return ERR_MEM;
+  }
+
+  memcpy(pbuf->payload, packet, payload_len);
+  err_t err = udp_sendto_if_src(
+    pcb,
+    pbuf,
+    IP_ADDR_BROADCAST,
+    AP_DHCP_CLIENT_PORT,
+    ap_netif,
+    netif_ip_addr4(ap_netif)
+  );
+  pbuf_free(pbuf);
+  return err;
+}
+
+static void
+ap_dhcp_udp_recv(void *arg, struct udp_pcb *pcb, struct pbuf *pbuf, const ip_addr_t *addr, u16_t port)
+{
+  ap_dhcp_packet_t packet;
+  ap_dhcp_lease_t *lease = NULL;
+  struct netif *ap_netif;
+  uint8_t *msg_type_opt;
+  size_t packet_len;
+  size_t options_len;
+  const size_t options_offset = offsetof(ap_dhcp_packet_t, options);
+
+  (void)addr;
+
+  if (!pbuf || port != AP_DHCP_CLIENT_PORT || pbuf->tot_len < options_offset) {
+    if (pbuf) {
+      pbuf_free(pbuf);
+    }
+    return;
+  }
+
+  ap_netif = (struct netif *)arg;
+  if (!ap_netif || ap_netif != &cyw43_state.netif[CYW43_ITF_AP]) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  memset(&packet, 0, sizeof(packet));
+  packet_len = pbuf_copy_partial(pbuf, &packet, LWIP_MIN((u16_t)sizeof(packet), pbuf->tot_len), 0);
+  if (packet_len < options_offset) {
+    pbuf_free(pbuf);
+    return;
+  }
+  options_len = packet_len - options_offset;
+
+  if (packet.op != 1 || packet.htype != 1 || packet.hlen != 6 ||
+      memcmp(packet.magic, s_magic_cookie, sizeof(s_magic_cookie)) != 0) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  msg_type_opt = ap_dhcp_find_option(packet.options, options_len, AP_DHCP_OPT_MESSAGE_TYPE);
+  if (!msg_type_opt || msg_type_opt[1] != 1) {
+    pbuf_free(pbuf);
+    return;
+  }
+
+  switch (msg_type_opt[2]) {
+    case AP_DHCP_DISCOVER:
+      lease = ap_dhcp_find_lease_by_mac(packet.chaddr);
+      if (!lease) {
+        lease = ap_dhcp_find_vacant_lease();
+        if (lease) {
+          memcpy(lease->mac, packet.chaddr, 6);
+          lease->expires_at_ms = ap_dhcp_now_ms() + (uint64_t)AP_DHCP_OFFER_HOLD_SEC * 1000;
+        }
+      }
+      if (lease) {
+        ap_dhcp_send_reply(pcb, ap_netif, &packet, AP_DHCP_OFFER, lease);
+      }
+      break;
+
+    case AP_DHCP_REQUEST: {
+      ap_dhcp_lease_t *current_lease = ap_dhcp_find_lease_by_mac(packet.chaddr);
+      uint8_t *server_id_opt = ap_dhcp_find_option(packet.options, options_len, AP_DHCP_OPT_SERVER_ID);
+      uint8_t *requested_ip_opt = ap_dhcp_find_option(packet.options, options_len, AP_DHCP_OPT_IP_ADDRESS);
+      ip4_addr_t requested_ip = ap_dhcp_get_ip(packet.ciaddr);
+
+      if (server_id_opt &&
+          (server_id_opt[1] != 4 ||
+           ap_dhcp_get_ip(server_id_opt + 2).addr != netif_ip4_addr(ap_netif)->addr)) {
+        break;
+      }
+      if (requested_ip_opt) {
+        if (requested_ip_opt[1] != 4) {
+          break;
+        }
+        requested_ip = ap_dhcp_get_ip(requested_ip_opt + 2);
+      }
+      if (requested_ip.addr == 0) {
+        break;
+      }
+
+      lease = ap_dhcp_find_lease_by_ip(requested_ip);
+      if (!lease || (lease != current_lease && !ap_dhcp_lease_vacant(lease))) {
+        break;
+      }
+      if (current_lease && current_lease != lease) {
+        ap_dhcp_release_lease(current_lease);
+      }
+      memcpy(lease->mac, packet.chaddr, 6);
+      lease->expires_at_ms = ap_dhcp_now_ms() + (uint64_t)lease->lease_sec * 1000;
+      ap_dhcp_send_reply(pcb, ap_netif, &packet, AP_DHCP_ACK, lease);
+      break;
+    }
+
+    case AP_DHCP_RELEASE:
+      lease = ap_dhcp_find_lease_by_mac(packet.chaddr);
+      if (lease) {
+        ap_dhcp_release_lease(lease);
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  pbuf_free(pbuf);
+}
+
+bool
+picoruby_ap_dhcp_server_start(void)
+{
+  struct netif *ap_netif = &cyw43_state.netif[CYW43_ITF_AP];
+  const ip4_addr_t *ap_ip;
+  const ip4_addr_t *ap_mask;
+  uint32_t network;
+
+  lwip_begin();
+
+  if ((cyw43_state.itf_state & (1 << CYW43_ITF_AP)) == 0) {
+    lwip_end();
+    return false;
+  }
+  ap_ip = netif_ip4_addr(ap_netif);
+  ap_mask = netif_ip4_netmask(ap_netif);
+  if (!ap_ip || !ap_mask || ap_ip->addr == 0 || ap_mask->addr == 0) {
+    lwip_end();
+    return false;
+  }
+
+  if (s_dhcp_pcb) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+  }
+
+  memset(s_leases, 0, sizeof(s_leases));
+  s_router = *ap_ip;
+  network = lwip_ntohl(ap_ip->addr) & lwip_ntohl(ap_mask->addr);
+
+  for (size_t i = 0; i < AP_DHCP_MAX_LEASES; i++) {
+    s_leases[i].addr.addr = lwip_htonl(network | (AP_DHCP_FIRST_HOST + (uint32_t)i));
+    s_leases[i].lease_sec = AP_DHCP_LEASE_TIME_SEC;
+  }
+
+  s_dhcp_pcb = udp_new();
+  if (!s_dhcp_pcb) {
+    lwip_end();
+    return false;
+  }
+
+  ip_set_option(s_dhcp_pcb, SOF_BROADCAST);
+  if (udp_bind(s_dhcp_pcb, IP_ADDR_ANY, AP_DHCP_SERVER_PORT) != ERR_OK) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+    lwip_end();
+    return false;
+  }
+
+  udp_bind_netif(s_dhcp_pcb, ap_netif);
+  udp_recv(s_dhcp_pcb, ap_dhcp_udp_recv, ap_netif);
+
+  lwip_end();
+  return true;
+}
+
+void
+picoruby_ap_dhcp_server_stop(void)
+{
+  lwip_begin();
+  if (s_dhcp_pcb) {
+    udp_remove(s_dhcp_pcb);
+    s_dhcp_pcb = NULL;
+  }
+  memset(s_leases, 0, sizeof(s_leases));
+  lwip_end();
+}

--- a/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.h
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/ap_dhcp_server.h
@@ -1,0 +1,9 @@
+#ifndef PICORUBY_CYW43_AP_DHCP_SERVER_H
+#define PICORUBY_CYW43_AP_DHCP_SERVER_H
+
+#include <stdbool.h>
+
+bool picoruby_ap_dhcp_server_start(void);
+void picoruby_ap_dhcp_server_stop(void);
+
+#endif /* PICORUBY_CYW43_AP_DHCP_SERVER_H */

--- a/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
+++ b/mrbgems/picoruby-cyw43/ports/rp2040/cyw43.c
@@ -1,10 +1,15 @@
 #include "../../include/cyw43.h"
+#include "ap_dhcp_server.h"
 
 #include <string.h>
 
 #include "pico/cyw43_arch.h"
 #include "lwip/dhcp.h"
 #include "lwip/netif.h"
+
+#define CYW43_AP_MAX_SSID_LEN 32
+#define CYW43_AP_MIN_PASSWORD_LEN 8
+#define CYW43_AP_MAX_PASSWORD_LEN 64
 
 int
 CYW43_CONST_link_down(void)
@@ -61,6 +66,39 @@ CYW43_dhcp_supplied(void)
   return dhcp_supplied_address(netif);
 }
 
+bool
+CYW43_ap_active(void)
+{
+  return (cyw43_state.itf_state & (1 << CYW43_ITF_AP)) != 0;
+}
+
+const char *
+CYW43_ap_ssid(char *buf, size_t buflen)
+{
+  size_t ssid_len = 0;
+  const uint8_t *ssid = NULL;
+
+  if (!CYW43_ap_active() || buflen == 0) {
+    return NULL;
+  }
+
+  cyw43_wifi_ap_get_ssid(&cyw43_state, &ssid_len, &ssid);
+  if (!ssid || ssid_len == 0) {
+    return NULL;
+  }
+
+  size_t copy_len = ssid_len < (buflen - 1) ? ssid_len : (buflen - 1);
+  memcpy(buf, ssid, copy_len);
+  buf[copy_len] = '\0';
+  return buf;
+}
+
+int
+CYW43_CONST_auth_wpa2_aes_psk(void)
+{
+  return CYW43_AUTH_WPA2_AES_PSK;
+}
+
 int
 CYW43_arch_init_with_country(const uint8_t *country)
 {
@@ -86,6 +124,7 @@ CYW43_arch_init_with_country(const uint8_t *country)
 void
 CYW43_arch_deinit(void)
 {
+  picoruby_ap_dhcp_server_stop();
   cyw43_arch_deinit();
 }
 
@@ -99,6 +138,33 @@ void
 CYW43_arch_disable_sta_mode(void)
 {
   cyw43_arch_disable_sta_mode();
+}
+
+bool
+CYW43_arch_enable_ap_mode(const char *ssid, const char *pw, uint32_t auth)
+{
+  size_t ssid_len = ssid ? strlen(ssid) : 0;
+  size_t password_len = pw ? strlen(pw) : 0;
+
+  if (ssid_len == 0 || CYW43_AP_MAX_SSID_LEN < ssid_len ||
+      password_len < CYW43_AP_MIN_PASSWORD_LEN || CYW43_AP_MAX_PASSWORD_LEN < password_len) {
+    return false;
+  }
+
+  cyw43_arch_enable_ap_mode(ssid, pw, auth);
+  if (!CYW43_ap_active() || !picoruby_ap_dhcp_server_start()) {
+    picoruby_ap_dhcp_server_stop();
+    cyw43_arch_disable_ap_mode();
+    return false;
+  }
+  return true;
+}
+
+void
+CYW43_arch_disable_ap_mode(void)
+{
+  picoruby_ap_dhcp_server_stop();
+  cyw43_arch_disable_ap_mode();
 }
 
 /* Response shape of CYW43_IOCTL_GET_SSID (wlc_ssid_t; cyw43_ll.h defines
@@ -168,47 +234,89 @@ CYW43_GPIO_read(uint8_t pin)
   return(cyw43_arch_gpio_get(pin) ? 1 : 0);
 }
 
-const char *
-CYW43_ipv4_address(char *buf, size_t buflen)
+static const char *
+cyw43_ipv4_address_for_if(int itf, char *buf, size_t buflen)
 {
   const char *res;
   lwip_begin();
-  const ip4_addr_t *ip = netif_ip4_addr(netif_default);
-  if (ip && ip->addr != 0) {
-    res = ipaddr_ntoa_r(ip, buf, buflen);
-  } else {
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
     res = NULL;
+  } else {
+    const ip4_addr_t *ip = netif_ip4_addr(&cyw43_state.netif[itf]);
+    if (ip && ip->addr != 0) {
+      res = ipaddr_ntoa_r(ip, buf, buflen);
+    } else {
+      res = NULL;
+    }
   }
   lwip_end();
   return res;
+}
+
+static const char *
+cyw43_ipv4_netmask_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *netmask = netif_ip4_netmask(&cyw43_state.netif[itf]);
+    if (netmask && netmask->addr != 0) {
+      res = ipaddr_ntoa_r(netmask, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+static const char *
+cyw43_ipv4_gateway_for_if(int itf, char *buf, size_t buflen)
+{
+  const char *res;
+  lwip_begin();
+  if ((cyw43_state.itf_state & (1 << itf)) == 0) {
+    res = NULL;
+  } else {
+    const ip4_addr_t *gateway = netif_ip4_gw(&cyw43_state.netif[itf]);
+    if (gateway && gateway->addr != 0) {
+      res = ipaddr_ntoa_r(gateway, buf, buflen);
+    } else {
+      res = NULL;
+    }
+  }
+  lwip_end();
+  return res;
+}
+
+const char *
+CYW43_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_netmask(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *netmask = netif_ip4_netmask(netif_default);
-  if (netmask && netmask->addr != 0) {
-    res = ipaddr_ntoa_r(netmask, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_STA, buf, buflen);
 }
 
 const char *
 CYW43_ipv4_gateway(char *buf, size_t buflen)
 {
-  const char *res;
-  lwip_begin();
-  const ip4_addr_t *gateway = netif_ip4_gw(netif_default);
-  if (gateway && gateway->addr != 0) {
-    res = ipaddr_ntoa_r(gateway, buf, buflen);
-  } else {
-    res = NULL;
-  }
-  lwip_end();
-  return res;
+  return cyw43_ipv4_gateway_for_if(CYW43_ITF_STA, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_address(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_address_for_if(CYW43_ITF_AP, buf, buflen);
+}
+
+const char *
+CYW43_ap_ipv4_netmask(char *buf, size_t buflen)
+{
+  return cyw43_ipv4_netmask_for_if(CYW43_ITF_AP, buf, buflen);
 }

--- a/mrbgems/picoruby-cyw43/sig/cyw43.rbs
+++ b/mrbgems/picoruby-cyw43/sig/cyw43.rbs
@@ -19,6 +19,8 @@ class CYW43
   def self.disconnect: () -> bool
   def self.enable_sta_mode: () -> bool
   def self.disable_sta_mode: () -> bool
+  def self.enable_ap_mode: (String ssid, String password, ?Integer auth) -> bool
+  def self.disable_ap_mode: () -> bool
   def self.tcpip_link_status: () -> Integer
   def self.tcpip_link_status_name: () -> String
   def self.dhcp_supplied?: () -> bool
@@ -26,6 +28,10 @@ class CYW43
   def self.ipv4_address: () -> (String | nil)
   def self.ipv4_netmask: () -> (String | nil)
   def self.ipv4_gateway: () -> (String | nil)
+  def self.ap_active?: () -> bool
+  def self.ap_ssid: () -> (String | nil)
+  def self.ap_ipv4_address: () -> (String | nil)
+  def self.ap_ipv4_netmask: () -> (String | nil)
   private def self._init: (String | nil country, bool force) -> bool
 
   # @sidebar hardware_device

--- a/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mruby/cyw43.c
@@ -41,6 +41,7 @@ mrb_s_initialized_p(mrb_state *mrb, mrb_value klass)
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 
 static mrb_value
 mrb_s_enable_sta_mode(mrb_state *mrb, mrb_value klass)
@@ -73,6 +74,42 @@ mrb_s_disable_sta_mode(mrb_state *mrb, mrb_value klass)
 }
 
 static bool cyw43_arch_connected = false;
+
+static mrb_value
+mrb_s_enable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  const char *ssid;
+  const char *pass;
+  mrb_int auth = CYW43_CONST_auth_wpa2_aes_psk();
+  mrb_get_args(mrb, "zz|i", &ssid, &pass, &auth);
+  if (!cyw43_arch_ap_mode_enabled) {
+    if (CYW43_arch_enable_ap_mode(ssid, pass, auth)) {
+      cyw43_arch_ap_mode_enabled = true;
+      return mrb_true_value();
+    }
+  } else {
+    return mrb_false_value();
+  }
+  return mrb_false_value();
+}
+
+static mrb_value
+mrb_s_disable_ap_mode(mrb_state *mrb, mrb_value klass)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
+    return mrb_true_value();
+  } else {
+    return mrb_false_value();
+  }
+}
 
 static mrb_value
 mrb_s_connect_timeout(mrb_state *mrb, mrb_value klass)
@@ -193,6 +230,58 @@ mrb_cyw43_s_ipv4_gateway(mrb_state *mrb, mrb_value self)
     return mrb_str_new_cstr(mrb, gateway_str);
   }
 }
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_address(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char addr_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(addr_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, addr_str);
+  }
+}
+
+static mrb_value
+mrb_cyw43_s_ap_active_p(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    return mrb_false_value();
+  }
+  return mrb_bool_value(CYW43_ap_active());
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ssid(mrb_state *mrb, mrb_value self)
+{
+  char ssid[33] = {0};
+
+  if (!cyw43_arch_init_flag) {
+    return mrb_nil_value();
+  }
+  if (!CYW43_ap_ssid(ssid, sizeof(ssid))) {
+    return mrb_nil_value();
+  }
+  return mrb_str_new_cstr(mrb, ssid);
+}
+
+static mrb_value
+mrb_cyw43_s_ap_ipv4_netmask(mrb_state *mrb, mrb_value self)
+{
+  if (!cyw43_arch_init_flag) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "CYW43 not initialized");
+  }
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    return mrb_nil_value();
+  } else {
+    return mrb_str_new_cstr(mrb, netmask_str);
+  }
+}
+
 #endif
 
 static mrb_value
@@ -224,6 +313,8 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
 #ifdef USE_WIFI
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_sta_mode), mrb_s_enable_sta_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_sta_mode), mrb_s_disable_sta_mode, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(enable_ap_mode), mrb_s_enable_ap_mode, MRB_ARGS_ARG(2, 1));
+  mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disable_ap_mode), mrb_s_disable_ap_mode, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(connect_timeout), mrb_s_connect_timeout, MRB_ARGS_ARG(3, 1));
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(disconnect), mrb_s_disconnect, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(tcpip_link_status), mrb_s_tcpip_link_status, MRB_ARGS_NONE());
@@ -231,6 +322,10 @@ mrb_picoruby_cyw43_gem_init(mrb_state* mrb)
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_address), mrb_cyw43_s_ipv4_address, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_netmask), mrb_cyw43_s_ipv4_netmask, MRB_ARGS_NONE());
   mrb_define_class_method_id(mrb, class_CYW43, MRB_SYM(ipv4_gateway), mrb_cyw43_s_ipv4_gateway, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_active?"), mrb_cyw43_s_ap_active_p, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ssid"), mrb_cyw43_s_ap_ssid, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_address"), mrb_cyw43_s_ap_ipv4_address, MRB_ARGS_NONE());
+  mrb_define_class_method_id(mrb, class_CYW43, mrb_intern_lit(mrb, "ap_ipv4_netmask"), mrb_cyw43_s_ap_ipv4_netmask, MRB_ARGS_NONE());
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_DOWN), mrb_fixnum_value(CYW43_CONST_link_down()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_JOIN), mrb_fixnum_value(CYW43_CONST_link_join()));
   mrb_define_const_id(mrb, class_CYW43, MRB_SYM(LINK_NOIP), mrb_fixnum_value(CYW43_CONST_link_noip()));

--- a/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
+++ b/mrbgems/picoruby-cyw43/src/mrubyc/cyw43.c
@@ -9,6 +9,7 @@ static bool cyw43_arch_init_flag = false;
 
 #ifdef USE_WIFI
 static bool cyw43_arch_sta_mode_enabled = false;
+static bool cyw43_arch_ap_mode_enabled = false;
 static bool cyw43_arch_connected = false;
 #endif
 
@@ -27,6 +28,7 @@ c__init(mrbc_vm *vm, mrbc_value *v, int argc)
     cyw43_arch_init_flag = false;
 #ifdef USE_WIFI
     cyw43_arch_sta_mode_enabled = false;
+    cyw43_arch_ap_mode_enabled = false;
     cyw43_arch_connected = false;
 #endif
   }
@@ -121,6 +123,53 @@ c_CYW43_connect_timeout(mrbc_vm *vm, mrbc_value *v, int argc)
 }
 
 static void
+c_CYW43_enable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (argc < 2 || 3 < argc) {
+    mrbc_raise(vm, MRBC_CLASS(ArgumentError), "wrong number of arguments");
+    return;
+  }
+  if (GET_ARG(1).tt != MRBC_TT_STRING || GET_ARG(2).tt != MRBC_TT_STRING ||
+      (argc == 3 && GET_ARG(3).tt != MRBC_TT_INTEGER)) {
+    mrbc_raise(vm, MRBC_CLASS(TypeError), "ssid and password must be strings and auth must be an integer");
+    return;
+  }
+  const char *ssid = (const char *)GET_STRING_ARG(1);
+  const char *pass = (const char *)GET_STRING_ARG(2);
+  int auth = argc < 3 ? CYW43_CONST_auth_wpa2_aes_psk() : GET_INT_ARG(3);
+  if (!cyw43_arch_ap_mode_enabled) {
+    if (CYW43_arch_enable_ap_mode(ssid, pass, auth)) {
+      cyw43_arch_ap_mode_enabled = true;
+      SET_TRUE_RETURN();
+      return;
+    }
+    SET_FALSE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
+c_CYW43_disable_ap_mode(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    mrbc_raise(vm, MRBC_CLASS(RuntimeError), "CYW43 not initialized");
+    return;
+  }
+  if (cyw43_arch_ap_mode_enabled) {
+    CYW43_arch_disable_ap_mode();
+    cyw43_arch_ap_mode_enabled = false;
+    SET_TRUE_RETURN();
+  } else {
+    SET_FALSE_RETURN();
+  }
+}
+
+static void
 c_CYW43_disconnect(mrbc_vm *vm, mrbc_value *v, int argc)
 {
   if (!cyw43_arch_init_flag) {
@@ -193,6 +242,55 @@ c_CYW43_ipv4_gateway(mrbc_vm *vm, mrbc_value *v, int argc)
   }
   SET_RETURN(mrbc_string_new_cstr(vm, gateway_str));
 }
+
+static void
+c_CYW43_ap_ipv4_address(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char ip_str[16] = {0};
+  if (!CYW43_ap_ipv4_address(ip_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, ip_str));
+}
+
+static void
+c_CYW43_ap_active_q(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  if (!cyw43_arch_init_flag) {
+    SET_FALSE_RETURN();
+    return;
+  }
+  SET_BOOL_RETURN(CYW43_ap_active());
+}
+
+static void
+c_CYW43_ap_ssid(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char ssid[33] = {0};
+
+  if (!cyw43_arch_init_flag) {
+    SET_NIL_RETURN();
+    return;
+  }
+  if (!CYW43_ap_ssid(ssid, sizeof(ssid))) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, ssid));
+}
+
+static void
+c_CYW43_ap_ipv4_netmask(mrbc_vm *vm, mrbc_value *v, int argc)
+{
+  char netmask_str[16] = {0};
+  if (!CYW43_ap_ipv4_netmask(netmask_str, 16)) {
+    SET_NIL_RETURN();
+    return;
+  }
+  SET_RETURN(mrbc_string_new_cstr(vm, netmask_str));
+}
+
 #endif
 
 static void
@@ -219,6 +317,8 @@ mrbc_cyw43_init(mrbc_vm *vm)
 #ifdef USE_WIFI
   mrbc_define_method(vm, class_CYW43, "enable_sta_mode", c_CYW43_enable_sta_mode);
   mrbc_define_method(vm, class_CYW43, "disable_sta_mode", c_CYW43_disable_sta_mode);
+  mrbc_define_method(vm, class_CYW43, "enable_ap_mode", c_CYW43_enable_ap_mode);
+  mrbc_define_method(vm, class_CYW43, "disable_ap_mode", c_CYW43_disable_ap_mode);
   mrbc_define_method(vm, class_CYW43, "connect_timeout", c_CYW43_connect_timeout);
   mrbc_define_method(vm, class_CYW43, "disconnect", c_CYW43_disconnect);
   mrbc_define_method(vm, class_CYW43, "tcpip_link_status", c_CYW43_tcpip_link_status);
@@ -226,6 +326,10 @@ mrbc_cyw43_init(mrbc_vm *vm)
   mrbc_define_method(vm, class_CYW43, "ipv4_address", c_CYW43_ipv4_address);
   mrbc_define_method(vm, class_CYW43, "ipv4_netmask", c_CYW43_ipv4_netmask);
   mrbc_define_method(vm, class_CYW43, "ipv4_gateway", c_CYW43_ipv4_gateway);
+  mrbc_define_method(vm, class_CYW43, "ap_active?", c_CYW43_ap_active_q);
+  mrbc_define_method(vm, class_CYW43, "ap_ssid", c_CYW43_ap_ssid);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_address", c_CYW43_ap_ipv4_address);
+  mrbc_define_method(vm, class_CYW43, "ap_ipv4_netmask", c_CYW43_ap_ipv4_netmask);
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_DOWN"), &mrbc_integer_value(CYW43_CONST_link_down()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_JOIN"), &mrbc_integer_value(CYW43_CONST_link_join()));
   mrbc_set_class_const(class_CYW43, mrbc_str_to_symid("LINK_NOIP"), &mrbc_integer_value(CYW43_CONST_link_noip()));


### PR DESCRIPTION
## Summary

- expose CYW43 access point lifecycle and AP-side status APIs to both PicoRuby VMs
- start a small DHCP server with the AP so connected clients receive usable IPv4 configuration
- document the API and add a minimal Pico W / Pico 2 W AP example

## Why

Pico SDK's `cyw43_arch_enable_ap_mode` brings up the wireless access point and its `192.168.4.1/24` netif, but it does not provide DHCP service in this build. A phone can associate with the SSID yet still cannot reliably reach the Pico because it has no leased address.

The earlier integration draft #488 also contains STA retry, socket, boot instrumentation, and application work. This PR isolates the AP capability into one commit on current `master`, which already uses `pico_cyw43_arch_lwip_poll`.

## Implementation

- bind the DHCP server only to the CYW43 AP netif and stop it with AP shutdown/deinit
- serve four leases (`192.168.4.2` through `.5`) with DISCOVER, REQUEST/renewal, and RELEASE handling
- reserve offers briefly to avoid assigning the same address to simultaneous clients
- validate DHCP packet shape, option lengths, server identifiers, and requested addresses
- expose `enable_ap_mode`, `disable_ap_mode`, `ap_active?`, `ap_ssid`, `ap_ipv4_address`, and `ap_ipv4_netmask`
- query explicit STA/AP netifs instead of relying on `netif_default`

The DHCP implementation is adapted from TinyUSB's MIT-licensed networking helper, with the license notice retained in the source.

## Validation

- `rake r2p2:femtoruby:pico2_w:prod`
- `rake r2p2:picoruby:pico2_w:prod`
- `rake test:gems:steep` (no type errors)
- `git diff --check upstream/master...HEAD`
- credential scan of the committed diff; only the documented example SSID/password are present
- flashed commit `c94d9808` to a Pico 2 W and confirmed AP startup, SSID, `192.168.4.1` address, and `255.255.255.0` netmask over serial
- associated an iPhone with `PicoRuby-AP` and confirmed it received an address from the `192.168.4.2` through `.5` DHCP pool

An earlier integration build was also verified through an HTTP response. HTTP server behavior remains outside this focused AP/DHCP PR.
