### PR TITLE
Enable lwIP SO_REUSE for TCPServer port reuse

### DIFF
--- a/mrbgems/picoruby-socket/include/lwipopts.h
+++ b/mrbgems/picoruby-socket/include/lwipopts.h
@@ -77,6 +77,7 @@
 #define LWIP_DHCP 1
 #define LWIP_IPV4 1
 #define LWIP_TCP 1
+#define SO_REUSE 1
 #define LWIP_UDP 1
 #define LWIP_DNS 1
 #define LWIP_TCP_KEEPALIVE 1


### PR DESCRIPTION
## Summary

Enable lwIP's `SO_REUSE` option so the existing `SOF_REUSEADDR` flags on RP2040/RP2350 `TCPServer` listeners take effect during bind conflict checks.

Without this global lwIP option, closing an accepted client and its server leaves the connection in TIME_WAIT and prevents an immediate bind to the same port. The relevant reuse path in lwIP's `tcp_bind()` is compiled only when `SO_REUSE` is enabled.

## Change

- Add `#define SO_REUSE 1` to `mrbgems/picoruby-socket/include/lwipopts.h`.

## Validation

Builds completed successfully from upstream `80efbea3`:

- `r2p2:femtoruby:pico2_w:prod` (Pico 2 W + mruby/c)
- `r2p2:picoruby:pico2_w:prod` (Pico 2 W + mruby)
- `R2P2_NO_SHARED_ALLOC=1 r2p2:femtoruby:pico_w:prod` (Pico W + mruby/c)

Hardware A/B validation on Pico 2 W + mruby:

- Before: immediate same-port rebind failed after one accepted and closed client.
- After enabling only `SO_REUSE`: the same rebind passed.

The earlier Pico 2 W + mruby/c comparison also completed ten consecutive accept/close/rebind cycles successfully.

The independent Ctrl-C shutdown exception in `TCPServer#accept` is intentionally out of scope.

Fixes #505
