### PR TITLE
Generalize JS::Object#to_binary

### DIFF
--- a/mrbgems/picoruby-wasm/demo/www/js_types.html
+++ b/mrbgems/picoruby-wasm/demo/www/js_types.html
@@ -296,6 +296,36 @@
       raise "body: #{body.inspect}" unless body == 'hello-binary'
     end
 
+    test_case("JS::Object#to_binary preserves Blob bytes") do
+      bytes = JS.global[:Uint8Array].new(5)
+      bytes[0] = 0x00
+      bytes[1] = 0x7f
+      bytes[2] = 0x80
+      bytes[3] = 0xff
+      bytes[4] = 0x0a
+      parts = JS.global.create_array
+      parts.push(bytes)
+      blob = JS.global[:Blob].new(parts)
+      body = blob.to_binary
+      expected = [0x00, 0x7f, 0x80, 0xff, 0x0a]
+      i = 0
+      while i < expected.length
+        raise "byte #{i}: #{body.getbyte(i)}" unless body.getbyte(i) == expected[i]
+        i += 1
+      end
+      raise "size: #{body.bytesize}" unless body.bytesize == expected.length
+    end
+
+    test_case("JS::Object#to_binary rejects objects without arrayBuffer") do
+      begin
+        JS.global.create_object.to_binary
+      rescue => e
+        raise "message: #{e.message}" unless e.message.include?('arrayBuffer')
+      else
+        raise "error was not raised"
+      end
+    end
+
     # ----- Phase 5: BasicObject inheritance -----
 
     test_case("JS::Object inherits from BasicObject") do

--- a/mrbgems/picoruby-wasm/docs/callback.md
+++ b/mrbgems/picoruby-wasm/docs/callback.md
@@ -72,7 +72,7 @@ Use it when the handler needs any of:
 **Constraints.** The block cannot suspend, so anything that would suspend raises
 `RuntimeError` inside it:
 
-- `fetch`, `Promise#await` / `#then`, `JS::Response#to_binary`
+- `fetch`, `Promise#await` / `#then`, `JS::Object#to_binary`
 - blocking `Task::Queue#pop`
 - `Task#join` / `#suspend` / `#resume` / `#terminate`
 

--- a/mrbgems/picoruby-wasm/docs/interoperability_between_js_and_ruby.md
+++ b/mrbgems/picoruby-wasm/docs/interoperability_between_js_and_ruby.md
@@ -43,6 +43,18 @@ items.each { |el| puts el[:textContent] }  # el is a JS::Object, [:textContent] 
 
 `#to_a` recursively auto-converts primitives too, so an array of numbers becomes `Array[Integer]`.
 
+### Reading binary data
+
+Use `#to_binary` with a `Blob`, `File`, `Response`, or another JavaScript object
+that implements `arrayBuffer()`. It returns a binary Ruby `String` without
+UTF-8 conversion and suspends the current task until the bytes are available:
+
+```ruby
+file = JS.document.getElementById('file-input')[:files][0]
+bytes = file.to_binary
+puts bytes.getbyte(0)
+```
+
 ## Writing to JS
 
 `[]=` and method arguments auto-convert Ruby types:
@@ -125,7 +137,7 @@ The complete set of Ruby-side methods on a `JS::Object` instance is:
   `typeof`, `refcount`, `create_object`, `create_array`
 - Ruby protocol predicates defined in C: `nil?` (always `false`), `is_a?`,
   `kind_of?`, `instance_of?`, `respond_to?`
-- Defined in Ruby: `addEventListener`, `fetch`, `setTimeout`, `clearTimeout`,
+- Defined in Ruby: `addEventListener`, `fetch`, `to_binary`, `setTimeout`, `clearTimeout`,
   and subclass methods such as `JS::Promise#await` / `#then`
 
 Every other method name is forwarded to JavaScript as a property read, method

--- a/mrbgems/picoruby-wasm/mrblib/js.rb
+++ b/mrbgems/picoruby-wasm/mrblib/js.rb
@@ -145,6 +145,23 @@ module JS
       success
     end
 
+    # Read Blob, File, Response, or another object implementing arrayBuffer()
+    # as a binary Ruby String without UTF-8 conversion.
+    def to_binary
+      # __id__: BasicObject has no object_id
+      callback_id = self.__id__
+      _to_binary_and_suspend(callback_id)
+      if $promise_errors.key?(callback_id)
+        message = $promise_errors[callback_id]
+        $promise_errors.delete(callback_id)
+        $promise_responses.delete(callback_id)
+        Kernel.raise message
+      end
+      result = $promise_responses[callback_id]
+      $promise_responses.delete(callback_id)
+      result.to_s
+    end
+
   end
 
   # Composite-type subclasses. wrap_ref_as_js_object in js.c picks the right
