### PR TITLE
picoruby-i2c(esp32): re-assert pad routing before every transfer

### DIFF
--- a/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/esp32/i2c.c
@@ -1,5 +1,4 @@
 #include <string.h>
-#include "driver/gpio.h"
 #include "driver/i2c_master.h"
 #include "esp_rom_gpio.h"
 #include "soc/i2c_periph.h"
@@ -36,9 +35,14 @@ static i2c_bus_context_t i2c_contexts[2] = {0};
 // SOC_I2C_SUPPORT_HW_FSM_RST the driver's error path resets the state machine
 // without re-running the pin configuration.
 //
-// Re-asserting the routing costs a handful of register writes against a
-// transfer measured in hundreds of microseconds, and is a no-op when nothing
-// else touches the pins.
+// Only the signal routing is restored. The pad's electrical setup (open
+// drain, pull-up, input enable) was done when the bus was created and is not
+// what gets taken away, and re-running it here would mean detaching the pad
+// from the peripheral and driving it as a plain GPIO for a moment before
+// re-attaching it -- gpio_set_direction() routes SIG_GPIO_OUT_IDX to the pad
+// on the way -- which is a glitch on a live bus for no gain.
+//
+// Two register writes per pin, and a no-op when nothing else touches them.
 static void
 i2c_reclaim_pins(int unit_num)
 {
@@ -49,15 +53,8 @@ i2c_reclaim_pins(int unit_num)
     return;
   }
 
-  gpio_set_level((gpio_num_t)sda_pin, 1);
-  gpio_set_direction((gpio_num_t)sda_pin, GPIO_MODE_INPUT_OUTPUT_OD);
-  gpio_set_pull_mode((gpio_num_t)sda_pin, GPIO_PULLUP_ONLY);
   esp_rom_gpio_connect_out_signal(sda_pin, i2c_periph_signal[unit_num].sda_out_sig, false, false);
   esp_rom_gpio_connect_in_signal(sda_pin, i2c_periph_signal[unit_num].sda_in_sig, false);
-
-  gpio_set_level((gpio_num_t)scl_pin, 1);
-  gpio_set_direction((gpio_num_t)scl_pin, GPIO_MODE_INPUT_OUTPUT_OD);
-  gpio_set_pull_mode((gpio_num_t)scl_pin, GPIO_PULLUP_ONLY);
   esp_rom_gpio_connect_out_signal(scl_pin, i2c_periph_signal[unit_num].scl_out_sig, false, false);
   esp_rom_gpio_connect_in_signal(scl_pin, i2c_periph_signal[unit_num].scl_in_sig, false);
 }

--- a/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/esp32/i2c.c
@@ -1,5 +1,8 @@
 #include <string.h>
+#include "driver/gpio.h"
 #include "driver/i2c_master.h"
+#include "esp_rom_gpio.h"
+#include "soc/i2c_periph.h"
 
 #include "../../include/i2c.h"
 
@@ -8,10 +11,56 @@ typedef struct {
   i2c_master_bus_handle_t bus_handle;
   bool initialized;
   uint32_t frequency;
+  int8_t sda_pin;
+  int8_t scl_pin;
 } i2c_bus_context_t;
 
 // Context for each I2C port (ESP32 has a maximum of 2 ports)
 static i2c_bus_context_t i2c_contexts[2] = {0};
