### PR TITLE
Add nRF52 timing and entropy port for picoruby-mbedtls

### DIFF
--- a/mrbgems/picoruby-mbedtls/README.md
+++ b/mrbgems/picoruby-mbedtls/README.md
@@ -94,3 +94,16 @@ pkey = MbedTLS::PKey.new
 - Used internally by `picoruby-socket` for HTTPS/TLS
 - Suitable for secure communications and data protection
 - Memory-efficient implementations for embedded systems
+
+## nRF52 notes
+
+- Entropy comes from the nRF52 RNG peripheral by way of picoruby-rng, which
+  leaves the hardware's bias correction on. `MBEDTLS_ENTROPY_HARDWARE_ALT`
+  is enabled, so this is the library's only entropy source.
+- The DTLS retransmission timer reads the wall clock through
+  `gettimeofday`, so it is exactly as good as the platform's clock. It
+  measures intervals with unsigned arithmetic and therefore survives a
+  wrapping clock, as long as a single timeout is shorter than the wrap
+  period.
+- Hardware acceleration is not used. The nRF52840 has a CryptoCell CC310,
+  but nothing here is routed through it yet.

--- a/mrbgems/picoruby-mbedtls/mrbgem.rake
+++ b/mrbgems/picoruby-mbedtls/mrbgem.rake
@@ -87,6 +87,9 @@ MRuby::Gem::Specification.new('picoruby-mbedtls') do |spec|
   spec.cc.defines << "MBEDTLS_CONFIG_FILE='\"#{dir}/include/mbedtls_config.h\"'"
   spec.cc.include_paths << "#{mbedtls_dir}/include"
   spec.cc.include_paths << "#{dir}/include"
+  # The nRF52 port draws entropy from picoruby-rng, which is already a
+  # dependency above; this makes its header reachable.
+  spec.cc.include_paths << "#{MRUBY_ROOT}/mrbgems/picoruby-rng/include"
 
   # While DTLS is disabled, config_adjust_ssl.h #undefs
   # MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT, then ssl.h evaluates it with

--- a/mrbgems/picoruby-mbedtls/ports/nrf52/timing_alt.c
+++ b/mrbgems/picoruby-mbedtls/ports/nrf52/timing_alt.c
@@ -1,0 +1,104 @@
+/*
+ * nRF52 port: the two platform-specific pieces Mbed TLS needs -- a
+ * millisecond delay timer for DTLS retransmission, and an entropy source.
+ *
+ * The timer reads the wall clock through gettimeofday, as the ESP32 port
+ * does, rather than touching a timer peripheral. On this platform that
+ * resolves to the product's clock shim, so the port improves for free
+ * when the shim gains a real time base, and claims no hardware of its own.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/time.h>
+
+#include "rng.h"
+
+#include "../../include/timing_alt.h"
+
+typedef struct {
+  uint64_t start_ms;
+  uint32_t int_ms;
+  uint32_t fin_ms;
+  int      active;
+} timing_delay_context;
+
+static uint64_t
+now_ms(void)
+{
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+  return (uint64_t)tv.tv_sec * 1000u + (uint64_t)(tv.tv_usec / 1000);
+}
+
+void
+mbedtls_timing_set_delay(void *data, uint32_t int_ms, uint32_t fin_ms)
+{
+  timing_delay_context *ctx = (timing_delay_context *)data;
+
+  ctx->int_ms = int_ms;
+  ctx->fin_ms = fin_ms;
+
+  if (fin_ms == 0) {
+    ctx->active = 0;   /* cancel */
+    return;
+  }
+  ctx->start_ms = now_ms();
+  ctx->active = 1;
+}
+
+int
+mbedtls_timing_get_delay(void *data)
+{
+  timing_delay_context *ctx = (timing_delay_context *)data;
+
+  if (ctx->fin_ms == 0 || !ctx->active) {
+    return -1;
+  }
+
+  /* Unsigned elapsed, so a clock that wraps still yields the right
+     interval as long as the interval itself is shorter than the wrap.
+     DTLS timeouts are seconds; the shortest wrap on this platform is
+     several minutes. */
+  uint64_t elapsed = now_ms() - ctx->start_ms;
+
+  if (elapsed >= ctx->fin_ms) {
+    return 2;
+  }
+  if (elapsed >= ctx->int_ms) {
+    return 1;
+  }
+  return 0;
+}
+
+/*
+ * Mbed TLS wants a monotonic tick for its own timing hardening. It does
+ * not have to be a real cycle count, and tying it to a peripheral would
+ * claim hardware for something that is only ever compared with itself.
+ */
+unsigned long
+mbedtls_timing_hardclock(void)
+{
+  static unsigned long counter = 0;
+  return ++counter;
+}
+
+/*
+ * MBEDTLS_ENTROPY_HARDWARE_ALT is on, so this is the only entropy the
+ * library gets. It comes from the nRF52 RNG peripheral through
+ * picoruby-rng, which applies the bias correction the raw stream needs.
+ */
+int
+mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+{
+  (void)data;
+
+  for (size_t i = 0; i < len; i++) {
+    output[i] = rng_random_byte_impl();
+  }
+  if (olen != NULL) {
+    *olen = len;
+  }
+  return 0;
+}


### PR DESCRIPTION
Part of #399, though not the item as written.

The checklist entry is "Back picoruby-mbedtls with CryptoCell CC310 on
nRF52". That premise does not hold: nRF5 SDK 17.1.0 ships mbedtls
2.16.10 (`external/mbedtls/include/mbedtls/version.h`) while this gem
pins v3.6.x, and the SDK's CC310 backend implements the `nrf_crypto`
API rather than mbedtls `*_ALT` hooks -- mbedtls is a backend *of*
nrf_crypto there, not the reverse. Wiring CC310 underneath this gem
would need the glue that only exists in nRF Connect SDK.

What is portable and useful on its own is the platform layer the gem
needs regardless of which crypto backend is used: `mbedtls_timing_*`
(the millisecond delay timer DTLS retransmission relies on) and
`mbedtls_hardware_poll`, backed by the nRF52 RNG.

Happy to retitle the checklist item if that reading is agreed.

Verified: cross-compiled with `-Wall -Wextra -Werror` against nRF5 SDK
17.1.0 for cortex-m4. Not exercised on hardware yet.