@@ -179,16 +196,6 @@ module JS
   end
 
   class Response < Object
-    # Read the response body as a binary String. Suspends the current Ruby
-    # task until the underlying ArrayBuffer is materialized.
-    def to_binary
-      # __id__: BasicObject has no object_id
-      callback_id = self.__id__
-      _to_binary_and_suspend(callback_id)
-      result = $promise_responses[callback_id]
-      $promise_responses.delete(callback_id)
-      result.to_s
-    end
   end
 
   class Event < Object

--- a/mrbgems/picoruby-wasm/sig/js.rbs
+++ b/mrbgems/picoruby-wasm/sig/js.rbs
@@ -49,6 +49,7 @@ module JS
 
     # Async operations
     def fetch: (String url, ?Hash[Symbol, untyped]? options) { (JS::Response response) -> void } -> void
+    def to_binary: () -> String
 
     # Timer operations
     def setTimeout: (Integer delay_ms) { () -> void } -> Integer
@@ -111,6 +112,7 @@ module JS
     private def self._register_callback: (Integer callback_id, String name) -> nil
     private def _fetch_and_suspend: (String url, Integer callback_id) -> nil
     private def _fetch_with_options_and_suspend: (String url, String options_json, Integer callback_id) -> nil
+    private def _to_binary_and_suspend: (Integer callback_id) -> nil
     private def _await_and_suspend: (Integer callback_id) -> nil
     private def _set_timeout: (Integer callback_id, Integer delay_ms) -> Integer
     private def _clear_timeout: (Integer callback_id) -> bool
@@ -143,8 +145,6 @@ module JS
   end
 
   class Response < Object
-    def to_binary: () -> String
-    private def _to_binary_and_suspend: (Integer callback_id) -> nil
   end
 
   class Element < Object

--- a/mrbgems/picoruby-wasm/src/mruby/js.c
+++ b/mrbgems/picoruby-wasm/src/mruby/js.c
@@ -1070,12 +1070,27 @@ EM_JS(bool, js_remove_attribute, (int ref_id, const char* name), {
 });
 
 EM_JS(int, setup_binary_handler, (int ref_id, uintptr_t mrb_ptr, uintptr_t task_ptr, uintptr_t callback_id), {
-  const response = globalThis.picorubyRefs[ref_id];
-  if (!response || typeof response.arrayBuffer !== 'function') {
-    console.error('Invalid response object:', response);
-    return 0;
-  }
-  response.arrayBuffer().then(arrayBuffer => {
+  const object = globalThis.picorubyRefs[ref_id];
+  const reportError = (error) => {
+    const message = error && typeof error.message === 'string'
+      ? error.message
+      : String(error);
+    const size = lengthBytesUTF8(message) + 1;
+    const errorPtr = _malloc(size);
+    stringToUTF8(message, errorPtr, size);
+    ccall(
+      'resume_promise_error_task',
+      'void',
+      ['number', 'number', 'number', 'number'],
+      [mrb_ptr, task_ptr, callback_id, errorPtr]
+    );
+  };
+  Promise.resolve().then(() => {
+    if (!object || typeof object.arrayBuffer !== 'function') {
+      throw new TypeError('JS object does not implement arrayBuffer()');
+    }
+    return object.arrayBuffer();
+  }).then(arrayBuffer => {
     const uint8Array = new Uint8Array(arrayBuffer);
     const ptr = _malloc(uint8Array.length);
     const heapBytes = new Uint8Array(HEAPU8.buffer, ptr, uint8Array.length);
@@ -1086,9 +1101,7 @@ EM_JS(int, setup_binary_handler, (int ref_id, uintptr_t mrb_ptr, uintptr_t task_
       ['number', 'number', 'number', 'number', 'number'],
       [mrb_ptr, task_ptr, callback_id, ptr, uint8Array.length]
     );
-  }).catch(error => {
-    console.error('Error in arrayBuffer processing:', error);
-  });
+  }).catch(reportError);
   return 0;
 });
 
@@ -2770,6 +2783,7 @@ mrb_js_init(mrb_state *mrb)
   mrb_define_class_method_id(mrb, class_JS_Object, MRB_SYM(_register_callback), mrb_object_s__register_callback, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_and_suspend), mrb_object__fetch_and_suspend, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_fetch_with_options_and_suspend), mrb_object__fetch_with_options_and_suspend, MRB_ARGS_REQ(3));