+
+// Re-assert this unit's pad routing before every transfer.
+//
+// The pins are configured once, in i2c_new_master_bus(), and nothing touches
+// them again for the lifetime of the bus. That is fine while this port is the
+// only thing driving them. It stops being fine as soon as another driver
+// talks to another device over the same two pins -- an I2C touch screen owned
+// by a display library is the usual case, since a board that exposes an I2C
+// connector often hangs it off the touch controller's bus. Such a driver
+// points the pins at its own I2C unit, typically on every transaction, and
+// leaves them there.
+//
+// Only one side can win: an ESP32 pad carries the output signal of a single
+// peripheral at a time and the routing is last-writer-wins, so once the other
+// driver has run we drive neither SDA nor SCL and every transfer fails. It
+// does not recover on its own either -- on targets with
+// SOC_I2C_SUPPORT_HW_FSM_RST the driver's error path resets the state machine
+// without re-running the pin configuration.
+//
+// Re-asserting the routing costs a handful of register writes against a
+// transfer measured in hundreds of microseconds, and is a no-op when nothing
+// else touches the pins.
+static void
+i2c_reclaim_pins(int unit_num)
+{
+  int8_t sda_pin = i2c_contexts[unit_num].sda_pin;
+  int8_t scl_pin = i2c_contexts[unit_num].scl_pin;
+
+  if (sda_pin < 0 || scl_pin < 0) {
+    return;
+  }
+
+  gpio_set_level((gpio_num_t)sda_pin, 1);
+  gpio_set_direction((gpio_num_t)sda_pin, GPIO_MODE_INPUT_OUTPUT_OD);
+  gpio_set_pull_mode((gpio_num_t)sda_pin, GPIO_PULLUP_ONLY);
+  esp_rom_gpio_connect_out_signal(sda_pin, i2c_periph_signal[unit_num].sda_out_sig, false, false);
+  esp_rom_gpio_connect_in_signal(sda_pin, i2c_periph_signal[unit_num].sda_in_sig, false);
+
+  gpio_set_level((gpio_num_t)scl_pin, 1);
+  gpio_set_direction((gpio_num_t)scl_pin, GPIO_MODE_INPUT_OUTPUT_OD);
+  gpio_set_pull_mode((gpio_num_t)scl_pin, GPIO_PULLUP_ONLY);
+  esp_rom_gpio_connect_out_signal(scl_pin, i2c_periph_signal[unit_num].scl_out_sig, false, false);
+  esp_rom_gpio_connect_in_signal(scl_pin, i2c_periph_signal[unit_num].scl_in_sig, false);
+}
 
 int
 I2C_read_timeout_us(int unit_num, uint8_t addr, uint8_t* dst, size_t len, bool nostop, uint32_t timeout_us)
@@ -19,6 +68,8 @@ I2C_read_timeout_us(int unit_num, uint8_t addr, uint8_t* dst, size_t len, bool n
   if (!i2c_contexts[unit_num].initialized) {
     return I2C_ERROR_INVALID_UNIT;
   }
+
+  i2c_reclaim_pins(unit_num);
 
   i2c_device_config_t dev_cfg = {
     .dev_addr_length = I2C_ADDR_BIT_LEN_7,
@@ -55,6 +106,8 @@ I2C_write_timeout_us(int unit_num, uint8_t addr, uint8_t* src, size_t len, bool 
   if (!i2c_contexts[unit_num].initialized) {
     return I2C_ERROR_INVALID_UNIT;
   }
+
+  i2c_reclaim_pins(unit_num);
 
   i2c_device_config_t dev_cfg = {
     .dev_addr_length = I2C_ADDR_BIT_LEN_7,
@@ -121,6 +174,8 @@ I2C_gpio_init(int unit_num, uint32_t frequency, int8_t sda_pin, int8_t scl_pin)
 
   i2c_contexts[unit_num].initialized = true;
   i2c_contexts[unit_num].frequency = frequency;
+  i2c_contexts[unit_num].sda_pin = sda_pin;
+  i2c_contexts[unit_num].scl_pin = scl_pin;
 
   return I2C_ERROR_NONE;
 }

--- a/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+++ b/mrbgems/picoruby-i2c/ports/esp32/i2c.c
@@ -15,34 +15,21 @@ typedef struct {
 } i2c_bus_context_t;
 
 // Context for each I2C port (ESP32 has a maximum of 2 ports)
-static i2c_bus_context_t i2c_contexts[2] = {0};
+static i2c_bus_context_t i2c_contexts[2] = {
+  [0] = { .sda_pin = -1, .scl_pin = -1 },
+  [1] = { .sda_pin = -1, .scl_pin = -1 },
+};
 
-// Re-assert this unit's pad routing before every transfer.
-//
-// The pins are configured once, in i2c_new_master_bus(), and nothing touches
-// them again for the lifetime of the bus. That is fine while this port is the
-// only thing driving them. It stops being fine as soon as another driver
-// talks to another device over the same two pins -- an I2C touch screen owned
-// by a display library is the usual case, since a board that exposes an I2C
-// connector often hangs it off the touch controller's bus. Such a driver
-// points the pins at its own I2C unit, typically on every transaction, and
-// leaves them there.
-//
-// Only one side can win: an ESP32 pad carries the output signal of a single
-// peripheral at a time and the routing is last-writer-wins, so once the other
-// driver has run we drive neither SDA nor SCL and every transfer fails. It
-// does not recover on its own either -- on targets with
-// SOC_I2C_SUPPORT_HW_FSM_RST the driver's error path resets the state machine
-// without re-running the pin configuration.
-//
-// Only the signal routing is restored. The pad's electrical setup (open
-// drain, pull-up, input enable) was done when the bus was created and is not
-// what gets taken away, and re-running it here would mean detaching the pad
-// from the peripheral and driving it as a plain GPIO for a moment before
-// re-attaching it -- gpio_set_direction() routes SIG_GPIO_OUT_IDX to the pad
-// on the way -- which is a glitch on a live bus for no gain.
-//
-// Two register writes per pin, and a no-op when nothing else touches them.
+// Pins are routed only once when the bus is created. Drivers that share them—
+// for example, the I2C touch controller in the display library—reset them
+// to point toward their own unit for each transaction, so that a single pad
+// transmits signals from only one peripheral at a time. Afterward, neither SDA nor SCL
+// is driven, and the state is not restored.
+// This is because the error path resets the state machine, but the pin routing is not reset.
+// However, this applies only to routing. The electrical configuration is not removed, and
+// gpio_set_direction(), when passing through a glitch on an active bus,
+// will hand the pad over to a normal GPIO. Two register writes are required per pin,
+// but if the pin is not shared, this results in a no-operation.
 static void
 i2c_reclaim_pins(int unit_num)
 {


### PR DESCRIPTION
## Problem

The ESP32 port takes the two pins it is given and configures them once, inside
`i2c_new_master_bus()`, when the bus is created. Nothing touches them again for
the lifetime of the bus. That is fine as long as this port is the only thing in
the firmware driving those pins.

It stops being fine as soon as another driver talks to another device over the
same two pins. An I2C touch screen owned by a display library is the usual way
this shows up: a board that exposes an I2C connector often hangs it off the
touch controller's bus. Such a driver configures the pins for its own I2C unit
-- typically on every transaction, since it expects to share them -- and leaves
them pointed there.

Only one side can win. An ESP32 pad carries the output signal of a single
peripheral at a time and the routing is last-writer-wins, so once the other
driver has run, this port drives neither SDA nor SCL. Every transfer from then
on fails, while the bus still reads idle-high through the pull-ups.

It does not recover by itself either. On targets with
`SOC_I2C_SUPPORT_HW_FSM_RST` (the ESP32-P4 among them) the driver's error path
resets the state machine without re-running the pin configuration, so the port
stays dead until the bus is recreated. Targets without that capability happen
to re-apply the pins while recovering, which is part of why this is easy to
miss.

## The case this came from

An ESP32-P4 board (Elecrow CrowPanel Advanced 7") whose I2C connector is a tap
on the touch controller's bus. M5GFX/LovyanGFX drives a GT911 touch panel on
I2C0 and re-applies its own pin setup inside `lgfx::i2c::beginTransaction()`
on every touch read, without restoring what it found. A DFRobot SEN0502 rotary
encoder hangs off the same two pins and is driven from PicoRuby on I2C1.

The encoder reads fine from boot -- the GT911 only talks while its INT line is
low, so nothing else touches the pins until a finger goes down. Touch the
screen once and the encoder is gone for good.

## Fix

Remember the pins in the bus context and reconnect the pad signals at the top
of `I2C_read_timeout_us()` / `I2C_write_timeout_us()`, the way a driver that
expects to share pins does.

A handful of register writes against a transfer measured in hundreds of
microseconds, and a no-op when this port is the only user of the pins.

Follow-up: `70b3191` narrows what the reclaim restores.

The first version also re-ran the pad's electrical setup (level, direction,
pull-up) before every transfer. That is not what gets taken away -- open
drain, pull-up and input enable are applied when the bus is created and the
other driver never changes them, it only re-points the signals.

And re-running it is not free. `gpio_set_direction()` reaches the pad through
`gpio_output_enable()`, which calls `gpio_hal_matrix_out_default()` to detach
the pad from whatever peripheral drives it and hand it to the plain GPIO
output. So every transfer took the pad away from the I2C unit and drove it as
a GPIO for a moment before re-attaching it -- a glitch on a live bus, for no
gain. Drivers that split a register read into a separate write and a read
(the SEN0502 driver does) land in the middle of that too.

It now restores the signal routing and nothing else: two register writes per
pin.

If you would rather see this as a single commit, say the word and I will
squash the two.

## Testing

On the board above: before the change, the encoder stops responding after the
first screen touch and never comes back. After it, touch and encoder both keep
working.

## Limitations

This restores the routing, it does not arbitrate between the two masters.
The other driver has its own lock and this port has the driver's bus lock,
and neither knows about the other, so a transfer that happens to overlap the
other driver's transaction can still fail. What changes is that the failure
is now transient instead of permanent.

On a shared bus, then, callers should expect an occasional failed transfer.
A one-shot probe is the case to watch: on the board above, a device that is
probed exactly once at startup would occasionally not be found, because that
single probe was the one that collided. Retrying the probe covers it.