+  mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_to_binary_and_suspend), mrb_object__to_binary_and_suspend, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_await_and_suspend), mrb_object__await_and_suspend, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_set_timeout), mrb_object__set_timeout, MRB_ARGS_REQ(2));
   mrb_define_method_id(mrb, class_JS_Object, MRB_SYM(_clear_timeout), mrb_object__clear_timeout, MRB_ARGS_REQ(1));
@@ -2801,7 +2815,6 @@ mrb_js_init(mrb_state *mrb)
 
   class_JS_Response = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Response), class_JS_Object);
   MRB_SET_INSTANCE_TT(class_JS_Response, MRB_TT_DATA);
-  mrb_define_method_id(mrb, class_JS_Response, MRB_SYM(_to_binary_and_suspend), mrb_object__to_binary_and_suspend, MRB_ARGS_REQ(1));
 
   class_JS_Element = mrb_define_class_under_id(mrb, module_JS, MRB_SYM(Element), class_JS_Object);
   MRB_SET_INSTANCE_TT(class_JS_Element, MRB_TT_DATA);

--- a/mrbgems/picoruby-wasm/test/js_binary_test.rb
+++ b/mrbgems/picoruby-wasm/test/js_binary_test.rb
@@ -1,0 +1,29 @@
+class JSBinaryTest < Picotest::Test
+  def setup
+    JS.eval(<<~JS)
+      globalThis.picorubyBinaryBlob = function() {
+        return new Blob([new Uint8Array([0x00, 0x7f, 0x80, 0xff, 0x0a])]);
+      };
+      globalThis.picorubyNotBinary = function() {
+        return {};
+      };
+    JS
+  end
+
+  def test_blob_to_binary_preserves_every_byte
+    binary = JS.global.picorubyBinaryBlob.to_binary
+
+    assert_equal(5, binary.bytesize)
+    assert_equal(0x00, binary.getbyte(0))
+    assert_equal(0x7f, binary.getbyte(1))
+    assert_equal(0x80, binary.getbyte(2))
+    assert_equal(0xff, binary.getbyte(3))
+    assert_equal(0x0a, binary.getbyte(4))
+  end
+
+  def test_to_binary_rejects_an_object_without_array_buffer
+    assert_raise(RuntimeError, 'JS object does not implement arrayBuffer()') do
+      JS.global.picorubyNotBinary.to_binary
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

`JS::Response#to_binary` already provides a byte-preserving bridge from a JavaScript `ArrayBuffer` to a Ruby `String`. The same operation is useful for other browser objects such as `Blob` and `File`, which also implement `arrayBuffer()`.

Making this operation available on `JS::Object` provides a reusable binary-data API for Web Terminal uploads and other work such as #425, without coupling it to a particular UI.

## Summary

- Move `#to_binary` from `JS::Response` to `JS::Object`.
- Support `Blob`, `File`, `Response`, and other JavaScript objects that implement `arrayBuffer()`.
- Preserve arbitrary bytes without UTF-8 conversion.
- Resume the suspended Ruby task with a `RuntimeError` when `arrayBuffer()` is unavailable or rejects.
- Update RBS declarations and interoperability/callback documentation.
- Add Node/WASM regression coverage and browser demo coverage.

## Technical details

`JS::Object#to_binary` suspends the current Ruby task while JavaScript resolves `arrayBuffer()`. The resulting `Uint8Array` is copied into WASM memory and then into a Ruby binary `String`. Both synchronous validation failures and Promise rejections use the existing promise-error resume path.

This PR intentionally contains only the JS interoperability API extracted from #491. The Web Terminal binary-upload UI will be submitted separately after this API is merged.

## Testing

- `JSBinaryTest`: 7 assertions passed
  - Preserves `00 7f 80 ff 0a` byte-for-byte
  - Verifies the exact exception class and message for objects without `arrayBuffer()`
- WASM test binary built successfully on the latest `origin/master`
- `git diff --check` passed

The local `test:gems:wasm[picoruby-wasm]` run completed the new tests successfully. The overall task exited non-zero because `JSGenericCallbackTest` and `JSSyncEventTest` crashed before emitting Picotest result JSON in the local Node.js 24 environment; the new test reported no failures, exceptions, or crashes.
